### PR TITLE
Removed beta xcode warning in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,8 +849,6 @@ QuickSpecEnd
 
 ## How to Install Quick
 
-> This module is beta software, it currently supports Xcode 6 Beta 4.
-
 Quick provides the syntax to define examples and example groups. Nimble
 provides the `expect(...).to` assertion syntax. You may use either one,
 or both, in your tests.


### PR DESCRIPTION
We might support Xcode versions greater than 6 beta 4 :wink:.

Also worth asking: are the version numbers enough to indicate beta-ness of Quick? If not, I can leave that part of the notice there.