### PR TITLE
multibyte language support of selector name

### DIFF
--- a/Quick/Core/NSString+QCKSelectorName.m
+++ b/Quick/Core/NSString+QCKSelectorName.m
@@ -15,13 +15,23 @@
     static NSMutableCharacterSet *invalidCharacters = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        invalidCharacters = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
+        invalidCharacters = [NSMutableCharacterSet new];
         
-        [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet illegalCharacterSet]];
-        [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet controlCharacterSet]];
-        [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
-        [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet nonBaseCharacterSet]];
-        [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet symbolCharacterSet]];
+        NSCharacterSet *whitespaceCharacterSet = [NSCharacterSet whitespaceCharacterSet];
+        NSCharacterSet *newlineCharacterSet = [NSCharacterSet newlineCharacterSet];
+        NSCharacterSet *illegalCharacterSet = [NSCharacterSet illegalCharacterSet];
+        NSCharacterSet *controlCharacterSet = [NSCharacterSet controlCharacterSet];
+        NSCharacterSet *punctuationCharacterSet = [NSCharacterSet punctuationCharacterSet];
+        NSCharacterSet *nonBaseCharacterSet = [NSCharacterSet nonBaseCharacterSet];
+        NSCharacterSet *symbolCharacterSet = [NSCharacterSet symbolCharacterSet];
+
+        [invalidCharacters formUnionWithCharacterSet:whitespaceCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:newlineCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:illegalCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:controlCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:punctuationCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:nonBaseCharacterSet];
+        [invalidCharacters formUnionWithCharacterSet:symbolCharacterSet];
     });
     
     NSArray *validComponents = [self componentsSeparatedByCharactersInSet:invalidCharacters];


### PR DESCRIPTION
This Pull Request is multibyte language support of describe and it and context string.

e.g.
describe("テスト"){ it("確認"){...} }
// SelectorName is "テスト__確認" (Japanese).

describe("Một thử nghiệm"){ it("xác nhận"){...} } 
// SelectorName is Một_thử_nghiệm__xác_nhận (Vietnamese).

describe("测试"){ it("确认"){...} }
// SelectorName is 测试__确认 (Chinese).

 describe("테스트"){ it("확인") {...} }
// SelectorName is 테스트__확인 (Korean)

You can write Test using multibyte language based on Unicode. :)
(Cannot use Unicode Pictogram. Pictogram are converted to "_")
