### PR TITLE
Quick.xcodeproj: Lower iOS deployment target to 7.0

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Quick"
-  s.version      = "0.3.0"
+  s.version      = "0.3.1"
   s.summary      = "The Swift (and Objective-C) testing framework."
 
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }
 
   s.author       = "Quick Contributors"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.10"
 
   s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v#{s.version}" }

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -1164,7 +1164,7 @@
 				);
 				INFOPLIST_FILE = Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1190,7 +1190,7 @@
 				);
 				INFOPLIST_FILE = Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_MODULE_NAME = Quick;
@@ -1215,7 +1215,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = QuickTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1235,7 +1235,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = QuickTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1300,7 +1300,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = QuickFocusedTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1320,7 +1320,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = QuickFocusedTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;


### PR DESCRIPTION
Depends on https://github.com/Quick/Nimble/pull/118. Once that's merged, this pull request should be update Externals/Nimble to point at v0.4.2.

Quick and Nimble can be used to test code running against on iOS 7.0, but their deployment targets were set too high in order to do so. Lower Quick's deployment target to make this possible.

Unfortunately, a warning is generated during the linking phase for Quick-iOS: "ld: warning: embedded dylibs/frameworks only run on iOS 8 or later". I'm not sure if this is avoidable. I'm no expert, though, I just skimmed ReactiveCocoa/ReactiveCocoa#1480.

A new release should be made after merging these changes.

Addresses #276.