### PR TITLE
Improves testing UIViewController examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,10 +671,10 @@ class DolphinTableViewControllerSpecs: QuickSpec {
 
     describe("viewDidLoad") {
       beforeEach {
-        // Causes the UIKit framework to trigger the necessary methods to render the view and perform viewWillAppear: and viewDidAppear: callbacks
-        viewController.beginAppearanceTransition(true, animated: false)
-        viewController.endAppearanceTransition()
+        // Accessing the view property causes the UIKit framework to trigger the necessary methods to render the view.
+        viewController.view
       }
+
 
       it("loads the table view with one cell") {
         let tableView = viewController.tableView
@@ -688,6 +688,7 @@ class DolphinTableViewControllerSpecs: QuickSpec {
 
     describe("didSelectRowAtIndexPath") {
       beforeEach {
+        // Causes the UIKit framework to trigger the necessary methods to render the view and perform viewWillAppear: and viewDidAppear: callbacks
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
       }
@@ -724,9 +725,8 @@ describe(@"viewDidLoad") {
 
   it(@"loads the table view with three types of dolphin", ^{
     beforeEach(^{
-        // Causes the UIKit framework to trigger the necessary methods to render the view and perform viewWillAppear: and viewDidAppear: callbacks
-      [viewController beginAppearanceTransition:YES animated:NO];
-      [viewController endAppearanceTransition];
+      // Accessing the view property causes the UIKit framework to trigger the necessary methods to render the view.
+      [viewController view];
     });
 
     UITableView *tableView = [viewController tableView];
@@ -741,6 +741,7 @@ describe(@"didSelectRowAtIndexPath") {
   __block DolphinTableViewController *viewController = nil;
 
   beforeEach(^{
+    // Causes the UIKit framework to trigger the necessary methods to render the view and perform viewWillAppear: and 
     viewController = [[DolphinTableViewController alloc] init];
     [viewController beginAppearanceTransition:YES animated:NO];
     [viewController endAppearanceTransition];


### PR DESCRIPTION
Expands on the work of #151. Currently, we just access the view property and rely on it causing side-effects like `viewDidLoad` to be called, but that's not necessarily the best approach. We're doing something similar on [eidolon](https://github.com/artsy/eidolon/blob/9ee7da7134667e649e8be631e1beface5dde6e8f/KioskTests/ListingsViewControllerTests.swift#L46-L51) and we use the `beginAppearanceTransition` and `endAppearanceTransition` methods. 

These are nice since they are explicit in what they do to the view controller and how they alter its state. Additionally, they call the `viewWillAppear:` and `viewDidAppear:` callbacks, which often have important code to set up the view controller (such as beginner network requests). 

Happy to hear feedback on this!
