### PR TITLE
Adds conditional support for falling back to XCTest-style names of tests.

### DIFF
--- a/Quick/Quick/QuickSpec.m
+++ b/Quick/Quick/QuickSpec.m
@@ -83,23 +83,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
     [super setInvocation:invocation];
 }
 
-#ifndef QUICK_DISABLE_CUSTOM_FORMAT
-
-/**
- The test's name. XCTest expects this to be overridden by subclasses. By default, this
- uses the invocation's selector's name (i.e.: "-[WinterTests testWinterIsComing]").
- QuickSpec overrides this method to provide the name of the test class, along with a
- string made up of the example group and example descriptions.
-
- @return A string to be displayed in the log navigator as the test is being run.
- */
-- (NSString *)name {
-    return [NSString stringWithFormat:@"%@: %@",
-            NSStringFromClass([self class]), self.example.name];
-}
-
-#endif
-
 #pragma mark - Public Interface
 
 - (void)spec { }


### PR DESCRIPTION
I use a [tool](https://github.com/AshFurrow/second_curtain/issues/18) that parses the output of test runs in order to do some things with artefacts of that run. This parsing relies on xcodebuild to output the test names in the format native to XCTest. 

Wasn't sure how to approach this one, so I used something borrowed from [Expecta](https://github.com/specta/expecta/blob/7d287afd31166a77b99d3f16a84064166df53ee9/src/Expecta.h#L14-L16). I'm open to alternatives and suggestions on documentation. 
