### PR TITLE
Switch LineNumber argument to an unsigned int

### DIFF
--- a/Quick/Callsite.swift
+++ b/Quick/Callsite.swift
@@ -11,9 +11,9 @@ final public class Callsite: NSObject {
     /**
         The line number on which an example is defined.
     */
-    public let line: Int
+    public let line: UInt
 
-    internal init(file: String, line: Int) {
+    internal init(file: String, line: UInt) {
         self.file = file
         self.line = line
     }

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -127,7 +127,7 @@ public func afterEach(closure: AfterExampleWithMetadataClosure) {
     - parameter file: The absolute path to the file containing the example. A sensible default is provided.
     - parameter line: The line containing the example. A sensible default is provided.
 */
-public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
+public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
     World.sharedWorld().it(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -143,7 +143,7 @@ public func it(description: String, flags: FilterFlags = [:], file: String = __F
     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
     - parameter line: The line containing the current example group. A sensible default is provided.
 */
-public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__) {
+public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__) {
     itBehavesLike(name, flags: flags, file: file, line: line, sharedExampleContext: { return [:] })
 }
 
@@ -163,7 +163,7 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
     - parameter line: The line containing the current example group. A sensible default is provided.
 */
-public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, sharedExampleContext: SharedExampleContext) {
+public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, sharedExampleContext: SharedExampleContext) {
     World.sharedWorld().itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
 }
 
@@ -198,7 +198,7 @@ public func xcontext(description: String, flags: FilterFlags, closure: () -> ())
     Use this to quickly mark an `it` closure as pending.
     This disables the example and ensures the code within the closure is never run.
 */
-public func xit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
+public func xit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
     World.sharedWorld().xit(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -222,6 +222,6 @@ public func fcontext(description: String, flags: FilterFlags = [:], closure: () 
     Use this to quickly focus an `it` closure, focusing the example.
     If any examples in the test suite are focused, only those examples are executed.
 */
-public func fit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: Int = __LINE__, closure: () -> ()) {
+public func fit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
     World.sharedWorld().fit(description, flags: flags, file: file, line: line, closure: closure)
 }

--- a/Quick/DSL/World+DSL.h
+++ b/Quick/DSL/World+DSL.h
@@ -12,9 +12,9 @@
 - (void)beforeEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
 - (void)afterEach:(void (^ __nonnull)(void))closure;
 - (void)afterEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
-- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
-- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
-- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line closure:(void (^ __nonnull)(void))closure;
-- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSInteger)line;
+- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line;
 - (void)pending:(NSString * __nonnull)description closure:(void (^ __nonnull)(void))closure;
 @end

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -59,28 +59,28 @@ extension World {
     }
 
     @objc(itWithDescription:flags:file:line:closure:)
-    internal func it(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
         let callsite = Callsite(file: file, line: line)
         let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
         currentExampleGroup!.appendExample(example)
     }
 
     @objc(fitWithDescription:flags:file:line:closure:)
-    internal func fit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func fit(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
         self.it(description, flags: focusedFlags, file: file, line: line, closure: closure)
     }
 
     @objc(xitWithDescription:flags:file:line:closure:)
-    internal func xit(description: String, flags: FilterFlags, file: String, line: Int, closure: () -> ()) {
+    internal func xit(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
         self.it(description, flags: pendingFlags, file: file, line: line, closure: closure)
     }
 
     @objc(itBehavesLikeSharedExampleNamed:sharedExampleContext:flags:file:line:)
-    internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: Int) {
+    internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: UInt) {
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld().sharedExample(name)
 


### PR DESCRIPTION
Lines are always greater than zero so they can be unsigned - just to match `XCTests`, because they are also using unsigned ints,