### PR TITLE
Fix access value in document

### DIFF
--- a/Documentation/ArrangeActAssert.md
+++ b/Documentation/ArrangeActAssert.md
@@ -98,7 +98,7 @@ Let's say we want to offer people bananas, using a function called `offer()`:
 
 /** Given a banana, returns a string that can be used to offer someone the banana. */
 public func offer(banana: Banana) -> String {
-  if banana.isPeeled {
+  if banana.isEdible {
     return "Hey, want a banana?"
   } else {
     return "Hey, want me to peel this banana for you?"


### PR DESCRIPTION
in [Effective Tests Using XCTest: Arrange, Act, and Assert](https://github.com/Quick/Quick/blob/swift-2.0/Documentation/ArrangeActAssert.md)

you should use ```public var isEdible``` instead of ```private var isPeeled``` in Banana/Offer.swift.