### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 # Pods/
+
+# Mac OS X
+.DS_Store


### PR DESCRIPTION
These files get created all the time and cause my submodules to be marked as out-of-date. Easy to remove the files, but also just as easy to ignore them.
