### PR TITLE
Markdown syntax fix in link to Carthage.private docs

### DIFF
--- a/Documentation/InstallingQuick.md
+++ b/Documentation/InstallingQuick.md
@@ -113,7 +113,7 @@ to copy them to the target's Frameworks destination.
 
  > As Carthage builds dynamic frameworks, you will need a valid code signing identity set up.
 
-1. Add Quick to your `[Cartfile.private](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileprivate)`:
+1. Add Quick to your [`Cartfile.private`](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileprivate):
 
     ```
     github "Quick/Quick"


### PR DESCRIPTION
This will make the link to Carthage.private look like this [`Carthage.private`](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileprivate). Most likely a typo while writing the documentation.

Documentation which is great btw, very informative and thorough. I especially like how it first focuses on teaching the bases of good tests, then _sells_ Quick. Very well done. Thanks!