### PR TITLE
Add example and suite hooks

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -53,6 +53,12 @@
 		DA3124EB19FCAEE8002858A7 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E419FCAEE8002858A7 /* QCKDSL.m */; };
 		DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E519FCAEE8002858A7 /* World+DSL.swift */; };
 		DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E519FCAEE8002858A7 /* World+DSL.swift */; };
+		DA408BE219FF5599005DF92A /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BDF19FF5599005DF92A /* Closures.swift */; };
+		DA408BE319FF5599005DF92A /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BDF19FF5599005DF92A /* Closures.swift */; };
+		DA408BE419FF5599005DF92A /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE019FF5599005DF92A /* ExampleHooks.swift */; };
+		DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE019FF5599005DF92A /* ExampleHooks.swift */; };
+		DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE119FF5599005DF92A /* SuiteHooks.swift */; };
+		DA408BE719FF5599005DF92A /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE119FF5599005DF92A /* SuiteHooks.swift */; };
 		DA54728219FC2B5700332193 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA54727F19FC2B4400332193 /* Nimble.framework */; };
 		DA54728319FC2B5C00332193 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA54727B19FC2B4400332193 /* Nimble.framework */; };
 		DA7AE6F119FC493F000AFDCE /* ItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7AE6F019FC493F000AFDCE /* ItTests.swift */; };
@@ -308,6 +314,9 @@
 		DA3124E319FCAEE8002858A7 /* QCKDSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QCKDSL.h; sourceTree = "<group>"; };
 		DA3124E419FCAEE8002858A7 /* QCKDSL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QCKDSL.m; sourceTree = "<group>"; };
 		DA3124E519FCAEE8002858A7 /* World+DSL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "World+DSL.swift"; sourceTree = "<group>"; };
+		DA408BDF19FF5599005DF92A /* Closures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Closures.swift; sourceTree = "<group>"; };
+		DA408BE019FF5599005DF92A /* ExampleHooks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleHooks.swift; sourceTree = "<group>"; };
+		DA408BE119FF5599005DF92A /* SuiteHooks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuiteHooks.swift; sourceTree = "<group>"; };
 		DA54727319FC2B4400332193 /* Nimble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Nimble.xcodeproj; path = Externals/Nimble/Nimble.xcodeproj; sourceTree = SOURCE_ROOT; };
 		DA7AE6F019FC493F000AFDCE /* ItTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItTests.swift; sourceTree = "<group>"; };
 		DA87078219F48775008C04AC /* BeforeEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeforeEachTests.swift; sourceTree = "<group>"; };
@@ -383,6 +392,16 @@
 			path = DSL;
 			sourceTree = "<group>";
 		};
+		DA408BDE19FF5599005DF92A /* Hooks */ = {
+			isa = PBXGroup;
+			children = (
+				DA408BDF19FF5599005DF92A /* Closures.swift */,
+				DA408BE019FF5599005DF92A /* ExampleHooks.swift */,
+				DA408BE119FF5599005DF92A /* SuiteHooks.swift */,
+			);
+			path = Hooks;
+			sourceTree = "<group>";
+		};
 		DA54727419FC2B4400332193 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -447,6 +466,7 @@
 			isa = PBXGroup;
 			children = (
 				DA3124E119FCAEE8002858A7 /* DSL */,
+				DA408BDE19FF5599005DF92A /* Hooks */,
 				DAEB6B931943873100289F44 /* Quick.h */,
 				34F375A619515CA700CE1B99 /* World.swift */,
 				DAEE632919FF4EE30089F850 /* World+Singleton.swift */,
@@ -752,8 +772,10 @@
 			files = (
 				34F375B219515CA700CE1B99 /* NSString+QCKSelectorName.m in Sources */,
 				DA3124EB19FCAEE8002858A7 /* QCKDSL.m in Sources */,
+				DA408BE319FF5599005DF92A /* Closures.swift in Sources */,
 				DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */,
 				5AFC5961195EEDA900D3E0A2 /* NSException+Callsite.swift in Sources */,
+				DA408BE719FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				5AFC594A195ED5B900D3E0A2 /* Failure.swift in Sources */,
 				34F375BA19515CA700CE1B99 /* QuickSpec.m in Sources */,
 				34F375A819515CA700CE1B99 /* Callsite.swift in Sources */,
@@ -762,6 +784,7 @@
 				34F375BC19515CA700CE1B99 /* World.swift in Sources */,
 				DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				5A4A0D801960A84E005678EA /* QuickSharedExampleGroups.m in Sources */,
+				DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				34F375AC19515CA700CE1B99 /* Example.swift in Sources */,
 				DA3124E719FCAEE8002858A7 /* DSL.swift in Sources */,
 			);
@@ -796,8 +819,10 @@
 			files = (
 				34F375B119515CA700CE1B99 /* NSString+QCKSelectorName.m in Sources */,
 				DA3124EA19FCAEE8002858A7 /* QCKDSL.m in Sources */,
+				DA408BE219FF5599005DF92A /* Closures.swift in Sources */,
 				DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */,
 				5AFC5960195EEDA900D3E0A2 /* NSException+Callsite.swift in Sources */,
+				DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				5AFC5949195ED5B900D3E0A2 /* Failure.swift in Sources */,
 				34F375B919515CA700CE1B99 /* QuickSpec.m in Sources */,
 				34F375A719515CA700CE1B99 /* Callsite.swift in Sources */,
@@ -806,6 +831,7 @@
 				34F375BB19515CA700CE1B99 /* World.swift in Sources */,
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				5A4A0D7F1960A84E005678EA /* QuickSharedExampleGroups.m in Sources */,
+				DA408BE419FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				34F375AB19515CA700CE1B99 /* Example.swift in Sources */,
 				DA3124E619FCAEE8002858A7 /* DSL.swift in Sources */,
 			);

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -6,7 +6,7 @@
     If the test suite crashes before the first example is run, this closure
     will not be executed.
 */
-public func beforeSuite(closure: () -> ()) {
+public func beforeSuite(closure: BeforeSuiteClosure) {
     World.sharedWorld().beforeSuite(closure)
 }
 
@@ -18,7 +18,7 @@ public func beforeSuite(closure: () -> ()) {
     If the test suite crashes before all examples are run, this closure
     will not be executed.
 */
-public func afterSuite(closure: () -> ()) {
+public func afterSuite(closure: AfterSuiteClosure) {
     World.sharedWorld().afterSuite(closure)
 }
 
@@ -79,7 +79,7 @@ public func context(description: String, closure: () -> ()) {
 
     :param: closure The closure to be run prior to each example.
 */
-public func beforeEach(closure: () -> ()) {
+public func beforeEach(closure: BeforeExampleClosure) {
     World.sharedWorld().beforeEach(closure)
 }
 
@@ -87,7 +87,7 @@ public func beforeEach(closure: () -> ()) {
     Identical to beforeEach, except the closure is provided with metadata on
     the example that the closure is being run prior to.
 */
-public func beforeEach(#closure: (exampleMetadata: ExampleMetadata) -> ()) {
+public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
     World.sharedWorld().beforeEach(closure: closure)
 }
 
@@ -99,7 +99,7 @@ public func beforeEach(#closure: (exampleMetadata: ExampleMetadata) -> ()) {
 
     :param: closure The closure to be run after each example.
 */
-public func afterEach(closure: () -> ()) {
+public func afterEach(closure: AfterExampleClosure) {
     World.sharedWorld().afterEach(closure)
 }
 
@@ -107,7 +107,7 @@ public func afterEach(closure: () -> ()) {
     Identical to afterEach, except the closure is provided with metadata on
     the example that the closure is being run after.
 */
-public func afterEach(#closure: (exampleMetadata: ExampleMetadata) -> ()) {
+public func afterEach(#closure: AfterExampleWithMetadataClosure) {
     World.sharedWorld().afterEach(closure: closure)
 }
 

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -1,15 +1,15 @@
 /**
     Adds methods to World to support top-level DSL functions (Swift) and
-    macros (Objective-C). These functions map directly to the DSL test
+    macros (Objective-C). These functions map directly to the DSL that test
     writers use in their specs.
 */
 extension World {
-    public func beforeSuite(closure: () -> ()) {
-        appendBeforeSuite(closure)
+    public func beforeSuite(closure: BeforeSuiteClosure) {
+        suiteHooks.appendBefore(closure)
     }
 
-    public func afterSuite(closure: () -> ()) {
-        appendAfterSuite(closure)
+    public func afterSuite(closure: AfterSuiteClosure) {
+        suiteHooks.appendAfter(closure)
     }
 
     public func sharedExamples(name: String, closure: SharedExampleClosure) {
@@ -28,24 +28,20 @@ extension World {
         describe(description, closure: closure)
     }
 
-    public func beforeEach(closure: () -> ()) {
-        currentExampleGroup!.appendBefore { (exampleMetadata: ExampleMetadata) in
-            closure()
-        }
+    public func beforeEach(closure: BeforeExampleClosure) {
+        currentExampleGroup!.hooks.appendBefore(closure)
     }
 
-    public func beforeEach(#closure: (exampleMetadata: ExampleMetadata) -> ()) {
-        currentExampleGroup!.appendBefore(closure)
+    public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
+        currentExampleGroup!.hooks.appendBefore(closure)
     }
 
-    public func afterEach(closure: () -> ()) {
-        currentExampleGroup!.appendAfter { (exampleMetadata: ExampleMetadata) in
-            closure()
-        }
+    public func afterEach(closure: AfterExampleClosure) {
+        currentExampleGroup!.hooks.appendAfter(closure)
     }
 
-    public func afterEach(#closure: (exampleMetadata: ExampleMetadata) -> ()) {
-        currentExampleGroup!.appendAfter(closure)
+    public func afterEach(#closure: AfterExampleWithMetadataClosure) {
+        currentExampleGroup!.hooks.appendAfter(closure)
     }
 
     public func it(description: String, file: String, line: Int, closure: () -> ()) {

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -30,7 +30,7 @@ var _numberOfExamplesRun = 0
 
     public func run() {
         if _numberOfExamplesRun == 0 {
-            World.sharedWorld().runBeforeSpec()
+            World.sharedWorld().suiteHooks.executeBefores()
         }
 
         let exampleMetadata = ExampleMetadata(example: self, exampleIndex: _numberOfExamplesRun)
@@ -48,7 +48,7 @@ var _numberOfExamplesRun = 0
 
         let world = World.sharedWorld()
         if !world.isRunningAdditionalSuites && _numberOfExamplesRun >= world.exampleCount {
-            World.sharedWorld().runAfterSpec()
+            World.sharedWorld().suiteHooks.executeAfters()
         }
     }
 }

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -1,14 +1,10 @@
 @objc public class ExampleGroup {
-    typealias BeforeClosure = (exampleMetadata: ExampleMetadata) -> ()
-    typealias AfterClosure = BeforeClosure
+    internal let hooks = ExampleHooks()
 
     weak var parent: ExampleGroup?
 
     let _description: String
     let _isInternalRootExampleGroup: Bool
-
-    var _localBefores = [BeforeClosure]()
-    var _localAfters = [AfterClosure]()
     var _groups = [ExampleGroup]()
     var _localExamples = [Example]()
 
@@ -17,21 +13,21 @@
         self._isInternalRootExampleGroup = isInternalRootExampleGroup
     }
 
-    var befores: [BeforeClosure] {
+    var befores: [BeforeExampleWithMetadataClosure] {
         get {
-            var closures = _localBefores
+            var closures = hooks.befores
             walkUp() { (group: ExampleGroup) -> () in
-                closures.extend(group._localBefores)
+                closures.extend(group.hooks.befores)
             }
             return closures.reverse()
         }
     }
 
-    var afters: [AfterClosure] {
+    var afters: [AfterExampleWithMetadataClosure] {
         get {
-            var closures = _localAfters
+            var closures = hooks.afters
             walkUp() { (group: ExampleGroup) -> () in
-                closures.extend(group._localAfters)
+                closures.extend(group.hooks.afters)
             }
             return closures
         }
@@ -92,13 +88,5 @@
     func appendExample(example: Example) {
         example.group = self
         _localExamples.append(example)
-    }
-
-    func appendBefore(closure: BeforeClosure) {
-        _localBefores.append(closure)
-    }
-
-    func appendAfter(closure: AfterClosure) {
-        _localAfters.append(closure)
     }
 }

--- a/Quick/Hooks/Closures.swift
+++ b/Quick/Hooks/Closures.swift
@@ -1,0 +1,36 @@
+// MARK: Example Hooks
+
+/**
+    A closure executed before an example is run.
+*/
+public typealias BeforeExampleClosure = () -> ()
+
+/**
+    A closure executed before an example is run. The closure is given example metadata,
+    which contains information about the example that is about to be run.
+*/
+public typealias BeforeExampleWithMetadataClosure = (exampleMetadata: ExampleMetadata) -> ()
+
+/**
+    A closure executed after an example is run.
+*/
+public typealias AfterExampleClosure = BeforeExampleClosure
+
+/**
+    A closure executed after an example is run. The closure is given example metadata,
+    which contains information about the example that has just finished running.
+*/
+public typealias AfterExampleWithMetadataClosure = BeforeExampleWithMetadataClosure
+
+// MARK: Suite Hooks
+
+
+/**
+    A closure executed before any examples are run.
+*/
+public typealias BeforeSuiteClosure = () -> ()
+
+/**
+    A closure executed after all examples have finished running.
+*/
+public typealias AfterSuiteClosure = BeforeSuiteClosure

--- a/Quick/Hooks/ExampleHooks.swift
+++ b/Quick/Hooks/ExampleHooks.swift
@@ -1,0 +1,36 @@
+/**
+    A container for closures to be executed before and after each example.
+*/
+internal class ExampleHooks {
+
+    internal var befores: [BeforeExampleWithMetadataClosure] = []
+    internal var afters: [AfterExampleWithMetadataClosure] = []
+
+    internal func appendBefore(closure: BeforeExampleWithMetadataClosure) {
+        befores.append(closure)
+    }
+
+    internal func appendBefore(closure: BeforeExampleClosure) {
+        befores.append { (exampleMetadata: ExampleMetadata) in closure() }
+    }
+
+    internal func appendAfter(closure: AfterExampleWithMetadataClosure) {
+        afters.append(closure)
+    }
+
+    internal func appendAfter(closure: AfterExampleClosure) {
+        afters.append { (exampleMetadata: ExampleMetadata) in closure() }
+    }
+
+    internal func executeBefores(exampleMetadata: ExampleMetadata) {
+        for before in befores {
+            before(exampleMetadata: exampleMetadata)
+        }
+    }
+
+    internal func executeAfters(exampleMetadata: ExampleMetadata) {
+        for after in afters {
+            after(exampleMetadata: exampleMetadata)
+        }
+    }
+}

--- a/Quick/Hooks/SuiteHooks.swift
+++ b/Quick/Hooks/SuiteHooks.swift
@@ -1,0 +1,34 @@
+/**
+    A container for closures to be executed before and after all examples.
+*/
+internal class SuiteHooks {
+    internal var befores: [BeforeSuiteClosure] = []
+    internal var beforesAlreadyExecuted = false
+
+    internal var afters: [AfterSuiteClosure] = []
+    internal var aftersAlreadyExecuted = false
+
+    internal func appendBefore(closure: BeforeSuiteClosure) {
+        befores.append(closure)
+    }
+
+    internal func appendAfter(closure: AfterSuiteClosure) {
+        afters.append(closure)
+    }
+
+    internal func executeBefores() {
+        assert(!beforesAlreadyExecuted)
+        for before in befores {
+            before()
+        }
+        beforesAlreadyExecuted = true
+    }
+
+    internal func executeAfters() {
+        assert(!aftersAlreadyExecuted)
+        for after in afters {
+            after()
+        }
+        aftersAlreadyExecuted = true
+    }
+}

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -4,18 +4,11 @@ public typealias SharedExampleContext = () -> (NSDictionary)
 public typealias SharedExampleClosure = (SharedExampleContext) -> ()
 
 public class World: NSObject {
-    typealias BeforeSuiteClosure = () -> ()
-    typealias AfterSuiteClosure = BeforeSuiteClosure
-
     var _specs: Dictionary<String, ExampleGroup> = [:]
 
-    var _beforeSuites = [BeforeSuiteClosure]()
-    var _beforeSuitesNotRunYet = true
-
-    var _afterSuites = [AfterSuiteClosure]()
-    var _afterSuitesNotRunYet = true
-
     var _sharedExamples: [String: SharedExampleClosure] = [:]
+
+    internal var suiteHooks = SuiteHooks()
 
     public var currentExampleGroup: ExampleGroup?
 
@@ -31,30 +24,6 @@ public class World: NSObject {
             _specs[name] = group
             return group
         }
-    }
-
-    func runBeforeSpec() {
-        assert(_beforeSuitesNotRunYet, "runBeforeSuite was called twice")
-        for beforeSuite in _beforeSuites {
-            beforeSuite()
-        }
-        _beforeSuitesNotRunYet = false
-    }
-
-    func runAfterSpec() {
-        assert(_afterSuitesNotRunYet, "runAfterSuite was called twice")
-        for afterSuite in _afterSuites {
-            afterSuite()
-        }
-        _afterSuitesNotRunYet = false
-    }
-
-    func appendBeforeSuite(closure: BeforeSuiteClosure) {
-        _beforeSuites.append(closure)
-    }
-
-    func appendAfterSuite(closure: AfterSuiteClosure) {
-        _afterSuites.append(closure)
     }
 
     var exampleCount: Int {


### PR DESCRIPTION
Add hook objects as containers for beforeEach/afterEach and
beforeSuite/afterSuite. Quick will soon be configurable to execute
suite-wide beforeEach/afterEach closures--this makes that change easier.

This commit also introduces typealiases for each of the hook closure
types, and uses them throughout the codebase.
