### PR TITLE
[WIP] Variable definitions

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5AFC5949195ED5B900D3E0A2 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC5948195ED5B900D3E0A2 /* Failure.swift */; };
 		5AFC594A195ED5B900D3E0A2 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC5948195ED5B900D3E0A2 /* Failure.swift */; };
+		CA16B0601AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
+		CA16B0611AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
 		DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
@@ -319,6 +321,7 @@
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AFC5948195ED5B900D3E0A2 /* Failure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
+		CA16B05F1AE2710000A708AF /* Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definitions.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
 		DA169E4719FF5DF100619816 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -567,6 +570,7 @@
 				34F3759C19515CA700CE1B99 /* Callsite.swift */,
 				5AFC5948195ED5B900D3E0A2 /* Failure.swift */,
 				DA6B30171A4DB0D500FFB148 /* Filter.swift */,
+				CA16B05F1AE2710000A708AF /* Definitions.swift */,
 				34F375A419515CA700CE1B99 /* QuickSpec.h */,
 				34F375A519515CA700CE1B99 /* QuickSpec.m */,
 				34F375A019515CA700CE1B99 /* NSString+QCKSelectorName.h */,
@@ -894,6 +898,7 @@
 				DAE7150119FF6A62005905B8 /* QuickConfiguration.m in Sources */,
 				34F375A819515CA700CE1B99 /* Callsite.swift in Sources */,
 				34F375AE19515CA700CE1B99 /* ExampleGroup.swift in Sources */,
+				CA16B0611AE2710000A708AF /* Definitions.swift in Sources */,
 				34F375BC19515CA700CE1B99 /* World.swift in Sources */,
 				DA169E4919FF5DF100619816 /* Configuration.swift in Sources */,
 				DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */,
@@ -969,6 +974,7 @@
 				DAE7150019FF6A62005905B8 /* QuickConfiguration.m in Sources */,
 				34F375A719515CA700CE1B99 /* Callsite.swift in Sources */,
 				34F375AD19515CA700CE1B99 /* ExampleGroup.swift in Sources */,
+				CA16B0601AE2710000A708AF /* Definitions.swift in Sources */,
 				34F375BB19515CA700CE1B99 /* World.swift in Sources */,
 				DA169E4819FF5DF100619816 /* Configuration.swift in Sources */,
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		5AFC594A195ED5B900D3E0A2 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC5948195ED5B900D3E0A2 /* Failure.swift */; };
 		CA16B0601AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
 		CA16B0611AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
+		CAA25A661AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
+		CAA25A671AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
 		DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
@@ -322,6 +324,7 @@
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AFC5948195ED5B900D3E0A2 /* Failure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
 		CA16B05F1AE2710000A708AF /* Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definitions.swift; sourceTree = "<group>"; };
+		CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionsTests.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
 		DA169E4719FF5DF100619816 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -472,6 +475,7 @@
 				47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */,
 				DA05D60F19F73A3800771050 /* AfterEachTests.swift */,
 				470D6EC91A43409600043E50 /* AfterEachTests+ObjC.m */,
+				CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */,
 				DAA63EA219F7637300CD0A3B /* PendingTests.swift */,
 				4715903F1A488F3F00FBA644 /* PendingTests+ObjC.m */,
 				DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */,
@@ -924,6 +928,7 @@
 				DA8C00221A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
 				DAA63EA419F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AC19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
+				CAA25A671AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */,
 				DA7AE6F219FC493F000AFDCE /* ItTests.swift in Sources */,
 				4748E8951A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
@@ -1000,6 +1005,7 @@
 				DA8C00211A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
 				DAA63EA319F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AB19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
+				CAA25A661AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */,
 				DA7AE6F119FC493F000AFDCE /* ItTests.swift in Sources */,
 				4748E8941A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -45,8 +45,10 @@
 		5AFC594A195ED5B900D3E0A2 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC5948195ED5B900D3E0A2 /* Failure.swift */; };
 		CA16B0601AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
 		CA16B0611AE2710000A708AF /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA16B05F1AE2710000A708AF /* Definitions.swift */; };
-		CAA25A661AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
-		CAA25A671AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
+		CA3C166E1AE293FD0086664A /* DefinitionsTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3C166D1AE293FD0086664A /* DefinitionsTests+ObjC.m */; };
+		CA3C166F1AE293FD0086664A /* DefinitionsTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3C166D1AE293FD0086664A /* DefinitionsTests+ObjC.m */; };
+		CA3C16721AE297DC0086664A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
+		CA3C16731AE297DD0086664A /* DefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */; };
 		DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
@@ -324,6 +326,7 @@
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AFC5948195ED5B900D3E0A2 /* Failure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
 		CA16B05F1AE2710000A708AF /* Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definitions.swift; sourceTree = "<group>"; };
+		CA3C166D1AE293FD0086664A /* DefinitionsTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "DefinitionsTests+ObjC.m"; sourceTree = "<group>"; };
 		CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinitionsTests.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
@@ -476,6 +479,7 @@
 				DA05D60F19F73A3800771050 /* AfterEachTests.swift */,
 				470D6EC91A43409600043E50 /* AfterEachTests+ObjC.m */,
 				CAA25A651AE27AD1009DCF0A /* DefinitionsTests.swift */,
+				CA3C166D1AE293FD0086664A /* DefinitionsTests+ObjC.m */,
 				DAA63EA219F7637300CD0A3B /* PendingTests.swift */,
 				4715903F1A488F3F00FBA644 /* PendingTests+ObjC.m */,
 				DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */,
@@ -923,12 +927,13 @@
 				4728253C1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				DAE714F119FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
 				DA05D61119F73A3800771050 /* AfterEachTests.swift in Sources */,
+				CA3C166F1AE293FD0086664A /* DefinitionsTests+ObjC.m in Sources */,
 				DAB0137019FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
 				DA8F91A619F3208B006F6675 /* BeforeSuiteTests.swift in Sources */,
 				DA8C00221A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
+				CA3C16731AE297DD0086664A /* DefinitionsTests.swift in Sources */,
 				DAA63EA419F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AC19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
-				CAA25A671AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */,
 				DA7AE6F219FC493F000AFDCE /* ItTests.swift in Sources */,
 				4748E8951A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
@@ -1000,12 +1005,13 @@
 				4728253B1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				DAE714F019FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
 				DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */,
+				CA3C166E1AE293FD0086664A /* DefinitionsTests+ObjC.m in Sources */,
 				DAB0136F19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
 				DA8F91A519F3208B006F6675 /* BeforeSuiteTests.swift in Sources */,
 				DA8C00211A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
+				CA3C16721AE297DC0086664A /* DefinitionsTests.swift in Sources */,
 				DAA63EA319F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AB19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
-				CAA25A661AE27AD1009DCF0A /* DefinitionsTests.swift in Sources */,
 				DA7AE6F119FC493F000AFDCE /* ItTests.swift in Sources */,
 				4748E8941A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,

--- a/Quick/Configuration/Configuration.swift
+++ b/Quick/Configuration/Configuration.swift
@@ -17,6 +17,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
 @objc final public class Configuration {
     internal let exampleHooks = ExampleHooks()
     internal let suiteHooks = SuiteHooks()
+    internal let definitions = Definitions()
     internal var exclusionFilters: [ExampleFilter] = [{ example in
         if let pending = example.filterFlags[Filter.pending] {
             return pending

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -117,6 +117,31 @@ public func afterEach(#closure: AfterExampleWithMetadataClosure) {
 }
 
 /**
+    Defines a variable in the current example group using a closure which
+    will be evaluated the first being fetched in each example and memoized
+    until the end of the example.
+
+    :param: name The name of the variable used to fetch it later on
+    :param: closure The closure to evaluate when fetching the variable
+*/
+public func define(name: String, closure: DefinitionClosure) {
+    World.sharedWorld().define(name, closure: closure)
+}
+
+/**
+    Fetches the specified variable from the current example group's defintions.
+    This will evaluate the variable closure when first run in each example and
+    return the memoized value in later fetches until the end of each example.
+
+    :param: name The name of the variable to fetch
+
+    :returns: The value of the specified variable
+*/
+public func fetch(name: String) -> AnyObject? {
+    return World.sharedWorld().fetch(name)
+}
+
+/**
     Defines an example. Examples use assertions to demonstrate how code should
     behave. These are like "tests" in XCTest.
 

--- a/Quick/DSL/QCKDSL.h
+++ b/Quick/DSL/QCKDSL.h
@@ -46,6 +46,7 @@
 typedef NSDictionary *(^QCKDSLSharedExampleContext)(void);
 typedef void (^QCKDSLSharedExampleBlock)(QCKDSLSharedExampleContext);
 typedef void (^QCKDSLEmptyBlock)(void);
+typedef NSObject* (^QCKDSLDefinitionBlock)(void);
 
 extern void qck_beforeSuite(QCKDSLEmptyBlock closure);
 extern void qck_afterSuite(QCKDSLEmptyBlock closure);
@@ -54,6 +55,8 @@ extern void qck_describe(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_context(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_beforeEach(QCKDSLEmptyBlock closure);
 extern void qck_afterEach(QCKDSLEmptyBlock closure);
+extern void qck_define(NSString *name, QCKDSLDefinitionBlock closure);
+extern NSObject* qck_fetch(NSString *name);
 extern void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
@@ -144,6 +147,31 @@ static inline void beforeEach(QCKDSLEmptyBlock closure) {
  */
 static inline void afterEach(QCKDSLEmptyBlock closure) {
     qck_afterEach(closure);
+}
+
+/**
+ Defines a variable in the current example group using a closure which
+ will be evaluated the first being fetched in each example and memoized
+ until the end of the example.
+ 
+ @param name The name of the variable used to fetch it later on
+ @param closure The closure to evaluate when fetching the variable
+ */
+static inline void define(NSString *name, QCKDSLDefinitionBlock closure) {
+    qck_define(name, closure);
+}
+
+/**
+ Fetches the specified variable from the current example group's defintions.
+ This will evaluate the variable closure when first run in each example and
+ return the memoized value in later fetches until the end of each example.
+ 
+ @param name The name of the variable to fetch
+ 
+ @return The value of the specified variable
+ */
+static inline NSObject* fetch(NSString *name) {
+    return qck_fetch(name);
 }
 
 /**

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -29,6 +29,14 @@ void qck_afterEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] afterEach:closure];
 }
 
+void qck_define(NSString *name, QCKDSLDefinitionBlock closure) {
+    [[World sharedWorld] define:name closure:closure];
+}
+
+NSObject *qck_fetch(NSString *name) {
+    return [[World sharedWorld] fetch:name];
+}
+
 QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line) {
     return ^(NSString *description, QCKDSLEmptyBlock closure) {
         [[World sharedWorld] itWithDescription:description

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -57,11 +57,11 @@ extension World {
     }
     
     public func define(name: String, closure: DefinitionClosure) {
-        currentExampleGroup!.defineVariable(name, closure: closure)
+        definitions.define(name, closure: closure)
     }
     
     public func fetch(name: String) -> AnyObject? {
-        return currentExampleGroup!.fetchVariable(name)
+        return definitions.fetch(name)
     }
 
     @objc(itWithDescription:flags:file:line:closure:)

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -55,6 +55,14 @@ extension World {
     public func afterEach(#closure: AfterExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
+    
+    public func define(name: String, closure: DefinitionClosure) {
+        currentExampleGroup!.defineVariable(name, closure: closure)
+    }
+    
+    public func fetch(name: String) -> AnyObject? {
+        return currentExampleGroup!.fetchVariable(name)
+    }
 
     @objc(itWithDescription:flags:file:line:closure:)
     public func it(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {

--- a/Quick/Definitions.swift
+++ b/Quick/Definitions.swift
@@ -1,12 +1,12 @@
-typealias DefinitionClosure = () -> AnyObject
+public typealias DefinitionClosure = () -> AnyObject
 
 /**
 A container for variable definitions in example groups
 */
 final internal class Definitions {
     
-    private let closures = [String: DefinitionClosure]()
-    private let memoizedValues = [String: AnyObject]()
+    private var closures = [String: DefinitionClosure]()
+    private var memoizedValues = [String: AnyObject]()
     
     internal func define(name: String, closure: DefinitionClosure) {
         closures[name] = closure
@@ -16,10 +16,10 @@ final internal class Definitions {
         if !contains(closures.keys, name) {
             return nil
         }
-        if let memoizedValue = memoizedValues[name] {
+        if let memoizedValue: AnyObject = memoizedValues[name] {
             return memoizedValue
         }
-        let computedValue = closures[name]()
+        let computedValue: AnyObject = closures[name]!()
         memoizedValues[name] = computedValue
         return computedValue
     }

--- a/Quick/Definitions.swift
+++ b/Quick/Definitions.swift
@@ -13,15 +13,15 @@ final internal class Definitions {
     }
     
     internal func fetch(name: String) -> AnyObject? {
-        if !contains(closures.keys, name) {
-            return nil
-        }
         if let memoizedValue: AnyObject = memoizedValues[name] {
             return memoizedValue
         }
-        let computedValue: AnyObject = closures[name]!()
-        memoizedValues[name] = computedValue
-        return computedValue
+        if let closure = closures[name] {
+            let computedValue: AnyObject = closure()
+            memoizedValues[name] = computedValue
+            return computedValue
+        }
+        return nil
     }
     
     internal func clearMemoizedValues() {

--- a/Quick/Definitions.swift
+++ b/Quick/Definitions.swift
@@ -1,0 +1,30 @@
+typealias DefinitionClosure = () -> AnyObject
+
+/**
+A container for variable definitions in example groups
+*/
+final internal class Definitions {
+    
+    private let closures = [String: DefinitionClosure]()
+    private let memoizedValues = [String: AnyObject]()
+    
+    internal func define(name: String, closure: DefinitionClosure) {
+        closures[name] = closure
+    }
+    
+    internal func fetch(name: String) -> AnyObject? {
+        if !contains(closures.keys, name) {
+            return nil
+        }
+        if let memoizedValue = memoizedValues[name] {
+            return memoizedValue
+        }
+        let computedValue = closures[name]()
+        memoizedValues[name] = computedValue
+        return computedValue
+    }
+    
+    internal func clearMemoizedValues() {
+        memoizedValues.removeAll(keepCapacity: false)
+    }
+}

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -71,6 +71,8 @@ private var numberOfExamplesRun = 0
             after(exampleMetadata: exampleMetadata)
         }
         world.exampleHooks.executeAfters(exampleMetadata)
+        
+        group!.clearMemoizedValues()
 
         ++numberOfExamplesRun
 

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -72,7 +72,7 @@ private var numberOfExamplesRun = 0
         }
         world.exampleHooks.executeAfters(exampleMetadata)
         
-        group!.clearMemoizedValues()
+        world.definitions.clearMemoizedValues()
 
         ++numberOfExamplesRun
 

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -6,6 +6,7 @@
 @objc final public class ExampleGroup {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
+    internal let definitions = Definitions()
 
     private let description: String
     private let flags: FilterFlags
@@ -67,7 +68,29 @@
         }
         return closures
     }
-
+    
+    internal func defineVariable(name: String, closure: DefinitionClosure) {
+        definitions.define(name, closure: closure)
+    }
+    
+    internal func fetchVariable(name: String) -> AnyObject? {
+        var group = self
+        while group {
+            if let value = group.definitions.fetch(name) {
+                return value
+            }
+            group = group.parent
+        }
+        return nil
+    }
+    
+    internal func clearMemoizedValues() {
+        definitions.clearMemoizedValues()
+        walkUp { group in
+            group.definitions.clearMemoizedValues()
+        }
+    }
+    
     internal func walkDownExamples(callback: (example: Example) -> ()) {
         for example in childExamples {
             callback(example: example)

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -74,12 +74,12 @@
     }
     
     internal func fetchVariable(name: String) -> AnyObject? {
-        var group = self
-        while group {
-            if let value = group.definitions.fetch(name) {
+        var group: ExampleGroup? = self
+        while let currentGroup = group {
+            if let value: AnyObject = currentGroup.definitions.fetch(name) {
                 return value
             }
-            group = group.parent
+            group = currentGroup.parent
         }
         return nil
     }

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -6,7 +6,6 @@
 @objc final public class ExampleGroup {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
-    internal let definitions = Definitions()
 
     private let description: String
     private let flags: FilterFlags
@@ -67,28 +66,6 @@
             closures.extend(group.hooks.afters)
         }
         return closures
-    }
-    
-    internal func defineVariable(name: String, closure: DefinitionClosure) {
-        definitions.define(name, closure: closure)
-    }
-    
-    internal func fetchVariable(name: String) -> AnyObject? {
-        var group: ExampleGroup? = self
-        while let currentGroup = group {
-            if let value: AnyObject = currentGroup.definitions.fetch(name) {
-                return value
-            }
-            group = currentGroup.parent
-        }
-        return nil
-    }
-    
-    internal func clearMemoizedValues() {
-        definitions.clearMemoizedValues()
-        walkUp { group in
-            group.definitions.clearMemoizedValues()
-        }
     }
     
     internal func walkDownExamples(callback: (example: Example) -> ()) {

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -67,7 +67,7 @@
         }
         return closures
     }
-    
+
     internal func walkDownExamples(callback: (example: Example) -> ()) {
         for example in childExamples {
             callback(example: example)

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -54,6 +54,8 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
     internal var exampleHooks: ExampleHooks {return configuration.exampleHooks }
     internal var suiteHooks: SuiteHooks { return configuration.suiteHooks }
 
+    internal var definitions: Definitions { return configuration.definitions }
+
     // MARK: Singleton Constructor
 
     private init() {}

--- a/QuickTests/FunctionalTests/DefinitionsTests+ObjC.m
+++ b/QuickTests/FunctionalTests/DefinitionsTests+ObjC.m
@@ -1,0 +1,61 @@
+#import <XCTest/XCTest.h>
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "QCKSpecRunner.h"
+
+static NSMutableArray *fetches;
+
+QuickSpecBegin(FunctionalTests_DefinitionsSpec)
+
+define(@"one", ^NSObject *{ return @1; });
+
+it(@"should evaluate and return the defined variable", ^{
+    NSNumber *one = (NSNumber *)fetch(@"one");
+    [fetches addObject:one];
+    expect(one).to(equal(@1));
+});
+
+__block NSNumber *mutatingNumber = @2;
+define(@"number", ^NSObject *{ return mutatingNumber; });
+
+it(@"should memoize the value of the first evaluation in each example", ^{
+    mutatingNumber = @2;
+    NSNumber *firstFetch = (NSNumber *)fetch(@"number");
+    [fetches addObject:firstFetch];
+    mutatingNumber = @3;
+    NSNumber *secondFetch = (NSNumber *)fetch(@"number");
+    [fetches addObject:secondFetch];
+    expect(secondFetch).to(equal(firstFetch));
+});
+
+it(@"should clear memoized values between examples", ^{
+    mutatingNumber = @4;
+    NSNumber *number = (NSNumber *)fetch(@"number");
+    [fetches addObject:number];
+    expect(number).to(equal(@4));
+});
+
+QuickSpecEnd
+
+@interface DefinitionsTests : XCTestCase; @end
+
+@implementation DefinitionsTests
+
+- (void)setUp {
+    [super setUp];
+    fetches = [NSMutableArray array];
+}
+
+- (void)tearDown {
+    fetches = [NSMutableArray array];
+    [super tearDown];
+}
+
+- (void)testFetchesReturnsTheExpectedValues {
+    qck_runSpec([FunctionalTests_DefinitionsSpec class]);
+    NSArray *expectedFetches = @[@1, @2, @2, @4];
+    XCTAssertEqualObjects(fetches, expectedFetches);
+}
+
+@end

--- a/QuickTests/FunctionalTests/DefinitionsTests+ObjC.m
+++ b/QuickTests/FunctionalTests/DefinitionsTests+ObjC.m
@@ -20,7 +20,6 @@ __block NSNumber *mutatingNumber = @2;
 define(@"number", ^NSObject *{ return mutatingNumber; });
 
 it(@"should memoize the value of the first evaluation in each example", ^{
-    mutatingNumber = @2;
     NSNumber *firstFetch = (NSNumber *)fetch(@"number");
     [fetches addObject:firstFetch];
     mutatingNumber = @3;

--- a/QuickTests/FunctionalTests/DefinitionsTests.swift
+++ b/QuickTests/FunctionalTests/DefinitionsTests.swift
@@ -1,0 +1,9 @@
+//
+//  DefinitionsTests.swift
+//  Quick
+//
+//  Created by Assaf Gelber on 4/18/15.
+//  Copyright (c) 2015 Brian Ivan Gesiak. All rights reserved.
+//
+
+import Foundation

--- a/QuickTests/FunctionalTests/DefinitionsTests.swift
+++ b/QuickTests/FunctionalTests/DefinitionsTests.swift
@@ -1,9 +1,35 @@
-//
-//  DefinitionsTests.swift
-//  Quick
-//
-//  Created by Assaf Gelber on 4/18/15.
-//  Copyright (c) 2015 Brian Ivan Gesiak. All rights reserved.
-//
+import XCTest
+import Quick
+import Nimble
 
-import Foundation
+private var fetches = [Int]()
+
+class FunctionalTests_DefinitionsSpec: QuickSpec {
+    override func spec() {
+        define("one") { return 1 }
+
+        it("should evaluate and return the defined variable") {
+            let one = fetch("one") as! Int
+            fetches.append(one)
+            expect(one).to(equal(1))
+        }
+    }
+}
+
+class DefinitionsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        fetches = []
+    }
+    
+    override func tearDown() {
+        fetches = []
+        super.tearDown()
+    }
+    
+    func testFetchesReturnExpectedValues() {
+        qck_runSpec(FunctionalTests_DefinitionsSpec)
+        let expectedFetches = [1]
+        XCTAssertEqual(fetches, expectedFetches)
+    }
+}

--- a/QuickTests/FunctionalTests/DefinitionsTests.swift
+++ b/QuickTests/FunctionalTests/DefinitionsTests.swift
@@ -13,6 +13,25 @@ class FunctionalTests_DefinitionsSpec: QuickSpec {
             fetches.append(one)
             expect(one).to(equal(1))
         }
+
+        var mutatingNumber = 2
+        define("number") { return mutatingNumber }
+
+        it("should memoize the value of the first evaluation in each example") {
+            let firstFetch = fetch("number") as! Int
+            fetches.append(firstFetch)
+            mutatingNumber = 3
+            let secondFetch = fetch("number") as! Int
+            fetches.append(secondFetch)
+            expect(secondFetch).to(equal(firstFetch))
+        }
+
+        it("should clear memoized values between examples") {
+            mutatingNumber = 4
+            let number = fetch("number") as! Int
+            fetches.append(number)
+            expect(number).to(equal(4))
+        }
     }
 }
 
@@ -21,15 +40,15 @@ class DefinitionsTests: XCTestCase {
         super.setUp()
         fetches = []
     }
-    
+
     override func tearDown() {
         fetches = []
         super.tearDown()
     }
-    
-    func testFetchesReturnExpectedValues() {
+
+    func testFetchesReturnsTheExpectedValues() {
         qck_runSpec(FunctionalTests_DefinitionsSpec)
-        let expectedFetches = [1]
+        let expectedFetches = [1, 2, 2, 4]
         XCTAssertEqual(fetches, expectedFetches)
     }
 }


### PR DESCRIPTION
Hi there!

__Background:__
I really like the way `let`s work in rspec, and also saw issue #231, so I tried implementing something similar for quick.

__Implementation:__
I added a `Definitions` class which holds a dictionary which maps "variable names" as strings to closures and a dictionary which holds memoized values of those closures.
I added a `definitions` property to `Configuration` which can also be used through `World`, in a similar fashion to the way hooks are used.
So now from anywhere in your tests, you can use `define` (`let` was taken :smile_cat:) which takes a name and a closure to define a variable and `fetch` which takes a variable name and returns the value for that variable. The values are memoized for example and reset between examples (just like rspec).

__My Problem:__
In swift, this works just as expected, the tests I wrote are passing and everything is happy.
In Objective-C, however, my last test (which is identical to the swift one) is failing. Instead of `number` being `4`, I get `2` again. My assumption is that the value of `mutatingNumber` is being captured in the block even though I marked it as `__block`. I am not completely sure why and I couldn't get this to work, so I though one of you guys might have a solution to this.

I really appreciate the work you've all been putting into Quick and would really love to see this feature making it's way in if we can figure this out.
Let me know if there's any more information I could give or any other thing I can do!

Thanks! :beers: 