### PR TITLE
Xcode7b2 migration

### DIFF
--- a/Quick/Configuration/Configuration.swift
+++ b/Quick/Configuration/Configuration.swift
@@ -43,7 +43,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
         All examples are filtered using all inclusion filters.
         The remaining examples are run. If no examples remain, all examples are run.
 
-        :param: filter A filter that, given an example, returns a value indicating
+        - parameter filter: A filter that, given an example, returns a value indicating
                        whether that example should be included in the examples
                        that are run.
     */
@@ -57,7 +57,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
         All examples that remain after being filtered by the inclusion filters are
         then filtered via all exclusion filters.
 
-        :param: filter A filter that, given an example, returns a value indicating
+        - parameter filter: A filter that, given an example, returns a value indicating
                        whether that example should be excluded from the examples
                        that are run.
     */
@@ -89,7 +89,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
         either. Mulitple beforeEach defined on a single configuration, however,
         will be executed in the order they're defined.
 
-        :param: closure The closure to be executed before each example
+        - parameter closure: The closure to be executed before each example
                         in the test suite.
     */
     public func beforeEach(closure: BeforeExampleClosure) {
@@ -120,7 +120,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
         either. Mulitple afterEach defined on a single configuration, however,
         will be executed in the order they're defined.
 
-        :param: closure The closure to be executed before each example
+        - parameter closure: The closure to be executed before each example
                         in the test suite.
     */
     public func afterEach(closure: AfterExampleClosure) {

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -6,7 +6,7 @@
     If the test suite crashes before the first example is run, this closure
     will not be executed.
 
-    :param: closure The closure to be run prior to any examples in the test suite.
+    - parameter closure: The closure to be run prior to any examples in the test suite.
 */
 public func beforeSuite(closure: BeforeSuiteClosure) {
     World.sharedWorld().beforeSuite(closure)
@@ -20,7 +20,7 @@ public func beforeSuite(closure: BeforeSuiteClosure) {
     If the test suite crashes before all examples are run, this closure
     will not be executed.
 
-    :param: closure The closure to be run after all of the examples in the test suite.
+    - parameter closure: The closure to be run after all of the examples in the test suite.
 */
 public func afterSuite(closure: AfterSuiteClosure) {
     World.sharedWorld().afterSuite(closure)
@@ -30,9 +30,9 @@ public func afterSuite(closure: AfterSuiteClosure) {
     Defines a group of shared examples. These examples can be re-used in several locations
     by using the `itBehavesLike` function.
 
-    :param: name The name of the shared example group. This must be unique across all shared example
+    - parameter name: The name of the shared example group. This must be unique across all shared example
                  groups defined in a test suite.
-    :param: closure A closure containing the examples. This behaves just like an example group defined
+    - parameter closure: A closure containing the examples. This behaves just like an example group defined
                     using `describe` or `context`--the closure may contain any number of `beforeEach`
                     and `afterEach` closures, as well as any number of examples (defined using `it`).
 */
@@ -44,9 +44,9 @@ public func sharedExamples(name: String, closure: () -> ()) {
     Defines a group of shared examples. These examples can be re-used in several locations
     by using the `itBehavesLike` function.
 
-    :param: name The name of the shared example group. This must be unique across all shared example
+    - parameter name: The name of the shared example group. This must be unique across all shared example
                  groups defined in a test suite.
-    :param: closure A closure containing the examples. This behaves just like an example group defined
+    - parameter closure: A closure containing the examples. This behaves just like an example group defined
                     using `describe` or `context`--the closure may contain any number of `beforeEach`
                     and `afterEach` closures, as well as any number of examples (defined using `it`).
 
@@ -61,9 +61,9 @@ public func sharedExamples(name: String, closure: SharedExampleClosure) {
     Defines an example group. Example groups are logical groupings of examples.
     Example groups can share setup and teardown code.
 
-    :param: description An arbitrary string describing the example group.
-    :param: closure A closure that can contain other examples.
-    :param: flags A mapping of string keys to booleans that can be used to filter examples or example groups.
+    - parameter description: An arbitrary string describing the example group.
+    - parameter closure: A closure that can contain other examples.
+    - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
 */
 public func describe(description: String, flags: FilterFlags = [:], closure: () -> ()) {
     World.sharedWorld().describe(description, flags: flags, closure: closure)
@@ -92,7 +92,7 @@ public func beforeEach(closure: BeforeExampleClosure) {
     Identical to Quick.DSL.beforeEach, except the closure is provided with
     metadata on the example that the closure is being run prior to.
 */
-public func beforeEach(closure closure: BeforeExampleWithMetadataClosure) {
+public func beforeEach(closure: BeforeExampleWithMetadataClosure) {
     World.sharedWorld().beforeEach(closure: closure)
 }
 
@@ -102,7 +102,7 @@ public func beforeEach(closure closure: BeforeExampleWithMetadataClosure) {
     An example group may contain an unlimited number of afterEach. They'll be
     run in the order they're defined, but you shouldn't rely on that behavior.
 
-    :param: closure The closure to be run after each example.
+    - parameter closure: The closure to be run after each example.
 */
 public func afterEach(closure: AfterExampleClosure) {
     World.sharedWorld().afterEach(closure)
@@ -112,7 +112,7 @@ public func afterEach(closure: AfterExampleClosure) {
     Identical to Quick.DSL.afterEach, except the closure is provided with
     metadata on the example that the closure is being run after.
 */
-public func afterEach(closure closure: AfterExampleWithMetadataClosure) {
+public func afterEach(closure: AfterExampleWithMetadataClosure) {
     World.sharedWorld().afterEach(closure: closure)
 }
 
@@ -120,12 +120,12 @@ public func afterEach(closure closure: AfterExampleWithMetadataClosure) {
     Defines an example. Examples use assertions to demonstrate how code should
     behave. These are like "tests" in XCTest.
 
-    :param: description An arbitrary string describing what the example is meant to specify.
-    :param: closure A closure that can contain assertions.
-    :param: flags A mapping of string keys to booleans that can be used to filter examples or example groups.
+    - parameter description: An arbitrary string describing what the example is meant to specify.
+    - parameter closure: A closure that can contain assertions.
+    - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
                   Empty by default.
-    :param: file The absolute path to the file containing the example. A sensible default is provided.
-    :param: line The line containing the example. A sensible default is provided.
+    - parameter file: The absolute path to the file containing the example. A sensible default is provided.
+    - parameter line: The line containing the example. A sensible default is provided.
 */
 public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
     World.sharedWorld().it(description, flags: flags, file: file, line: line, closure: closure)
@@ -135,13 +135,13 @@ public func it(description: String, flags: FilterFlags = [:], file: String = __F
     Inserts the examples defined using a `sharedExamples` function into the current example group.
     The shared examples are executed at this location, as if they were written out manually.
 
-    :param: name The name of the shared examples group to be executed. This must be identical to the
+    - parameter name: The name of the shared examples group to be executed. This must be identical to the
                  name of a shared examples group defined using `sharedExamples`. If there are no shared
                  examples that match the name given, an exception is thrown and the test suite will crash.
-    :param: flags A mapping of string keys to booleans that can be used to filter examples or example groups.
+    - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
                   Empty by default.
-    :param: file The absolute path to the file containing the current example group. A sensible default is provided.
-    :param: line The line containing the current example group. A sensible default is provided.
+    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+    - parameter line: The line containing the current example group. A sensible default is provided.
 */
 public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
     itBehavesLike(name, flags: flags, file: file, line: line, sharedExampleContext: { return [:] })
@@ -153,15 +153,15 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     This function also passes those shared examples a context that can be evaluated to give the shared
     examples extra information on the subject of the example.
 
-    :param: name The name of the shared examples group to be executed. This must be identical to the
+    - parameter name: The name of the shared examples group to be executed. This must be identical to the
                  name of a shared examples group defined using `sharedExamples`. If there are no shared
                  examples that match the name given, an exception is thrown and the test suite will crash.
-    :param: sharedExampleContext A closure that, when evaluated, returns key-value pairs that provide the
+    - parameter sharedExampleContext: A closure that, when evaluated, returns key-value pairs that provide the
                                  shared examples with extra information on the subject of the example.
-    :param: flags A mapping of string keys to booleans that can be used to filter examples or example groups.
+    - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
                   Empty by default.
-    :param: file The absolute path to the file containing the current example group. A sensible default is provided.
-    :param: line The line containing the current example group. A sensible default is provided.
+    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+    - parameter line: The line containing the current example group. A sensible default is provided.
 */
 public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, sharedExampleContext: SharedExampleContext) {
     World.sharedWorld().itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
@@ -171,8 +171,8 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     Defines an example or example group that should not be executed. Use `pending` to temporarily disable
     examples or groups that should not be run yet.
 
-    :param: description An arbitrary string describing the example or example group.
-    :param: closure A closure that will not be evaluated.
+    - parameter description: An arbitrary string describing the example or example group.
+    - parameter closure: A closure that will not be evaluated.
 */
 public func pending(description: String, closure: () -> ()) {
     World.sharedWorld().pending(description, closure: closure)

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -97,6 +97,6 @@ extension World {
     }
 
     internal func pending(description: String, closure: () -> ()) {
-        print("Pending: \(description)", appendNewline: false)
+        print("Pending: \(description)")
     }
 }

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -97,6 +97,6 @@ extension World {
     }
 
     internal func pending(description: String, closure: () -> ()) {
-        print("Pending: \(description)")
+        print("Pending: \(description)", appendNewline: false)
     }
 }

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -71,7 +71,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         so that it may be configured. This method must not be called outside of
         an overridden +[QuickConfiguration configure:] method.
 
-        :param: closure  A closure that takes a Configuration object that can
+        - parameter closure:  A closure that takes a Configuration object that can
                          be mutated to change Quick's behavior.
     */
     internal func configure(closure: QuickConfigurer) {
@@ -103,8 +103,8 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
                 it("is at the top level") {}
             }
 
-        :param: cls The QuickSpec class for which to retrieve the root example group.
-        :returns: The root example group for the class.
+        - parameter cls: The QuickSpec class for which to retrieve the root example group.
+        - returns: The root example group for the class.
     */
     internal func rootExampleGroupForSpecClass(cls: AnyClass) -> ExampleGroup {
         let name = NSStringFromClass(cls)
@@ -127,8 +127,8 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
         That is, these examples are the ones that are included by inclusion filters, and are
         not excluded by exclusion filters.
 
-        :param: specClass The QuickSpec subclass for which examples are to be returned.
-        :returns: A list of examples to be run as test invocations.
+        - parameter specClass: The QuickSpec subclass for which examples are to be returned.
+        - returns: A list of examples to be run as test invocations.
     */
     @objc(examplesForSpecClass:)
     internal func examples(specClass: AnyClass) -> [Example] {


### PR DESCRIPTION
Ran through Xcode 7 beta 2's Swift Syntax Migrator.

Fixes support for carthage too. Fixes #325.