### PR TITLE
Update cocoapods instructions

### DIFF
--- a/Documentation/InstallingQuick.md
+++ b/Documentation/InstallingQuick.md
@@ -95,13 +95,30 @@ First, update CocoaPods to Version 0.36.0 or newer, which is necessary to instal
 Then, add Quick and Nimble to your Podfile. Additionally, the ```use_frameworks!``` line is necessary for using Swift in CocoaPods:
 
 ```rb
+
 # Podfile
 
-link_with 'MyTests', 'MyUITests'
-
 use_frameworks!
-pod 'Quick'
-pod 'Nimble'
+
+def testing_pods
+    
+    # If you're using Xcode 7 / Swift 2
+    pod 'Quick', '0.5.0'
+    pod 'Nimble', '2.0.0-rc.1'
+    
+    # If you're using Xcode 6 / Swift 1.2
+    pod 'Quick', '0.3.0'
+    pod 'Nimble', '1.0.0-rc.1'
+end
+
+target 'MyTests' do
+    testing_pods
+end
+
+target 'MyUITests' do
+    testing_pods
+end
+
 ```
 
 Finally, download and link Quick and Nimble to your tests:

--- a/README.md
+++ b/README.md
@@ -40,17 +40,27 @@ All documentation can be found in the [Documentation folder](./Documentation), i
 ```
 # Podfile
 
-link_with 'MyTests', 'MyUITests'
-
 use_frameworks!
 
-# If you're using Xcode 7 / Swift 2
-pod 'Quick', '0.5.0'
-pod 'Nimble', '2.0.0-rc.1'
+def testing_pods
 
-# If you're using Xcode 6 / Swift 1.2
-pod 'Quick', '0.3.0'
-pod 'Nimble', '1.0.0-rc.1'
+    # If you're using Xcode 7 / Swift 2
+    pod 'Quick', '0.5.0'
+    pod 'Nimble', '2.0.0-rc.1'
+    
+    # If you're using Xcode 6 / Swift 1.2
+    pod 'Quick', '0.3.0'
+    pod 'Nimble', '1.0.0-rc.1'
+end
+
+target 'MyTests' do
+    testing_pods
+end
+
+target 'MyUITests' do
+    testing_pods
+end
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Quick comes together with [Nimble](https://github.com/Quick/Nimble) — a matche
 
 All documentation can be found in the [Documentation folder](./Documentation), including [detailed installation instructions](./Documentation/InstallingQuick.md) for CocoaPods, Carthage, Git submodules, and more. For example, you can install Quick and [Nimble](https://github.com/Quick/Nimble) using CocoaPods by adding the following to your Podfile:
 
-```
+```rb
 # Podfile
 
 use_frameworks!
 
 def testing_pods
-
+    
     # If you're using Xcode 7 / Swift 2
     pod 'Quick', '0.5.0'
     pod 'Nimble', '2.0.0-rc.1'


### PR DESCRIPTION
CocoaPods link_with does not do what I thought it does! Updated the README and Installation Instructions with the correct way (thanks [@neonichu](https://gist.github.com/neonichu/16ce4cca9f0b8230f8ba)) of linking the testing pods against both the Unit Test and the new UITests targets in a DRY way. 