### PR TITLE
Changes XCode version on Circle CI to be 7.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,6 @@
 machine:
   xcode:
-    version: "6.3.1"
-
-general:
-  branches:
-    ignore:
-      - swift-2.0 # Circle CI doesn't support Xcode 7/Swift 2.0 yet.
+    version: "7.0"
 
 checkout:
   post:


### PR DESCRIPTION
Circle CI recently announced support for XCode 7.0
https://twitter.com/circleci/status/644589240907489280

It may not be 100% stable yet, but as the swift-2.0 branch is being ignored anyway, I think it's better than what we have now.