### PR TITLE
Update README.md for correct CocoaPods gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,8 +912,9 @@ can be done by including a Gemfile that looks like this:
 source 'https://rubygems.org'
 
 gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :branch => 'swift'
-gem 'cocoapods-core', :git => 'https://github.com/CocoaPods/Core.git', :branch => 'swift'
-gem 'xcodeproj',  :git => "https://github.com/CocoaPods/Xcodeproj.git", :branch => 'ext_build_settings'
+gem 'cocoapods-core', :git => 'https://github.com/CocoaPods/Core.git'
+gem 'xcodeproj',  :git => 'https://github.com/CocoaPods/Xcodeproj.git'
+gem 'claide', :git => 'https://github.com/CocoaPods/CLAide.git'
 ```
 
 Then run `bundle install` to start using Swift CocoaPods for just this project.


### PR DESCRIPTION
Some swift branches are now merged onto master and deleted. Also it doesn't seem to work without CLAide anymore so we need to change the Gemfile for this setup to work.

This is all expected anyways as it's actively being worked upon.
