### PR TITLE
Support Swift 1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ it.
 - Be sure the unit tests for both the OS X and iOS targets of both Quick
   and Nimble pass before submitting your pull request. You can run all
   the iOS and OS X unit tests using `rake test`.
+- To make minor updates to old versions of Quick that support Swift
+  1.1, issue a pull request against the `swift-1.1` branch. The master
+  branch supports Swift 1.2. Travis CI will only pass for pull requests
+  issued against the `swift-1.1` branch.
 
 ### Style Conventions
 

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -65,15 +65,15 @@ public func sharedExamples(name: String, closure: SharedExampleClosure) {
     :param: closure A closure that can contain other examples.
     :param: flags A mapping of string keys to booleans that can be used to filter examples or example groups.
 */
-public func describe(description: String, closure: () -> (), flags: FilterFlags = [:]) {
-    World.sharedWorld().describe(description, closure: closure, flags: flags)
+public func describe(description: String, flags: FilterFlags = [:], closure: () -> ()) {
+    World.sharedWorld().describe(description, flags: flags, closure: closure)
 }
 
 /**
     Defines an example group. Equivalent to `describe`.
 */
-public func context(description: String, closure: () -> (), flags: FilterFlags = [:]) {
-    describe(description, closure, flags: flags)
+public func context(description: String, flags: FilterFlags = [:], closure: () -> ()) {
+    describe(description, flags: flags, closure)
 }
 
 /**
@@ -127,7 +127,7 @@ public func afterEach(#closure: AfterExampleWithMetadataClosure) {
     :param: file The absolute path to the file containing the example. A sensible default is provided.
     :param: line The line containing the example. A sensible default is provided.
 */
-public func it(description: String, closure: () -> (), flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
+public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
     World.sharedWorld().it(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -144,7 +144,7 @@ public func it(description: String, closure: () -> (), flags: FilterFlags = [:],
     :param: line The line containing the current example group. A sensible default is provided.
 */
 public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
-    itBehavesLike(name, { return [:] }, flags: flags, file: file, line: line)
+    itBehavesLike(name, flags: flags, file: file, line: line, { return [:] })
 }
 
 /**
@@ -163,7 +163,7 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     :param: file The absolute path to the file containing the current example group. A sensible default is provided.
     :param: line The line containing the current example group. A sensible default is provided.
 */
-public func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
+public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, sharedExampleContext: SharedExampleContext) {
     World.sharedWorld().itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
 }
 
@@ -182,23 +182,23 @@ public func pending(description: String, closure: () -> ()) {
     Use this to quickly mark a `describe` closure as pending.
     This disables all examples within the closure.
 */
-public func xdescribe(description: String, closure: () -> (), flags: FilterFlags) {
-    World.sharedWorld().xdescribe(description, closure: closure, flags: flags)
+public func xdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
+    World.sharedWorld().xdescribe(description, flags: flags, closure: closure)
 }
 
 /**
     Use this to quickly mark a `context` closure as pending.
     This disables all examples within the closure.
 */
-public func xcontext(description: String, closure: () -> (), flags: FilterFlags) {
-    xdescribe(description, closure, flags)
+public func xcontext(description: String, flags: FilterFlags, closure: () -> ()) {
+    xdescribe(description, flags, closure)
 }
 
 /**
     Use this to quickly mark an `it` closure as pending.
     This disables the example and ensures the code within the closure is never run.
 */
-public func xit(description: String, closure: () -> (), flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
+public func xit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
     World.sharedWorld().xit(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -207,21 +207,21 @@ public func xit(description: String, closure: () -> (), flags: FilterFlags = [:]
     If any examples in the test suite are focused, only those examples are executed.
     This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
 */
-public func fdescribe(description: String, closure: () -> (), flags: FilterFlags = [:]) {
-    World.sharedWorld().fdescribe(description, closure: closure, flags: flags)
+public func fdescribe(description: String, flags: FilterFlags = [:], closure: () -> ()) {
+    World.sharedWorld().fdescribe(description, flags: flags, closure: closure)
 }
 
 /**
     Use this to quickly focus a `context` closure. Equivalent to `fdescribe`.
 */
-public func fcontext(description: String, closure: () -> (), flags: FilterFlags = [:]) {
-    fdescribe(description, closure, flags: flags)
+public func fcontext(description: String, flags: FilterFlags = [:], closure: () -> ()) {
+    fdescribe(description, flags: flags, closure)
 }
 
 /**
     Use this to quickly focus an `it` closure, focusing the example.
     If any examples in the test suite are focused, only those examples are executed.
 */
-public func fit(description: String, closure: () -> (), flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
+public func fit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
     World.sharedWorld().fit(description, flags: flags, file: file, line: line, closure: closure)
 }

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -14,7 +14,7 @@ void qck_sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure) {
 }
 
 void qck_describe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] describe:description closure:closure flags:@{}];
+    [[World sharedWorld] describe:description flags:@{} closure:closure];
 }
 
 void qck_context(NSString *description, QCKDSLEmptyBlock closure) {
@@ -54,7 +54,7 @@ void qck_pending(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] xdescribe:description closure:closure flags:@{}];
+    [[World sharedWorld] xdescribe:description flags:@{} closure:closure];
 }
 
 void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
@@ -62,7 +62,7 @@ void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] fdescribe:description closure:closure flags:@{}];
+    [[World sharedWorld] fdescribe:description flags:@{} closure:closure];
 }
 
 void qck_fcontext(NSString *description, QCKDSLEmptyBlock closure) {

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -16,7 +16,7 @@ extension World {
         registerSharedExample(name, closure: closure)
     }
 
-    public func describe(description: String, closure: () -> (), flags: FilterFlags) {
+    public func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         var group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup!.appendExampleGroup(group)
         currentExampleGroup = group
@@ -24,20 +24,20 @@ extension World {
         currentExampleGroup = group.parent
     }
 
-    public func context(description: String, closure: () -> (), flags: FilterFlags) {
-        self.describe(description, closure: closure, flags: flags)
+    public func context(description: String, flags: FilterFlags, closure: () -> ()) {
+        self.describe(description, flags: flags, closure: closure)
     }
 
-    public func fdescribe(description: String, closure: () -> (), flags: FilterFlags) {
+    public func fdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
-        self.describe(description, closure: closure, flags: focusedFlags)
+        self.describe(description, flags: focusedFlags, closure: closure)
     }
 
-    public func xdescribe(description: String, closure: () -> (), flags: FilterFlags) {
+    public func xdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
-        self.describe(description, closure: closure, flags: pendingFlags)
+        self.describe(description, flags: pendingFlags, closure: closure)
     }
 
     public func beforeEach(closure: BeforeExampleClosure) {
@@ -59,7 +59,7 @@ extension World {
     @objc(itWithDescription:flags:file:line:closure:)
     public func it(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
         let callsite = Callsite(file: file, line: line)
-        let example = Example(description: description, callsite: callsite, flags: flags, closure)
+        let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
         currentExampleGroup!.appendExample(example)
     }
 

--- a/QuickTests/Fixtures/FunctionalTests_SharedExamplesTests_SharedExamples.swift
+++ b/QuickTests/Fixtures/FunctionalTests_SharedExamplesTests_SharedExamples.swift
@@ -11,7 +11,7 @@ class FunctionalTests_SharedExamplesTests_SharedExamples: QuickConfiguration {
 
         sharedExamples("shared examples that take a context") { (sharedExampleContext: SharedExampleContext) in
             it("is passed the correct parameters via the context") {
-                let callsite = sharedExampleContext()["callsite"] as String
+                let callsite = sharedExampleContext()["callsite"] as! String
                 expect(callsite).to(equal("SharedExamplesSpec"))
             }
         }

--- a/QuickTests/FunctionalTests/AfterSuiteTests.swift
+++ b/QuickTests/FunctionalTests/AfterSuiteTests.swift
@@ -25,7 +25,7 @@ class AfterSuiteTests: XCTestCase {
         // Execute the spec with an assertion after the one with an afterSuite.
         let specs = NSArray(objects: FunctionalTests_AfterSuite_AfterSuiteSpec.classForCoder(),
                                      FunctionalTests_AfterSuite_Spec.classForCoder())
-        let result = qck_runSpecs(specs)
+        let result = qck_runSpecs(specs as! [AnyObject])
 
         // Although this ensures that afterSuite is not called before any
         // examples, it doesn't test that it's ever called in the first place.

--- a/QuickTests/FunctionalTests/BeforeSuiteTests.swift
+++ b/QuickTests/FunctionalTests/BeforeSuiteTests.swift
@@ -25,7 +25,7 @@ class BeforeSuiteTests: XCTestCase {
         // Execute the spec with an assertion before the one with a beforeSuite
         let specs = NSArray(objects: FunctionalTests_BeforeSuite_Spec.classForCoder(),
                                      FunctionalTests_BeforeSuite_BeforeSuiteSpec.classForCoder())
-        let result = qck_runSpecs(specs)
+        let result = qck_runSpecs(specs as! [AnyObject])
 
         XCTAssert(result.hasSucceeded)
     }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Quick is a behavior-driven development framework for Swift and Objective-C.
 Inspired by [RSpec](https://github.com/rspec/rspec), [Specta](https://github.com/specta/specta), and [Ginkgo](https://github.com/onsi/ginkgo).
 
-[![Build Status](https://travis-ci.org/Quick/Quick.svg)](https://travis-ci.org/Quick/Quick)
-
+[![Build Status](https://travis-ci.org/Quick/Quick.svg?branch=swift-1.1)](https://travis-ci.org/Quick/Quick)
 ![](https://raw.githubusercontent.com/Quick/Assets/master/Screenshots/QuickSpec%20screenshot.png)
 
 ```swift
@@ -862,6 +861,9 @@ To use Quick and Nimble to test your iOS or OS X applications, follow these 4 ea
 
 Example projects with this complete setup is available in the
 [`Examples`](https://github.com/modocache/Quick/tree/master/Examples) directory.
+
+The master branch of Quick supports Swift 1.2. For Swift 1.1 support,
+use the `swift-1.1` branch.
 
 ### 1. Clone the Quick and Nimble repositories
 


### PR DESCRIPTION
Builds upon @mprudhom's changes in #244. These changes get the tests passing using Xcode 6.3 and Swift 1.2. Of course, since Travis CI doesn't support Swift 1.2, CI does not pass on this branch.