### PR TITLE
Updated README with instructions for Swift 1.2

### DIFF
--- a/Documentation/InstallingQuick.md
+++ b/Documentation/InstallingQuick.md
@@ -94,6 +94,14 @@ target 'MyTests' do
 end
 ```
 
+If you want to use Quick and Nimble with Swift 1.2, you'll currently need to use Quick Version 0.3.0 and Nimble Version 0.4.0. To do so, extend these lines in your Podfile:
+
+```rb
+    pod 'Quick', :git => 'git@github.com:Quick/Quick.git', :tag => 'v0.3.0'
+    pod 'Nimble', :git => 'git@github.com:Quick/Nimble.git', :tag => 'v0.4.0'
+```
+
+
 Finally, download and link Quick and Nimble to your tests:
 
 ```sh


### PR DESCRIPTION
Using Quick and Nimble with Swift 1.2 requires use of Quick Version 0.3.0 and Nimble Version 0.4.0 which both are currently not released to the central CocoaPods Podspec repo.

In order to use those Versions with Cocoapods, it is therefore necessary to target the specific tags in the Podfile. 

In this PR, I've added a note to the install instructions for CocoaPods to explain how to do this. 
This note can be removed once Quick 0.3.0 Nimble v0.4.0 are published to the central Podspec repo.