### PR TITLE
Fix typo in Objective-C DSL

### DIFF
--- a/Quick/DSL/QCKDSL.h
+++ b/Quick/DSL/QCKDSL.h
@@ -205,7 +205,7 @@ static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
 #define qck_fitBehavesLike qck_itBehavesLike_builder(@{Filter.focused: @YES}, @(__FILE__), __LINE__)
 
 typedef void (^QCKItBlock)(NSString *description, QCKDSLEmptyBlock closure);
-typedef void (^QCKItBehavesLikeBlock)(NSString *descritpion, QCKDSLSharedExampleContext context);
+typedef void (^QCKItBehavesLikeBlock)(NSString *description, QCKDSLSharedExampleContext context);
 
 extern QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line);
 extern QCKItBehavesLikeBlock qck_itBehavesLike_builder(NSDictionary *flags, NSString *file, NSUInteger line);


### PR DESCRIPTION
Somehow this managed to sneak in there without anyone noticing :wolf: 