### PR TITLE
Fix "Build Active Architecture Only" build setting for iOS target

### DIFF
--- a/Quick/Quick.xcodeproj/project.pbxproj
+++ b/Quick/Quick.xcodeproj/project.pbxproj
@@ -1036,7 +1036,6 @@
 				INFOPLIST_FILE = Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
:warning: **Depends on Quick/Nimble#19** :warning:

As in the mentioned Nimble pull request, the `ONLY_ACTIVE_ARCH` ("Build Active Architecture Only") build setting should be set to `NO` for iOS targets, as per jspahrsummers/xcconfigs@ae4762d:

> If a library only built one architecture, then was used in a parent project that wanted all of them, things asplode.

This should fix #111, i.e. phantom "unresolved identifier" errors, but requires Quick/Nimble#19 to be merged as well (and an updated submodule).
