### PR TITLE
Xcode7/xctool compatibility

### DIFF
--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -45,6 +45,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
                            @"Here's the original exception: '%@', reason: '%@', userInfo: '%@'",
                            exception.name, exception.reason, exception.userInfo];
     }
+    [self testInvocations];
 }
 
 /**


### PR DESCRIPTION
I'm using Quick 0.6.0 to run tests for an Objective-C target and everything works fine within Xcode and `xcodebuild` but not with `xctool`. xctool now supports Xcode 7 but the tests don't run with Quick due to a similar issue issue in Specta that was discussed in https://github.com/facebook/xctool/issues/572 and fixed in https://github.com/specta/specta/pull/184. 

I have to confess I don't fully understand how Quick works but I can confirm that with this fix and by building the Quick framework and adding it to my App's test target, the tests run correctly under xctool. 

Without this change, run-tests fails with a message like this:

>*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '*** Assertion failure in void ParseClassAndMethodFromTestName(NSString **, NSString **, NSString *), /tmp/xctool20150921-10719-9r0vvv/Common/ParseTestName.m:38: Test name seems to be malformed: -[DCDateValueTransformerSpec (null)]'