### PR TITLE
Support XCTestAssert macros in Quick specs written in Objective-C

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		DA6B30191A4DB0D500FFB148 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6B30171A4DB0D500FFB148 /* Filter.swift */; };
 		DA7AE6F119FC493F000AFDCE /* ItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7AE6F019FC493F000AFDCE /* ItTests.swift */; };
 		DA7AE6F219FC493F000AFDCE /* ItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7AE6F019FC493F000AFDCE /* ItTests.swift */; };
+		DA8940F01B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */; };
+		DA8940F11B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */; };
 		DA8C00211A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8C00201A01E4B900CE58A6 /* QuickConfigurationTests.m */; };
 		DA8C00221A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8C00201A01E4B900CE58A6 /* QuickConfigurationTests.m */; };
 		DA8F919919F31680006F6675 /* QCKSpecRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8F919619F31680006F6675 /* QCKSpecRunner.m */; };
@@ -335,6 +337,7 @@
 		DA6B30171A4DB0D500FFB148 /* Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		DA7AE6F019FC493F000AFDCE /* ItTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItTests.swift; sourceTree = "<group>"; };
 		DA87078219F48775008C04AC /* BeforeEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeforeEachTests.swift; sourceTree = "<group>"; };
+		DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FailureUsingXCTAssertTests+ObjC.m"; sourceTree = "<group>"; };
 		DA8C00201A01E4B900CE58A6 /* QuickConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QuickConfigurationTests.m; sourceTree = "<group>"; };
 		DA8F919519F31680006F6675 /* QCKSpecRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QCKSpecRunner.h; sourceTree = "<group>"; };
 		DA8F919619F31680006F6675 /* QCKSpecRunner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QCKSpecRunner.m; sourceTree = "<group>"; };
@@ -471,6 +474,7 @@
 				DA7AE6F019FC493F000AFDCE /* ItTests.swift */,
 				479C31E11A36156E00DA8718 /* ItTests+ObjC.m */,
 				DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */,
+				DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */,
 				DA87078219F48775008C04AC /* BeforeEachTests.swift */,
 				47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */,
 				DA05D60F19F73A3800771050 /* AfterEachTests.swift */,
@@ -920,6 +924,7 @@
 				DAE714F819FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAA7C0D719F777EB0093D1D9 /* BeforeEachTests.swift in Sources */,
 				DA8F919A19F31680006F6675 /* QCKSpecRunner.m in Sources */,
+				DA8940F11B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253C1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				DAE714F119FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
 				DA05D61119F73A3800771050 /* AfterEachTests.swift in Sources */,
@@ -994,6 +999,7 @@
 				DAE714F719FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAB067E919F7801C00F970AC /* BeforeEachTests.swift in Sources */,
 				DA8F919919F31680006F6675 /* QCKSpecRunner.m in Sources */,
+				DA8940F01B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253B1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				DAE714F019FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
 				DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */,

--- a/QuickTests/FunctionalTests/FailureTests+ObjC.m
+++ b/QuickTests/FunctionalTests/FailureTests+ObjC.m
@@ -27,38 +27,34 @@ describe(@"a group of failing examples", ^{
 
 QuickSpecEnd
 
-#pragma mark - Test Helpers
-
-/**
- Run the functional tests within a context that causes two test failures
- and return the result.
- */
-static XCTestRun *qck_runFailureSpec(void) {
-    isRunningFunctionalTests = YES;
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
-    isRunningFunctionalTests = NO;
-
-    return result;
-}
-
 #pragma mark - Tests
 
 @interface FailureTests : XCTestCase; @end
 
 @implementation FailureTests
 
+- (void)setUp {
+    [super setUp];
+    isRunningFunctionalTests = YES;
+}
+
+- (void)tearDown {
+    isRunningFunctionalTests = NO;
+    [super tearDown];
+}
+
 - (void)testFailureSpecHasSucceededIsFalse {
-    XCTestRun *result = qck_runFailureSpec();
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
     XCTAssertFalse(result.hasSucceeded);
 }
 
 - (void)testFailureSpecExecutedAllExamples {
-    XCTestRun *result = qck_runFailureSpec();
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
     XCTAssertEqual(result.executionCount, 3);
 }
 
 - (void)testFailureSpecFailureCountIsEqualToTheNumberOfFailingExamples {
-    XCTestRun *result = qck_runFailureSpec();
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
     XCTAssertEqual(result.failureCount, 2);
 }
 

--- a/QuickTests/FunctionalTests/FailureUsingXCTAssertTests+ObjC.m
+++ b/QuickTests/FunctionalTests/FailureUsingXCTAssertTests+ObjC.m
@@ -1,0 +1,55 @@
+#import <XCTest/XCTest.h>
+#import <Quick/Quick.h>
+
+#import "QCKSpecRunner.h"
+
+static BOOL isRunningFunctionalTests = NO;
+
+QuickSpecBegin(FunctionalTests_FailureUsingXCTAssertSpec)
+
+it(@"fails using an XCTAssert (but only when running the functional tests)", ^{
+    XCTAssertFalse(isRunningFunctionalTests);
+});
+
+it(@"fails again using an XCTAssert (but only when running the functional tests)", ^{
+    XCTAssertFalse(isRunningFunctionalTests);
+});
+
+it(@"succeeds using an XCTAssert", ^{
+    XCTAssertTrue(YES);
+});
+
+QuickSpecEnd
+
+#pragma mark - Tests
+
+@interface FailureUsingXCTAssertTests_ObjC : XCTestCase; @end
+
+@implementation FailureUsingXCTAssertTests_ObjC
+
+- (void)setUp {
+    [super setUp];
+    isRunningFunctionalTests = YES;
+}
+
+- (void)tearDown {
+    isRunningFunctionalTests = NO;
+    [super tearDown];
+}
+
+- (void)testFailureUsingXCTAssertSpecHasSucceededIsFalse {
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTAssertFalse(result.hasSucceeded);
+}
+
+- (void)testFailureUsingXCTAssertSpecExecutedAllExamples {
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTAssertEqual(result.executionCount, 3);
+}
+
+- (void)testFailureUsingXCTAssertSpecFailureCountIsEqualToTheNumberOfFailingExamples {
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTAssertEqual(result.failureCount, 2);
+}
+
+@end


### PR DESCRIPTION
Fixes #121. See individual commit messages for details.

---

I wanted to make sure `XCTAssert` macros also worked within shared examples, but that brought up a separate issue: since shared examples are now typically defined within `+[QuickConfiguration configure:]`, a class method, `XCTAssert` macros raise a warning:

> Incompatible pointer types passing 'Class' to parameter of type 'XCTestCase'

We may have to change the configuration API in order to support `XCTAssert` macros in shared examples... I'll file a separate issue for this, unless any reviewers think it's not an issue that should be considered separately from this PR.