### PR TITLE
Fix block syntax in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ class DolphinTableViewControllerSpecs: QuickSpec {
 
 QuickSpecBegin(DolphinTableViewControllerSpec)
 
-describe(@"viewDidLoad") {
+describe(@"viewDidLoad", ^{
   __block DolphinTableViewController *viewController = nil;
 
   beforeEach(^{
@@ -767,7 +767,7 @@ describe(@"viewDidLoad") {
   });
 }
 
-describe(@"didSelectRowAtIndexPath") {
+describe(@"didSelectRowAtIndexPath", ^{
   __block DolphinTableViewController *viewController = nil;
 
   beforeEach(^{


### PR DESCRIPTION
I noticed that the Objective-C code example in section "Testing UIKit with Quick" was using Swift style trailing closures. So I went on and fixed those to proper Objective-C block syntax.
