### PR TITLE
Add to Cocoapods Trunk

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Quick"
-  s.version      = "0.2.0"
+  s.version      = "0.2.2"
   s.summary      = "The Swift (and Objective-C) testing framework."
 
   s.description  = <<-DESC
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
 
-  s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v0.2.0" }
+  s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v#{s.version}" }
   s.source_files  = "Quick", "Quick/**/*.{swift,h,m}"
 
   s.framework = "XCTest"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ class TableOfContentsSpec: QuickSpec {
   - [Adding Quick as a Git Submodule](#adding-quick-as-a-git-submodule)
   - [Updating the Quick Submodule](#updating-the-quick-submodule)
   - [Cloning a Repository that Includes a Quick Submodule](#cloning-a-repository-that-includes-a-quick-submodule)
-- [How to Install Quick using Beta CocoaPods](#how-to-install-quick-using-beta-cocoapods)
+- [How to Install Quick using CocoaPods](#how-to-install-quick-using-cocoapods)
 - [How to Install Quick File Templates](#how-to-install-quick-file-templates)
   - [Using Alcatraz](#using-alcatraz)
   - [Manually via the Rakefile](#manually-via-the-rakefile)
@@ -957,16 +957,21 @@ You can read more about Git submodules
 of Git submodules in action, check out any of the repositories linked to
 in the ["Who Uses Quick"](#who-uses-quick) section of this guide.
 
-## How to Install Quick using Beta CocoaPods
+## How to Install Quick using CocoaPods
 
 If you would like to use Quick with CocoaPods today, you need to install the
 beta build of CocoaPods via `[sudo] gem install cocoapods --pre` then add Quick
 to your Podfile.
 
-```
-  pod 'Quick', :git => 'https://github.com/Quick/Quick', :tag => 'v0.2.2'
+```rb
+pod 'Quick'
 ```
 
+If you need the latest cutting-edge code, use the following:
+
+```rb
+pod 'Quick', :head
+```
 
 ## How to Install Quick using [Carthage](https://github.com/Carthage/Carthage)
 As Test targets do not have the "Embedded Binaries" section, the frameworks must be added to the target's "Link Binary With Libraries" as well as a "Copy Files" build phase to copy them to the target's Frameworks destination.  


### PR DESCRIPTION
I'd like to add Quick to [CocoaPods Trunk](http://guides.cocoapods.org/making/getting-setup-with-trunk.html) so that others may use it more easily and may also write pods using [quick as a dependency](https://github.com/ashfurrow/Nimble-Snapshots/issues/19). This pull requests contains updates to the README, as well as an update to bump the podspec to [0.2.2](https://github.com/Quick/Quick/releases/tag/v0.2.2)

Once this is merged, someone will need to push this to CocoaPods Trunk. I'm happy to do it, happy to add others as owners, and happy to allow someone else to do it altogether. Just let me know, @Quick/owners .