### PR TITLE
Bumped Podspec version to 0.3.0

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Quick"
-  s.version      = "0.2.2"
+  s.version      = "0.3.0"
   s.summary      = "The Swift (and Objective-C) testing framework."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Worth noting is on v0.2.2 (what the current podspec is pointing to), in DSL.swift, the func `it` reads:

```public func it(description: String, closure: () -> (), flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) ```


Which will not allow the syntax in the readme

```it("has everything you need to get started") { }```

to work, as the closure is not yet updated to be at the end of the func declaration. I would expect this to be causing problems with users who are using the cocoapods beta. 
