### PR TITLE
Support Swift 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+*.xcscmblueprint
 
 # CocoaPods
 #

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 		DA8F919519F31680006F6675 /* QCKSpecRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QCKSpecRunner.h; sourceTree = "<group>"; };
 		DA8F919619F31680006F6675 /* QCKSpecRunner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QCKSpecRunner.m; sourceTree = "<group>"; };
 		DA8F919719F31680006F6675 /* QuickTestsBridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuickTestsBridgingHeader.h; sourceTree = "<group>"; };
-		DA8F919819F31680006F6675 /* XCTestObservationCenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCTestObservationCenter.h; sourceTree = "<group>"; };
+		DA8F919819F31680006F6675 /* XCTestObservationCenter+QCKSuspendObservation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestObservationCenter+QCKSuspendObservation.h"; sourceTree = "<group>"; };
 		DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FailureTests+ObjC.m"; sourceTree = "<group>"; };
 		DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeforeSuiteTests.swift; sourceTree = "<group>"; };
 		DA8F91A719F32556006F6675 /* AfterSuiteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterSuiteTests.swift; sourceTree = "<group>"; };
@@ -452,7 +452,7 @@
 				DA8F919719F31680006F6675 /* QuickTestsBridgingHeader.h */,
 				DA8F919519F31680006F6675 /* QCKSpecRunner.h */,
 				DA8F919619F31680006F6675 /* QCKSpecRunner.m */,
-				DA8F919819F31680006F6675 /* XCTestObservationCenter.h */,
+				DA8F919819F31680006F6675 /* XCTestObservationCenter+QCKSuspendObservation.h */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -785,7 +785,7 @@
 		DAEB6B851943873100289F44 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Brian Ivan Gesiak";
 				TargetAttributes = {
 					5A5D117B19473F2100F6D13D = {
@@ -1164,6 +1164,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Quick;
 				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
@@ -1189,6 +1190,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Quick;
 				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
@@ -1215,6 +1217,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
@@ -1235,6 +1238,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
@@ -1259,6 +1263,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1278,6 +1283,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
 			};
@@ -1300,6 +1306,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
@@ -1320,6 +1327,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
@@ -1347,6 +1355,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1424,6 +1433,7 @@
 				INFOPLIST_FILE = Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Quick;
 				PRODUCT_NAME = Quick;
 				SKIP_INSTALL = YES;
@@ -1447,6 +1457,7 @@
 				INFOPLIST_FILE = Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Quick;
 				PRODUCT_NAME = Quick;
 				SKIP_INSTALL = YES;
@@ -1470,6 +1481,7 @@
 				INFOPLIST_FILE = QuickTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1488,6 +1500,7 @@
 				INFOPLIST_FILE = QuickTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
 			};

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-OSX.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -58,6 +58,8 @@
             ReferencedContainer = "container:Quick.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -67,6 +69,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -58,6 +58,8 @@
             ReferencedContainer = "container:Quick.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -67,6 +69,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -73,7 +73,7 @@ public func describe(description: String, flags: FilterFlags = [:], closure: () 
     Defines an example group. Equivalent to `describe`.
 */
 public func context(description: String, flags: FilterFlags = [:], closure: () -> ()) {
-    describe(description, flags: flags, closure)
+    describe(description, flags: flags, closure: closure)
 }
 
 /**
@@ -82,7 +82,7 @@ public func context(description: String, flags: FilterFlags = [:], closure: () -
     An example group may contain an unlimited number of beforeEach. They'll be
     run in the order they're defined, but you shouldn't rely on that behavior.
 
-    :param: closure The closure to be run prior to each example.
+    - parameter closure: The closure to be run prior to each example.
 */
 public func beforeEach(closure: BeforeExampleClosure) {
     World.sharedWorld().beforeEach(closure)
@@ -92,7 +92,7 @@ public func beforeEach(closure: BeforeExampleClosure) {
     Identical to Quick.DSL.beforeEach, except the closure is provided with
     metadata on the example that the closure is being run prior to.
 */
-public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
+public func beforeEach(closure closure: BeforeExampleWithMetadataClosure) {
     World.sharedWorld().beforeEach(closure: closure)
 }
 
@@ -112,7 +112,7 @@ public func afterEach(closure: AfterExampleClosure) {
     Identical to Quick.DSL.afterEach, except the closure is provided with
     metadata on the example that the closure is being run after.
 */
-public func afterEach(#closure: AfterExampleWithMetadataClosure) {
+public func afterEach(closure closure: AfterExampleWithMetadataClosure) {
     World.sharedWorld().afterEach(closure: closure)
 }
 
@@ -144,7 +144,7 @@ public func it(description: String, flags: FilterFlags = [:], file: String = __F
     :param: line The line containing the current example group. A sensible default is provided.
 */
 public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
-    itBehavesLike(name, flags: flags, file: file, line: line, { return [:] })
+    itBehavesLike(name, flags: flags, file: file, line: line, sharedExampleContext: { return [:] })
 }
 
 /**
@@ -191,7 +191,7 @@ public func xdescribe(description: String, flags: FilterFlags, closure: () -> ()
     This disables all examples within the closure.
 */
 public func xcontext(description: String, flags: FilterFlags, closure: () -> ()) {
-    xdescribe(description, flags, closure)
+    xdescribe(description, flags: flags, closure: closure)
 }
 
 /**
@@ -215,7 +215,7 @@ public func fdescribe(description: String, flags: FilterFlags = [:], closure: ()
     Use this to quickly focus a `context` closure. Equivalent to `fdescribe`.
 */
 public func fcontext(description: String, flags: FilterFlags = [:], closure: () -> ()) {
-    fdescribe(description, flags: flags, closure)
+    fdescribe(description, flags: flags, closure: closure)
 }
 
 /**

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -17,7 +17,7 @@ extension World {
     }
 
     public func describe(description: String, flags: FilterFlags, closure: () -> ()) {
-        var group = ExampleGroup(description: description, flags: flags)
+        let group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup!.appendExampleGroup(group)
         currentExampleGroup = group
         closure()
@@ -44,7 +44,7 @@ extension World {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 
-    public func beforeEach(#closure: BeforeExampleWithMetadataClosure) {
+    public func beforeEach(closure closure: BeforeExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendBefore(closure)
     }
 
@@ -52,7 +52,7 @@ extension World {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
 
-    public func afterEach(#closure: AfterExampleWithMetadataClosure) {
+    public func afterEach(closure closure: AfterExampleWithMetadataClosure) {
         currentExampleGroup!.hooks.appendAfter(closure)
     }
 
@@ -82,7 +82,7 @@ extension World {
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld().sharedExample(name)
 
-        var group = ExampleGroup(description: name, flags: flags)
+        let group = ExampleGroup(description: name, flags: flags)
         currentExampleGroup!.appendExampleGroup(group)
         currentExampleGroup = group
         closure(sharedExampleContext)
@@ -95,6 +95,6 @@ extension World {
     }
 
     public func pending(description: String, closure: () -> ()) {
-        println("Pending: \(description)")
+        print("Pending: \(description)")
     }
 }

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -53,11 +53,11 @@
     }
 
     internal var befores: [BeforeExampleWithMetadataClosure] {
-        var closures = hooks.befores.reverse()
+        var closures = Array(hooks.befores.reverse())
         walkUp() { (group: ExampleGroup) -> () in
-            closures.extend(group.hooks.befores.reverse())
+            closures.extend(Array(group.hooks.befores.reverse()))
         }
-        return closures.reverse()
+        return Array(closures.reverse())
     }
 
     internal var afters: [AfterExampleWithMetadataClosure] {

--- a/Quick/Info.plist
+++ b/Quick/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.quick.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -135,7 +135,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         // 1. Grab all included examples.
         let included = includedExamples
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.
-        let spec = rootExampleGroupForSpecClass(specClass).examples.filter { contains(included, $0) }
+        let spec = rootExampleGroupForSpecClass(specClass).examples.filter { included.contains($0) }
         // 3. Remove all excluded examples.
         return spec.filter { example in
             !self.configuration.exclusionFilters.reduce(false) { $0 || $1(example: example) }

--- a/QuickFocusedTests/Info.plist
+++ b/QuickFocusedTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.quick.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QuickTests/FunctionalTests/AfterSuiteTests.swift
+++ b/QuickTests/FunctionalTests/AfterSuiteTests.swift
@@ -25,7 +25,7 @@ class AfterSuiteTests: XCTestCase {
         // Execute the spec with an assertion after the one with an afterSuite.
         let specs = NSArray(objects: FunctionalTests_AfterSuite_AfterSuiteSpec.classForCoder(),
                                      FunctionalTests_AfterSuite_Spec.classForCoder())
-        let result = qck_runSpecs(specs as! [AnyObject])
+        let result = qck_runSpecs(specs as [AnyObject])
 
         // Although this ensures that afterSuite is not called before any
         // examples, it doesn't test that it's ever called in the first place.

--- a/QuickTests/FunctionalTests/BeforeSuiteTests.swift
+++ b/QuickTests/FunctionalTests/BeforeSuiteTests.swift
@@ -25,7 +25,7 @@ class BeforeSuiteTests: XCTestCase {
         // Execute the spec with an assertion before the one with a beforeSuite
         let specs = NSArray(objects: FunctionalTests_BeforeSuite_Spec.classForCoder(),
                                      FunctionalTests_BeforeSuite_BeforeSuiteSpec.classForCoder())
-        let result = qck_runSpecs(specs as! [AnyObject])
+        let result = qck_runSpecs(specs as [AnyObject])
 
         XCTAssert(result.hasSucceeded)
     }

--- a/QuickTests/Helpers/QCKSpecRunner.m
+++ b/QuickTests/Helpers/QCKSpecRunner.m
@@ -1,5 +1,5 @@
 #import "QCKSpecRunner.h"
-#import "XCTestObservationCenter.h"
+#import "XCTestObservationCenter+QCKSuspendObservation.h"
 
 #import <Quick/Quick.h>
 
@@ -7,7 +7,7 @@ XCTestRun *qck_runSuite(XCTestSuite *suite) {
     [World sharedWorld].isRunningAdditionalSuites = YES;
 
     __block XCTestRun *result = nil;
-    [[XCTestObservationCenter sharedObservationCenter] _suspendObservationForBlock:^{
+    [[XCTestObservationCenter sharedTestObservationCenter] _suspendObservationForBlock:^{
         result = [suite run];
     }];
     return result;

--- a/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.h
+++ b/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.h
@@ -8,12 +8,7 @@
  with the message "Timed out waiting for IDE barrier message to complete", it is
  likely that this internal interface has been changed.
  */
-@interface XCTestObservationCenter : NSObject
-
-/**
- Returns the global instance of XCTestObservationCenter.
- */
-+ (instancetype)sharedObservationCenter;
+@interface XCTestObservationCenter (QCKSuspendObservation)
 
 /**
  Suspends test suite observation for the duration that the block is executing.

--- a/QuickTests/Info.plist
+++ b/QuickTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.quick.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
1. Update .gitmodules to pull in Nimble Swift 2.0 support
   (https://github.com/Quick/Nimble/pull/131).
2. Run Edit > Convert > To Latest Swift Syntax.
3. XCTestObservationCenter is now a public XCTest API, although it
   doesn't expose "suspend observation". Expose that method via a category.

---

We should get a consensus on #311 before merging this, but would love to get some early feedback from @Quick/contributors! :+1: 