### PR TITLE
Example: Don't include internal root group in name

### DIFF
--- a/Quick/DSL.swift
+++ b/Quick/DSL.swift
@@ -14,7 +14,7 @@ import Foundation
     }
 
     public class func describe(description: String, closure: () -> ()) {
-        var group = ExampleGroup(description)
+        var group = ExampleGroup(description: description)
         World.sharedWorld().currentExampleGroup!.appendExampleGroup(group)
         World.sharedWorld().currentExampleGroup = group
         closure()
@@ -55,7 +55,7 @@ import Foundation
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld().sharedExample(name)
 
-        var group = ExampleGroup(name)
+        var group = ExampleGroup(description: name)
         World.sharedWorld().currentExampleGroup!.appendExampleGroup(group)
         World.sharedWorld().currentExampleGroup = group
         closure(sharedExampleContext)

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -11,7 +11,16 @@ var _numberOfExamplesRun = 0
     public var isSharedExample = false
     public var callsite: Callsite
 
-    public var name: String { get { return group!.name + ", " + _description } }
+    public var name: String {
+        get {
+            switch group!.name {
+                case .Some(let groupName):
+                    return "\(groupName), \(_description)"
+                case .None:
+                    return _description
+            }
+        }
+    }
 
     init(_ description: String, _ callsite: Callsite, _ closure: () -> ()) {
         self._description = description

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -4,14 +4,17 @@
 
     weak var parent: ExampleGroup?
 
-    var _description: String
+    let _description: String
+    let _isInternalRootExampleGroup: Bool
+
     var _localBefores = [BeforeClosure]()
     var _localAfters = [AfterClosure]()
     var _groups = [ExampleGroup]()
     var _localExamples = [Example]()
 
-    init(_ description: String) {
+    init(description: String, isInternalRootExampleGroup: Bool = false) {
         self._description = description
+        self._isInternalRootExampleGroup = isInternalRootExampleGroup
     }
 
     var befores: [BeforeClosure] {
@@ -44,15 +47,17 @@
         }
     }
 
-    var name: String {
+    var name: String? {
         get {
-            var name = _description
-            walkUp() { (group: ExampleGroup) -> () in
-                if group.parent != nil {
+            if self._isInternalRootExampleGroup {
+                return nil
+            } else {
+                var name = _description
+                walkUp() { (group: ExampleGroup) -> () in
                     name = group._description + ", " + name
                 }
+                return name
             }
-            return name
         }
     }
 

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -33,7 +33,8 @@ public class World: NSObject {
         if let group = _specs[name] {
             return group
         } else {
-            let group = ExampleGroup("root example group")
+            let group = ExampleGroup(description: "root example group",
+                                     isInternalRootExampleGroup: true)
             _specs[name] = group
             return group
         }

--- a/QuickTests/FunctionalTests/ItTests.swift
+++ b/QuickTests/FunctionalTests/ItTests.swift
@@ -8,13 +8,11 @@ class FunctionalTests_ItSpec: QuickSpec {
         beforeEach { (metadata: ExampleMetadata) in exampleMetadata = metadata }
 
         it("") {
-            // This is a bug; example names should not include "root example group".
-            // See: https://github.com/Quick/Quick/issues/168
-            expect(exampleMetadata!.example.name).to(equal("root example group, "))
+            expect(exampleMetadata!.example.name).to(equal(""))
         }
 
         it("has a description with セレクター名に使えない文字が入っている 👊💥") {
-            let name = "root example group, has a description with セレクター名に使えない文字が入っている 👊💥"
+            let name = "has a description with セレクター名に使えない文字が入っている 👊💥"
             expect(exampleMetadata!.example.name).to(equal(name))
         }
     }


### PR DESCRIPTION
Due to an internal implementation detail, all examples belong to an
example group. When not explicitly added to an example group, Quick adds
examples to an internal "root example group". This is to handle cases
like:

```
override func spec() {
  beforeEach { /* ... */ }
  it("is an example") { /* ... */ }
}
```

`beforeEach` closures need to be executed within an example group, so in
the above case Quick adds the example to an internal group.

This internal group, however, appears in example names. The above
example name was reported as "root example group, is an example". This
obviously isn't the intended example name, and the bug was reported in
issue #168.

In order to fix the issue, add a flag to example groups to determine
whether they are internal root example groups. If they are, do not
return a name.
