### PR TITLE
Add link to new documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class TableOfContentsSpec: QuickSpec {
 
 ## Documentation
 
-Read the documentation [here](https://github.com/Quick/Quick/tree/master/Documentation).
+Read the documentation [in the Documentation folder](https://github.com/Quick/Quick/tree/master/Documentation).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ class TableOfContentsSpec: QuickSpec {
 }
 ```
 
+## Documentation
+
+Read the documentation [here](https://github.com/Quick/Quick/tree/master/Documentation).
+
 ## License
 
 Apache 2.0 license. See the `LICENSE` file for details.


### PR DESCRIPTION
It took me a while to find out that the documentation was moved to a separate directory. (I remember when it was in the README.) I think this will help with any confusion in the future for others. 