### PR TITLE
Bridge example metadata to Objective-C

### DIFF
--- a/Documentation/QuickExamplesAndGroups.md
+++ b/Documentation/QuickExamplesAndGroups.md
@@ -460,3 +460,21 @@ You can specify as many `beforeSuite` and `afterSuite` as you like. All
 `beforeSuite` closures will be executed before any tests run, and all
 `afterSuite` closures will be executed after all the tests are finished.
 There is no guarantee as to what order these closures will be executed in.
+
+## Accessing Metadata for the Current Example
+
+There may be some cases in which you'd like the know the name of the example
+that is currently being run, or how many have been run so far. Quick provides
+access to this metadata in `beforeEach` and `afterEach` closures.
+
+```swift
+beforeEach { exampleMetadata in
+  println("This is example number \(exampleMetadata.exampleIndex)")
+}
+```
+
+```objc
+beforeEachWithMetadata(^(ExampleMetadata *exampleMetadata){
+  NSLog(@"This is example number %l", (long)exampleMetadata.exampleIndex);
+});
+```

--- a/Documentation/QuickExamplesAndGroups.md
+++ b/Documentation/QuickExamplesAndGroups.md
@@ -469,12 +469,20 @@ access to this metadata in `beforeEach` and `afterEach` closures.
 
 ```swift
 beforeEach { exampleMetadata in
-  println("This is example number \(exampleMetadata.exampleIndex)")
+  println("Example number \(exampleMetadata.exampleIndex) is about to be run.")
+}
+
+afterEach { exampleMetadata in
+  println("Example number \(exampleMetadata.exampleIndex) has run.")
 }
 ```
 
 ```objc
 beforeEachWithMetadata(^(ExampleMetadata *exampleMetadata){
-  NSLog(@"This is example number %l", (long)exampleMetadata.exampleIndex);
+  NSLog(@"Example number %l is about to be run.", (long)exampleMetadata.exampleIndex);
+});
+
+afterEachWithMetadata(^(ExampleMetadata *exampleMetadata){
+  NSLog(@"Example number %l has run.", (long)exampleMetadata.exampleIndex);
 });
 ```

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -93,7 +93,7 @@ public func beforeEach(closure: BeforeExampleClosure) {
     metadata on the example that the closure is being run prior to.
 */
 public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
-    World.sharedWorld().beforeEach(closure: closure)
+    World.sharedWorld().beforeEach(closure)
 }
 
 /**

--- a/Quick/DSL/QCKDSL.h
+++ b/Quick/DSL/QCKDSL.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+@class ExampleMetadata;
+
 /**
  Provides a hook for Quick to be configured before any examples are run.
  Within this scope, override the +[QuickConfiguration configure:] method
@@ -46,6 +48,7 @@
 typedef NSDictionary *(^QCKDSLSharedExampleContext)(void);
 typedef void (^QCKDSLSharedExampleBlock)(QCKDSLSharedExampleContext);
 typedef void (^QCKDSLEmptyBlock)(void);
+typedef void (^QCKDSLExampleMetadataBlock)(ExampleMetadata *exampleMetadata);
 
 extern void qck_beforeSuite(QCKDSLEmptyBlock closure);
 extern void qck_afterSuite(QCKDSLEmptyBlock closure);
@@ -53,6 +56,7 @@ extern void qck_sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure)
 extern void qck_describe(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_context(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_beforeEach(QCKDSLEmptyBlock closure);
+extern void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure);
 extern void qck_afterEach(QCKDSLEmptyBlock closure);
 extern void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
@@ -132,6 +136,10 @@ static inline void context(NSString *description, QCKDSLEmptyBlock closure) {
  */
 static inline void beforeEach(QCKDSLEmptyBlock closure) {
     qck_beforeEach(closure);
+}
+
+static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_beforeEachWithMetadata(closure);
 }
 
 /**

--- a/Quick/DSL/QCKDSL.h
+++ b/Quick/DSL/QCKDSL.h
@@ -138,6 +138,10 @@ static inline void beforeEach(QCKDSLEmptyBlock closure) {
     qck_beforeEach(closure);
 }
 
+/**
+    Identical to QCKDSL.beforeEach, except the closure is provided with
+    metadata on the example that the closure is being run prior to.
+ */
 static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     qck_beforeEachWithMetadata(closure);
 }

--- a/Quick/DSL/QCKDSL.h
+++ b/Quick/DSL/QCKDSL.h
@@ -58,6 +58,7 @@ extern void qck_context(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_beforeEach(QCKDSLEmptyBlock closure);
 extern void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure);
 extern void qck_afterEach(QCKDSLEmptyBlock closure);
+extern void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure);
 extern void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
 extern void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
@@ -156,6 +157,14 @@ static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
  */
 static inline void afterEach(QCKDSLEmptyBlock closure) {
     qck_afterEach(closure);
+}
+
+/**
+    Identical to QCKDSL.afterEach, except the closure is provided with
+    metadata on the example that the closure is being run after.
+ */
+static inline void afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_afterEachWithMetadata(closure);
 }
 
 /**

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -25,6 +25,10 @@ void qck_beforeEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] beforeEach:closure];
 }
 
+void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    [[World sharedWorld] beforeEachWithMetadata:closure];
+}
+
 void qck_afterEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] afterEach:closure];
 }

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -33,6 +33,10 @@ void qck_afterEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] afterEach:closure];
 }
 
+void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    [[World sharedWorld] afterEachWithMetadata:closure];
+}
+
 QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line) {
     return ^(NSString *description, QCKDSLEmptyBlock closure) {
         [[World sharedWorld] itWithDescription:description

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -44,7 +44,8 @@ extension World {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 
-    public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
+    @objc(beforeEachWithMetadata:)
+    public func beforeEach(closure: BeforeExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -53,6 +53,7 @@ extension World {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
 
+    @objc(afterEachWithMetadata:)
     public func afterEach(#closure: AfterExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendAfter(closure)
     }

--- a/QuickTests/FunctionalTests/ItTests+ObjC.m
+++ b/QuickTests/FunctionalTests/ItTests+ObjC.m
@@ -3,14 +3,12 @@
 #import <Nimble/Nimble.h>
 
 #import "QCKSpecRunner.h"
-#import "Quick/Quick-Swift.h"
 
 QuickSpecBegin(FunctionalTests_ItSpec)
 
 __block ExampleMetadata *exampleMetadata = nil;
-
-beforeEach(^{
-    exampleMetadata = [[World sharedWorld] currentExampleMetadata];
+beforeEachWithMetadata(^(ExampleMetadata *metadata) {
+    exampleMetadata = metadata;
 });
 
 it(@" ", ^{

--- a/QuickTests/FunctionalTests/ItTests.swift
+++ b/QuickTests/FunctionalTests/ItTests.swift
@@ -5,7 +5,7 @@ import Nimble
 class FunctionalTests_ItSpec: QuickSpec {
     override func spec() {
         var exampleMetadata: ExampleMetadata?
-        beforeEach { (metadata: ExampleMetadata) in exampleMetadata = metadata }
+        beforeEach { metadata in exampleMetadata = metadata }
 
         it("") {
             expect(exampleMetadata!.example.name).to(equal(""))


### PR DESCRIPTION
A goal for Quick v1.0 is to no longer expose the `Quick.World` singleton. This is made harder by the fact that our very own tests use it!

Bridge `beforeEach` and `afterEach` closures that take example metadata arguments to Objective-C, in order to allow `ItTests+ObjC.m` to not use "private" APIs.