### PR TITLE
[Nimble] Create a workaround fix for issue #20

### DIFF
--- a/Quick/Core/QuickSpec.h
+++ b/Quick/Core/QuickSpec.h
@@ -53,4 +53,10 @@
  */
 - (void)exampleGroups;
 
+/**
+ Indicates whether or not the spec currently has any invocations.
+ 
+ @return YES if the spec contains invocations; NO otherwise. 
+ */
++(BOOL)hasInvocations;
 @end

--- a/Quick/Core/QuickSpec.m
+++ b/Quick/Core/QuickSpec.m
@@ -49,6 +49,8 @@ const void * const QCKExampleKey = &QCKExampleKey;
         [invocations addObject:invocation];
     }
 
+    specHasInvocations = (invocations.count > 0);
+    
     return invocations;
 }
 
@@ -78,6 +80,9 @@ const void * const QCKExampleKey = &QCKExampleKey;
 #pragma mark - Public Interface
 
 - (void)exampleGroups { }
+
+static BOOL specHasInvocations = NO;
++(BOOL)hasInvocations {return specHasInvocations;}
 
 #pragma mark - Internal Methods
 

--- a/Quick/Expectations/Expectation.swift
+++ b/Quick/Expectations/Expectation.swift
@@ -17,10 +17,21 @@ class Expectation: Prediction {
     }
 
     override func evaluate(matcher: Matcher) {
-        if (negative && matcher.match(actual)) {
-            XCTFail(matcher.negativeFailureMessage(actual), file: callsite.file, line: callsite.line)
-        } else if (!negative && !matcher.match(actual)) {
-            XCTFail(matcher.failureMessage(actual), file: callsite.file, line: callsite.line)
+        if QuickSpec.hasInvocations() {
+            if (negative && matcher.match(actual)) {
+                fail(matcher)
+            } else if (!negative && !matcher.match(actual)) {
+                fail(matcher)
+            }
         }
+        else {
+            it("is wrapping the fail to prevent an exception") {
+                self.fail(matcher)
+            }
+        }
+    }
+    
+    func fail(matcher: Matcher) {
+        XCTFail(matcher.negativeFailureMessage(actual), file: callsite.file, line: callsite.line)
     }
 }


### PR DESCRIPTION
When a test failed from an expect() outside of an it(),
an exception ('Parameter "test" must not be nil') was thrown
by XCTest upon a call to XCFail().

This was happening because World did not contain any Example
objects, which are created and added via it().

The fix simply adds a boolean flag to QuickSpec indicating whether
or not the spec currently has any invocations. The flag is set by
checking the count of the invocations array at the end of
testInvocations().

This flag is then checked in Expectation.evaluate() before
calling XCFail(). If the flag is NO, we wrap the call to XCFail()
within an it() to prevent the exception from being thrown.
