### PR TITLE
Carthage install: Add Nimble to cartfile.private

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,8 +973,10 @@ As Test targets do not have the "Embedded Binaries" section, the frameworks must
  > As Carthage builds dynamic frameworks, you will need a valid code signing identity set up.
 
 1. Add Quick to your **[Cartfile.private](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileprivate)**
+
     ```
     github "Quick/Quick"
+    github "Quick/Nimble"
     ```
     
 2. Run `carthage update` 


### PR DESCRIPTION
Finally trying out Quick (& Carthage at the same time), great test library (was using Kiwi before).
In the README.md, the carthage installation seems to be missing the Nimble line (used afterwards).

Thanks!