### PR TITLE
Shared examples with different context

### DIFF
--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -101,7 +101,8 @@ const void * const QCKExampleKey = &QCKExampleKey;
         [example run];
     });
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
-    SEL selector = NSSelectorFromString(example.name.qck_selectorName);
+    NSString *selectorName = [NSString stringWithFormat:@"%@_%@_%ld", example.name.qck_selectorName, example.callsite.file, (long)example.callsite.line];
+    SEL selector = NSSelectorFromString(selectorName);
     class_addMethod(self, selector, implementation, types);
 
     return selector;

--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -101,7 +101,10 @@ const void * const QCKExampleKey = &QCKExampleKey;
         [example run];
     });
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
-    NSString *selectorName = [NSString stringWithFormat:@"%@_%@_%ld", example.name.qck_selectorName, example.callsite.file, (long)example.callsite.line];
+    NSString *selectorName = [NSString stringWithFormat:@"%@_%@_%ld",
+                              example.name.qck_selectorName,
+                              example.callsite.file,
+                              (long)example.callsite.line];
     SEL selector = NSSelectorFromString(selectorName);
     class_addMethod(self, selector, implementation, types);
 

--- a/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
+++ b/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
@@ -20,7 +20,7 @@ QuickSpecEnd
 
 QuickSpecBegin(FunctionalTests_SharedExamples_SameContextSpec)
 
-__block NSInteger counter;
+__block NSInteger counter = 0;
 
 afterEach(^{
     counter++;

--- a/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
+++ b/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
@@ -37,15 +37,11 @@ sharedExamples(@"gets called with a different context from within the same spec 
 });
 
 itBehavesLike(@"gets called with a different context from within the same spec file", ^{
-    return @{
-             @"payload" : @"0"
-             };
+    return @{ @"payload" : @"0" };
 });
 
 itBehavesLike(@"gets called with a different context from within the same spec file", ^{
-    return @{
-             @"payload" : @"1"
-             };
+    return @{ @"payload" : @"1" };
 });
 
 QuickSpecEnd

--- a/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
+++ b/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
@@ -18,6 +18,39 @@ itBehavesLike(@"shared examples that take a context", ^NSDictionary *{
 
 QuickSpecEnd
 
+QuickSpecBegin(FunctionalTests_SharedExamples_SameContextSpec)
+
+__block NSInteger counter;
+
+afterEach(^{
+    counter++;
+});
+
+sharedExamples(@"gets called with a different context from within the same spec file", ^(QCKDSLSharedExampleContext exampleContext) {
+    
+    it(@"tracks correctly", ^{
+        NSString *payload = exampleContext()[@"payload"];
+        BOOL expected = [payload isEqualToString:[NSString stringWithFormat:@"%ld", (long)counter]];
+        expect(@(expected)).to(beTrue());
+    });
+    
+});
+
+itBehavesLike(@"gets called with a different context from within the same spec file", ^{
+    return @{
+             @"payload" : @"0"
+             };
+});
+
+itBehavesLike(@"gets called with a different context from within the same spec file", ^{
+    return @{
+             @"payload" : @"1"
+             };
+});
+
+QuickSpecEnd
+
+
 @interface SharedExamplesTests : XCTestCase; @end
 
 @implementation SharedExamplesTests


### PR DESCRIPTION
When calling `itBehavesLike` multiple times from within the same ObjC spec, the `sharedExamples` gets always called with the same context. Problem is, that the dynamically generated selector for the instance of the `Example` is always the same same. see c5675e53f55ab05a0e861556ad03f012b9ce4d4a
This PR tries to fix this by adding more unique properties (filename and line number) to the generated selector name. see 563f61570ce3b3cfce7fa5de6e566b5d6c767913