### PR TITLE
[CI] Use rakefile task instead of xcodebuild directly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,30 +12,7 @@ checkout:
 # See: https://github.com/facebook/xctool/issues/415
 test:
   override:
-    - set -o pipefail &&
-      xcodebuild
-        -scheme "Quick-iOS"
-        -sdk iphonesimulator
-        -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 6'
-        -workspace Quick.xcworkspace
-        -configuration Debug
-        CODE_SIGNING_REQUIRED=NO
-        CODE_SIGN_IDENTITY=
-        PROVISIONING_PROFILE=
-        clean test |
-      tee $CIRCLE_ARTIFACTS/xcode_raw_ios.log |
-      xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/ios-results.xml
-    - set -o pipefail &&
-      xcodebuild
-        -scheme "Quick-OSX"
-        -sdk macosx
-        -workspace Quick.xcworkspace
-        -configuration Debug
-        CODE_SIGNING_REQUIRED=NO
-        CODE_SIGN_IDENTITY=
-        PROVISIONING_PROFILE=
-        clean test |
-      tee $CIRCLE_ARTIFACTS/xcode_raw_osx.log |
-      xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/osx-results.xml
+    - rake test:ios
+    - rake test:osx
 
 


### PR DESCRIPTION
I was wrong about the circleci setup stuff.

Being more implicit for xcodebuild seems to make it build the dependent Nimble.framework for Quick-OSX.

Since it would be nearly the same as running the rake tasks, I've converted them to the rake tasks.

Hopefully, this should resolve all the inconsistent CI failures we've been experiencing.