### PR TITLE
Forward-declare World, which is now internal

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -109,6 +109,10 @@
 		DAE7150119FF6A62005905B8 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE714FD19FF6A62005905B8 /* QuickConfiguration.m */; };
 		DAEB6B941943873100289F44 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAEB6B9A1943873100289F44 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAEB6B8E1943873100289F44 /* Quick.framework */; };
+		DAED1EC41B1105BC006F61EC /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC21B1105BC006F61EC /* World.h */; };
+		DAED1EC51B1105BC006F61EC /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC21B1105BC006F61EC /* World.h */; };
+		DAED1ECA1B110699006F61EC /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC81B110699006F61EC /* World+DSL.h */; };
+		DAED1ECB1B110699006F61EC /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC81B110699006F61EC /* World+DSL.h */; };
 		DAF28BC31A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */; };
 		DAF28BC41A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */; };
 /* End PBXBuildFile section */
@@ -357,6 +361,8 @@
 		DAEB6B931943873100289F44 /* Quick.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Quick.h; sourceTree = "<group>"; };
 		DAEB6B991943873100289F44 /* Quick-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAEB6B9F1943873100289F44 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DAED1EC21B1105BC006F61EC /* World.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = World.h; sourceTree = "<group>"; };
+		DAED1EC81B110699006F61EC /* World+DSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "World+DSL.h"; sourceTree = "<group>"; };
 		DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FocusedTests+ObjC.m"; sourceTree = "<group>"; };
 		F8100E901A1E4447007595ED /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -429,6 +435,7 @@
 			isa = PBXGroup;
 			children = (
 				DA3124E519FCAEE8002858A7 /* World+DSL.swift */,
+				DAED1EC81B110699006F61EC /* World+DSL.h */,
 				DA3124E219FCAEE8002858A7 /* DSL.swift */,
 				DA3124E319FCAEE8002858A7 /* QCKDSL.h */,
 				DA3124E419FCAEE8002858A7 /* QCKDSL.m */,
@@ -560,6 +567,7 @@
 				DA408BDE19FF5599005DF92A /* Hooks */,
 				DAEB6B931943873100289F44 /* Quick.h */,
 				34F375A619515CA700CE1B99 /* World.swift */,
+				DAED1EC21B1105BC006F61EC /* World.h */,
 				34F3759E19515CA700CE1B99 /* Example.swift */,
 				DA02C91819A8073100093156 /* ExampleMetadata.swift */,
 				34F3759F19515CA700CE1B99 /* ExampleGroup.swift */,
@@ -629,6 +637,8 @@
 				34F375B019515CA700CE1B99 /* NSString+QCKSelectorName.h in Headers */,
 				DAE714FF19FF6A62005905B8 /* QuickConfiguration.h in Headers */,
 				DA3124E919FCAEE8002858A7 /* QCKDSL.h in Headers */,
+				DAED1ECB1B110699006F61EC /* World+DSL.h in Headers */,
+				DAED1EC51B1105BC006F61EC /* World.h in Headers */,
 				34F375B819515CA700CE1B99 /* QuickSpec.h in Headers */,
 				5A5D11A7194740E000F6D13D /* Quick.h in Headers */,
 			);
@@ -641,6 +651,8 @@
 				34F375AF19515CA700CE1B99 /* NSString+QCKSelectorName.h in Headers */,
 				DAE714FE19FF6A62005905B8 /* QuickConfiguration.h in Headers */,
 				DA3124E819FCAEE8002858A7 /* QCKDSL.h in Headers */,
+				DAED1ECA1B110699006F61EC /* World+DSL.h in Headers */,
+				DAED1EC41B1105BC006F61EC /* World.h in Headers */,
 				34F375B719515CA700CE1B99 /* QuickSpec.h in Headers */,
 				DAEB6B941943873100289F44 /* Quick.h in Headers */,
 			);

--- a/Quick/Configuration/QuickConfiguration.m
+++ b/Quick/Configuration/QuickConfiguration.m
@@ -1,6 +1,9 @@
 #import "QuickConfiguration.h"
+#import "World.h"
 #import <Quick/Quick-Swift.h>
 #import <objc/runtime.h>
+
+QuickWorldBridge
 
 typedef void (^QCKClassEnumerationBlock)(Class klass);
 

--- a/Quick/Configuration/QuickConfiguration.m
+++ b/Quick/Configuration/QuickConfiguration.m
@@ -1,9 +1,6 @@
 #import "QuickConfiguration.h"
 #import "World.h"
-#import <Quick/Quick-Swift.h>
 #import <objc/runtime.h>
-
-QuickWorldBridge
 
 typedef void (^QCKClassEnumerationBlock)(Class klass);
 

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -1,5 +1,10 @@
 #import "QCKDSL.h"
+#import "World.h"
+#import "World+DSL.h"
 #import <Quick/Quick-Swift.h>
+
+QuickWorldBridge
+QuickWorldDSLBridge
 
 void qck_beforeSuite(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] beforeSuite:closure];

--- a/Quick/DSL/QCKDSL.m
+++ b/Quick/DSL/QCKDSL.m
@@ -1,10 +1,6 @@
 #import "QCKDSL.h"
 #import "World.h"
 #import "World+DSL.h"
-#import <Quick/Quick-Swift.h>
-
-QuickWorldBridge
-QuickWorldDSLBridge
 
 void qck_beforeSuite(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] beforeSuite:closure];

--- a/Quick/DSL/World+DSL.h
+++ b/Quick/DSL/World+DSL.h
@@ -1,0 +1,20 @@
+#define QuickWorldDSLBridge \
+@interface World (SWIFT_EXTENSION(Quick)) \
+- (void)beforeSuite:(void (^ __nonnull)(void))closure; \
+- (void)afterSuite:(void (^ __nonnull)(void))closure; \
+- (void)sharedExamples:(NSString * __nonnull)name closure:(void (^ __nonnull)(NSDictionary * __nonnull (^ __nonnull)(void)))closure; \
+- (void)describe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
+- (void)context:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
+- (void)fdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
+- (void)xdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
+- (void)beforeEach:(void (^ __nonnull)(void))closure; \
+- (void)beforeEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure; \
+- (void)afterEach:(void (^ __nonnull)(void))closure; \
+- (void)afterEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure; \
+- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
+- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
+- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
+- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line; \
+- (void)pending:(NSString * __nonnull)description closure:(void (^ __nonnull)(void))closure; \
+@end \
+ \

--- a/Quick/DSL/World+DSL.h
+++ b/Quick/DSL/World+DSL.h
@@ -1,20 +1,20 @@
-#define QuickWorldDSLBridge \
-@interface World (SWIFT_EXTENSION(Quick)) \
-- (void)beforeSuite:(void (^ __nonnull)(void))closure; \
-- (void)afterSuite:(void (^ __nonnull)(void))closure; \
-- (void)sharedExamples:(NSString * __nonnull)name closure:(void (^ __nonnull)(NSDictionary * __nonnull (^ __nonnull)(void)))closure; \
-- (void)describe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
-- (void)context:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
-- (void)fdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
-- (void)xdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure; \
-- (void)beforeEach:(void (^ __nonnull)(void))closure; \
-- (void)beforeEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure; \
-- (void)afterEach:(void (^ __nonnull)(void))closure; \
-- (void)afterEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure; \
-- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
-- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
-- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure; \
-- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line; \
-- (void)pending:(NSString * __nonnull)description closure:(void (^ __nonnull)(void))closure; \
-@end \
- \
+#import <Quick/Quick-Swift.h>
+
+@interface World (SWIFT_EXTENSION(Quick))
+- (void)beforeSuite:(void (^ __nonnull)(void))closure;
+- (void)afterSuite:(void (^ __nonnull)(void))closure;
+- (void)sharedExamples:(NSString * __nonnull)name closure:(void (^ __nonnull)(NSDictionary * __nonnull (^ __nonnull)(void)))closure;
+- (void)describe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)context:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)fdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)xdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)beforeEach:(void (^ __nonnull)(void))closure;
+- (void)beforeEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
+- (void)afterEach:(void (^ __nonnull)(void))closure;
+- (void)afterEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
+- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line;
+- (void)pending:(NSString * __nonnull)description closure:(void (^ __nonnull)(void))closure;
+@end

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -4,19 +4,19 @@
     writers use in their specs.
 */
 extension World {
-    public func beforeSuite(closure: BeforeSuiteClosure) {
+    internal func beforeSuite(closure: BeforeSuiteClosure) {
         suiteHooks.appendBefore(closure)
     }
 
-    public func afterSuite(closure: AfterSuiteClosure) {
+    internal func afterSuite(closure: AfterSuiteClosure) {
         suiteHooks.appendAfter(closure)
     }
 
-    public func sharedExamples(name: String, closure: SharedExampleClosure) {
+    internal func sharedExamples(name: String, closure: SharedExampleClosure) {
         registerSharedExample(name, closure: closure)
     }
 
-    public func describe(description: String, flags: FilterFlags, closure: () -> ()) {
+    internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         var group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup!.appendExampleGroup(group)
         currentExampleGroup = group
@@ -24,63 +24,63 @@ extension World {
         currentExampleGroup = group.parent
     }
 
-    public func context(description: String, flags: FilterFlags, closure: () -> ()) {
+    internal func context(description: String, flags: FilterFlags, closure: () -> ()) {
         self.describe(description, flags: flags, closure: closure)
     }
 
-    public func fdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
+    internal func fdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
         self.describe(description, flags: focusedFlags, closure: closure)
     }
 
-    public func xdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
+    internal func xdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
         self.describe(description, flags: pendingFlags, closure: closure)
     }
 
-    public func beforeEach(closure: BeforeExampleClosure) {
+    internal func beforeEach(closure: BeforeExampleClosure) {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 
     @objc(beforeEachWithMetadata:)
-    public func beforeEach(closure: BeforeExampleWithMetadataClosure) {
+    internal func beforeEach(closure: BeforeExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 
-    public func afterEach(closure: AfterExampleClosure) {
+    internal func afterEach(closure: AfterExampleClosure) {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
 
     @objc(afterEachWithMetadata:)
-    public func afterEach(#closure: AfterExampleWithMetadataClosure) {
+    internal func afterEach(#closure: AfterExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
 
     @objc(itWithDescription:flags:file:line:closure:)
-    public func it(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func it(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
         let callsite = Callsite(file: file, line: line)
         let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
         currentExampleGroup!.appendExample(example)
     }
 
     @objc(fitWithDescription:flags:file:line:closure:)
-    public func fit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func fit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
         self.it(description, flags: focusedFlags, file: file, line: line, closure: closure)
     }
 
     @objc(xitWithDescription:flags:file:line:closure:)
-    public func xit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func xit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
         self.it(description, flags: pendingFlags, file: file, line: line, closure: closure)
     }
 
     @objc(itBehavesLikeSharedExampleNamed:sharedExampleContext:flags:file:line:)
-    public func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: Int) {
+    internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: Int) {
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld().sharedExample(name)
 
@@ -96,7 +96,7 @@ extension World {
         currentExampleGroup = group.parent
     }
 
-    public func pending(description: String, closure: () -> ()) {
+    internal func pending(description: String, closure: () -> ()) {
         println("Pending: \(description)")
     }
 }

--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -1,8 +1,11 @@
 #import "QuickSpec.h"
 #import "QuickConfiguration.h"
 #import "NSString+QCKSelectorName.h"
+#import "World.h"
 #import <Quick/Quick-Swift.h>
 #import <objc/runtime.h>
+
+QuickWorldBridge
 
 const void * const QCKExampleKey = &QCKExampleKey;
 

--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -2,10 +2,7 @@
 #import "QuickConfiguration.h"
 #import "NSString+QCKSelectorName.h"
 #import "World.h"
-#import <Quick/Quick-Swift.h>
 #import <objc/runtime.h>
-
-QuickWorldBridge
 
 const void * const QCKExampleKey = &QCKExampleKey;
 

--- a/Quick/World.h
+++ b/Quick/World.h
@@ -1,0 +1,18 @@
+#define QuickWorldBridge \
+@class ExampleGroup; \
+@class ExampleMetadata; \
+ \
+SWIFT_CLASS("_TtC5Quick5World") \
+@interface World \
+ \
+@property (nonatomic) ExampleGroup * __nullable currentExampleGroup; \
+@property (nonatomic) ExampleMetadata * __nullable currentExampleMetadata; \
+@property (nonatomic) BOOL isRunningAdditionalSuites; \
++ (World * __nonnull)sharedWorld; \
+- (void)configure:(void (^ __nonnull)(Configuration * __nonnull))closure; \
+- (void)finalizeConfiguration; \
+- (ExampleGroup * __nonnull)rootExampleGroupForSpecClass:(Class __nonnull)cls; \
+- (NSArray * __nonnull)examplesForSpecClass:(Class __nonnull)specClass; \
+ \
+@end \
+ \

--- a/Quick/World.h
+++ b/Quick/World.h
@@ -1,18 +1,17 @@
-#define QuickWorldBridge \
-@class ExampleGroup; \
-@class ExampleMetadata; \
- \
-SWIFT_CLASS("_TtC5Quick5World") \
-@interface World \
- \
-@property (nonatomic) ExampleGroup * __nullable currentExampleGroup; \
-@property (nonatomic) ExampleMetadata * __nullable currentExampleMetadata; \
-@property (nonatomic) BOOL isRunningAdditionalSuites; \
-+ (World * __nonnull)sharedWorld; \
-- (void)configure:(void (^ __nonnull)(Configuration * __nonnull))closure; \
-- (void)finalizeConfiguration; \
-- (ExampleGroup * __nonnull)rootExampleGroupForSpecClass:(Class __nonnull)cls; \
-- (NSArray * __nonnull)examplesForSpecClass:(Class __nonnull)specClass; \
- \
-@end \
- \
+#import <Quick/Quick-Swift.h>
+
+@class ExampleGroup;
+@class ExampleMetadata;
+
+SWIFT_CLASS("_TtC5Quick5World")
+@interface World
+
+@property (nonatomic) ExampleGroup * __nullable currentExampleGroup;
+@property (nonatomic) ExampleMetadata * __nullable currentExampleMetadata;
+@property (nonatomic) BOOL isRunningAdditionalSuites;
++ (World * __nonnull)sharedWorld;
+- (void)configure:(void (^ __nonnull)(Configuration * __nonnull))closure;
+- (void)finalizeConfiguration;
+- (ExampleGroup * __nonnull)rootExampleGroupForSpecClass:(Class __nonnull)cls;
+- (NSArray * __nonnull)examplesForSpecClass:(Class __nonnull)specClass;
+@end

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -23,13 +23,13 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
     You may configure how Quick behaves by calling the -[World configure:]
     method from within an overridden +[QuickConfiguration configure:] method.
 */
-@objc final public class World {
+@objc final internal class World {
     /**
         The example group that is currently being run.
         The DSL requires that this group is correctly set in order to build a
         correct hierarchy of example groups and their examples.
     */
-    public var currentExampleGroup: ExampleGroup?
+    internal var currentExampleGroup: ExampleGroup?
 
     /**
         The example metadata of the test that is currently being run.
@@ -37,14 +37,14 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         runtime.
     */
 
-    public var currentExampleMetadata: ExampleMetadata?
+    internal var currentExampleMetadata: ExampleMetadata?
 
     /**
         A flag that indicates whether additional test suites are being run
         within this test suite. This is only true within the context of Quick
         functional tests.
     */
-    public var isRunningAdditionalSuites = false
+    internal var isRunningAdditionalSuites = false
 
     private var specs: Dictionary<String, ExampleGroup> = [:]
     private var sharedExamples: [String: SharedExampleClosure] = [:]
@@ -60,7 +60,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
     private struct Shared {
         static let instance = World()
     }
-    public class func sharedWorld() -> World {
+    internal class func sharedWorld() -> World {
         return Shared.instance
     }
 
@@ -74,7 +74,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         :param: closure  A closure that takes a Configuration object that can
                          be mutated to change Quick's behavior.
     */
-    public func configure(closure: QuickConfigurer) {
+    internal func configure(closure: QuickConfigurer) {
         assert(!isConfigurationFinalized,
                "Quick cannot be configured outside of a +[QuickConfiguration configure:] method. You should not call -[World configure:] directly. Instead, subclass QuickConfiguration and override the +[QuickConfiguration configure:] method.")
         closure(configuration: configuration)
@@ -84,7 +84,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         Finalizes the World's configuration.
         Any subsequent calls to World.configure() will raise.
     */
-    public func finalizeConfiguration() {
+    internal func finalizeConfiguration() {
         isConfigurationFinalized = true
     }
 
@@ -106,7 +106,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         :param: cls The QuickSpec class for which to retrieve the root example group.
         :returns: The root example group for the class.
     */
-    public func rootExampleGroupForSpecClass(cls: AnyClass) -> ExampleGroup {
+    internal func rootExampleGroupForSpecClass(cls: AnyClass) -> ExampleGroup {
         let name = NSStringFromClass(cls)
         if let group = specs[name] {
             return group
@@ -131,7 +131,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         :returns: A list of examples to be run as test invocations.
     */
     @objc(examplesForSpecClass:)
-    public func examples(specClass: AnyClass) -> [Example] {
+    internal func examples(specClass: AnyClass) -> [Example] {
         // 1. Grab all included examples.
         let included = includedExamples
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.

--- a/QuickTests/Helpers/QCKSpecRunner.m
+++ b/QuickTests/Helpers/QCKSpecRunner.m
@@ -1,7 +1,9 @@
 #import "QCKSpecRunner.h"
 #import "XCTestObservationCenter.h"
-
+#import "World.h"
 #import <Quick/Quick.h>
+
+QuickWorldBridge
 
 XCTestRun *qck_runSuite(XCTestSuite *suite) {
     [World sharedWorld].isRunningAdditionalSuites = YES;

--- a/QuickTests/Helpers/QCKSpecRunner.m
+++ b/QuickTests/Helpers/QCKSpecRunner.m
@@ -3,8 +3,6 @@
 #import "World.h"
 #import <Quick/Quick.h>
 
-QuickWorldBridge
-
 XCTestRun *qck_runSuite(XCTestSuite *suite) {
     [World sharedWorld].isRunningAdditionalSuites = YES;
 


### PR DESCRIPTION
This must be merged **after** #302. This pull request is a revision of #287.

---

One of Quick's greatest design flaws is due to the combination
of four factors:

1. Quick has a predilection for Swift--one of it's goals was to be
   written entirely in Swift if possible.
2. Quick supports tests written in both Swift and Objective-C.
3. XCTest relies upon subclassing for test discovery.
4. Objective-C classes cannot subclass Swift base classes.

As such, Quick is unable to define QuickSpec, a base XCTestCase
subclass, in Swift, and then have both Objective-C and Swift tests
subclass QuickSpec.

Instead, in order to be used from both Swift and Objective-C, QuickSpec
must be implemented in Objective-C. This forces internal Quick code,
such as Quick.World, to be marked as public. People using Quick to
write tests were thus able to call Quick.World directly, even though
that class is meant to be an implementation detail.

In order to get around the need for World to be public, define macros
which can be used to make a forward declaration of World within an
Objective-C file.