### PR TITLE
.travis.yml: Test OS X as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 
 before_install: git submodule update --init --recursive
-script: "rake test:ios"
+script: "rake"
 


### PR DESCRIPTION
Travis CI did not support OS X builds until recently. Begin testing
Quick-OSX as well, in order to prevent regressions.
