### PR TITLE
Only allow x86_64 for OS X builds

### DIFF
--- a/Quick/Quick.xcodeproj/project.pbxproj
+++ b/Quick/Quick.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -1078,6 +1079,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Parallels the change submitted in https://github.com/Quick/Nimble/pull/44.
