### PR TITLE
Update contributing guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,7 @@ it.
 
 ## Building the Project
 
-- Use `Quick.xcworkspace` to work on Quick, Nimble, and the example
-  apps.
+- Use `Quick.xcodeproj` to work on Quick.
 
 ## Pull Requests
 


### PR DESCRIPTION
- To reflect that Quick.xcworkspace has been removed.
