### PR TITLE
Swift and Xcode 7 beta 4 compatibility fix

### DIFF
--- a/Quick/Callsite.swift
+++ b/Quick/Callsite.swift
@@ -2,7 +2,7 @@
     An object encapsulating the file and line number at which
     a particular example is defined.
 */
-@objc final public class Callsite: Equatable {
+final public class Callsite: NSObject {
     /**
         The absolute path of the file in which an example is defined.
     */

--- a/Quick/Configuration/Configuration.swift
+++ b/Quick/Configuration/Configuration.swift
@@ -14,7 +14,7 @@ public typealias ExampleFilter = (example: Example) -> Bool
     A configuration encapsulates various options you can use
     to configure Quick's behavior.
 */
-@objc final public class Configuration {
+final public class Configuration: NSObject {
     internal let exampleHooks = ExampleHooks()
     internal let suiteHooks = SuiteHooks()
     internal var exclusionFilters: [ExampleFilter] = [{ example in

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -4,7 +4,7 @@ private var numberOfExamplesRun = 0
     Examples, defined with the `it` function, use assertions to
     demonstrate how code should behave. These are like "tests" in XCTest.
 */
-@objc final public class Example: Equatable {
+final public class Example: NSObject {
     /**
         A boolean indicating whether the example is a shared example;
         i.e.: whether it is an example defined with `itBehavesLike`.
@@ -20,15 +20,19 @@ private var numberOfExamplesRun = 0
 
     weak internal var group: ExampleGroup?
 
-    private let description: String
+    private let internalDescription: String
     private let closure: () -> ()
     private let flags: FilterFlags
 
     internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: () -> ()) {
-        self.description = description
+        self.internalDescription = description
         self.closure = closure
         self.callsite = callsite
         self.flags = flags
+    }
+    
+    public override var description: String {
+        return internalDescription
     }
 
     /**

--- a/Quick/ExampleGroup.swift
+++ b/Quick/ExampleGroup.swift
@@ -3,20 +3,24 @@
     the `describe` and `context` functions. Example groups can share
     setup and teardown code.
 */
-@objc final public class ExampleGroup {
+final public class ExampleGroup: NSObject {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
 
-    private let description: String
+    private let internalDescription: String
     private let flags: FilterFlags
     private let isInternalRootExampleGroup: Bool
     private var childGroups = [ExampleGroup]()
     private var childExamples = [Example]()
 
     internal init(description: String, flags: FilterFlags, isInternalRootExampleGroup: Bool = false) {
-        self.description = description
+        self.internalDescription = description
         self.flags = flags
         self.isInternalRootExampleGroup = isInternalRootExampleGroup
+    }
+    
+    public override var description: String {
+        return internalDescription
     }
 
     /**

--- a/Quick/ExampleMetadata.swift
+++ b/Quick/ExampleMetadata.swift
@@ -3,7 +3,7 @@
     including the index at which the example was executed, as
     well as the example itself.
 */
-@objc final public class ExampleMetadata {
+final public class ExampleMetadata: NSObject {
     /**
         The example for which this metadata was collected.
     */

--- a/Quick/Filter.swift
+++ b/Quick/Filter.swift
@@ -11,7 +11,7 @@ public typealias FilterFlags = [String: Bool]
     A namespace for filter flag keys, defined primarily to make the
     keys available in Objective-C.
 */
-@objc(QCKFilter) final public class Filter {
+final public class Filter: NSObject {
     /**
         Example and example groups with [Focused: true] are included in test runs,
         excluding all other examples without this flag. Use this to only run one or

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -23,7 +23,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
     You may configure how Quick behaves by calling the -[World configure:]
     method from within an overridden +[QuickConfiguration configure:] method.
 */
-@objc final internal class World {
+final internal class World: NSObject {
     /**
         The example group that is currently being run.
         The DSL requires that this group is correctly set in order to build a
@@ -56,7 +56,7 @@ public typealias SharedExampleClosure = (SharedExampleContext) -> ()
 
     // MARK: Singleton Constructor
 
-    private init() {}
+    private override init() {}
     private struct Shared {
         static let instance = World()
     }


### PR DESCRIPTION
the new Beta doesn't like having a class marked @objc that isn't a subclass of NSObject