### PR TITLE
Contributing guide clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ it.
   README or other documentation.
 - Be sure the unit tests for both the OS X and iOS targets of both Quick
   and Nimble pass before submitting your pull request. You can run all
-  the iOS and OS X unit tests using `rake test`.
+  the iOS and OS X unit tests using `rake`.
 - To make minor updates to old versions of Quick that support Swift
   1.1, issue a pull request against the `swift-1.1` branch. The master
   branch supports Swift 1.2. Travis CI will only pass for pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ it.
 
 ## Building the Project
 
+- After cloning the repository, run `git submodule update --init` to pull the Nimble submodule.
 - Use `Quick.xcworkspace` to work on Quick. The workspace includes
   Nimble, which is used in Quick's tests.
 


### PR DESCRIPTION
Hey there!

These are 2 really small things I ran into when working on something else.

- The first is that the command for running ios and osx tests is just `rake` rather than `rake test`. If you prefer, I can change the Rakefile so that it'll be `rake test` instead of changing the docs.
- The second is just a comment about updating the submodule just so other people forking and cloning for the first time will know what to do if they run into that issue.

Thank you very much! :rocket: 
