### PR TITLE
QuickTests: Suffix Objective-C tests with "_ObjC"

### DIFF
--- a/QuickFocusedTests/FocusedTests+ObjC.m
+++ b/QuickFocusedTests/FocusedTests+ObjC.m
@@ -4,7 +4,7 @@
 
 #import "QCKSpecRunner.h"
 
-QuickConfigurationBegin(FunctionalTests_SharedExamplesConfiguration)
+QuickConfigurationBegin(FunctionalTests_SharedExamplesConfiguration_ObjC)
 
 + (void)configure:(Configuration *)configuration {
     sharedExamples(@"two passing shared examples (Objective-C)", ^(QCKDSLSharedExampleContext exampleContext) {
@@ -15,7 +15,7 @@ QuickConfigurationBegin(FunctionalTests_SharedExamplesConfiguration)
 
 QuickConfigurationEnd
 
-QuickSpecBegin(FunctionalTests_FocusedSpec_Focused)
+QuickSpecBegin(FunctionalTests_FocusedSpec_Focused_ObjC)
 
 it(@"has an unfocused example that fails, but is never run", ^{ XCTFail(); });
 fit(@"has a focused example that passes (1)", ^{});
@@ -29,7 +29,7 @@ fitBehavesLike(@"two passing shared examples (Objective-C)", ^NSDictionary *{ re
 
 QuickSpecEnd
 
-QuickSpecBegin(FunctionalTests_FocusedSpec_Unfocused)
+QuickSpecBegin(FunctionalTests_FocusedSpec_Unfocused_ObjC)
 
 it(@"has an unfocused example thay fails, but is never run", ^{ XCTFail(); });
 
@@ -40,15 +40,15 @@ describe(@"an unfocused example group that is never run", ^{
 
 QuickSpecEnd
 
-@interface FocusedTests: XCTestCase
+@interface FocusedTests_ObjC: XCTestCase
 @end
 
-@implementation FocusedTests
+@implementation FocusedTests_ObjC
 
 - (void)testOnlyFocusedExamplesAreExecuted {
     XCTestRun *result = qck_runSpecs(@[
-        [FunctionalTests_FocusedSpec_Focused class],
-        [FunctionalTests_FocusedSpec_Unfocused class]
+        [FunctionalTests_FocusedSpec_Focused_ObjC class],
+        [FunctionalTests_FocusedSpec_Unfocused_ObjC class]
     ]);
     XCTAssertEqual(result.executionCount, 5);
 }

--- a/QuickTests/FunctionalTests/AfterEachTests+ObjC.m
+++ b/QuickTests/FunctionalTests/AfterEachTests+ObjC.m
@@ -15,7 +15,7 @@ typedef NS_ENUM(NSUInteger, AfterEachType) {
 
 static NSMutableArray *afterEachOrder;
 
-QuickSpecBegin(FunctionalTests_AfterEachSpec)
+QuickSpecBegin(FunctionalTests_AfterEachSpec_ObjC)
 
 afterEach(^{ [afterEachOrder addObject:@(OuterOne)]; });
 afterEach(^{ [afterEachOrder addObject:@(OuterTwo)]; });
@@ -49,9 +49,9 @@ context(@"when there are nested afterEach without examples", ^{
 
 QuickSpecEnd
 
-@interface AfterEachTests : XCTestCase; @end
+@interface AfterEachTests_ObjC : XCTestCase; @end
 
-@implementation AfterEachTests
+@implementation AfterEachTests_ObjC
 
 - (void)setUp {
     [super setUp];
@@ -64,7 +64,7 @@ QuickSpecEnd
 }
 
 - (void)testAfterEachIsExecutedInTheCorrectOrder {
-    qck_runSpec([FunctionalTests_AfterEachSpec class]);
+    qck_runSpec([FunctionalTests_AfterEachSpec_ObjC class]);
     NSArray *expectedOrder = @[
         // [1] The outer afterEach closures are executed from top to bottom.
         @(OuterOne), @(OuterTwo), @(OuterThree),

--- a/QuickTests/FunctionalTests/AfterSuiteTests+ObjC.m
+++ b/QuickTests/FunctionalTests/AfterSuiteTests+ObjC.m
@@ -6,7 +6,7 @@
 
 static BOOL afterSuiteWasExecuted = NO;
 
-QuickSpecBegin(FunctionalTests_AfterSuite_AfterSuiteSpec)
+QuickSpecBegin(FunctionalTests_AfterSuite_AfterSuiteSpec_ObjC)
 
 afterSuite(^{
     afterSuiteWasExecuted = YES;
@@ -14,7 +14,7 @@ afterSuite(^{
 
 QuickSpecEnd
 
-QuickSpecBegin(FunctionalTests_AfterSuite_Spec)
+QuickSpecBegin(FunctionalTests_AfterSuite_Spec_ObjC)
 
 it(@"is executed before afterSuite", ^{
     expect(@(afterSuiteWasExecuted)).to(beFalsy());
@@ -22,15 +22,15 @@ it(@"is executed before afterSuite", ^{
 
 QuickSpecEnd
 
-@interface AfterSuiteTests : XCTestCase; @end
+@interface AfterSuiteTests_ObjC : XCTestCase; @end
 
-@implementation AfterSuiteTests
+@implementation AfterSuiteTests_ObjC
 
 - (void)testAfterSuiteIsNotExecutedBeforeAnyExamples {
     // Execute the spec with an assertion after the one with an afterSuite.
     NSArray *specs = @[
-        [FunctionalTests_AfterSuite_AfterSuiteSpec class],
-        [FunctionalTests_AfterSuite_Spec class]
+        [FunctionalTests_AfterSuite_AfterSuiteSpec_ObjC class],
+        [FunctionalTests_AfterSuite_Spec_ObjC class]
     ];
     XCTestRun *result = qck_runSpecs(specs);
 

--- a/QuickTests/FunctionalTests/BeforeEachTests+ObjC.m
+++ b/QuickTests/FunctionalTests/BeforeEachTests+ObjC.m
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSUInteger, BeforeEachType) {
 
 static NSMutableArray *beforeEachOrder;
 
-QuickSpecBegin(FunctionalTests_BeforeEachSpec)
+QuickSpecBegin(FunctionalTests_BeforeEachSpec_ObjC)
 
 beforeEach(^{ [beforeEachOrder addObject:@(OuterOne)]; });
 beforeEach(^{ [beforeEachOrder addObject:@(OuterTwo)]; });
@@ -36,9 +36,9 @@ context(@"when there are nested beforeEach without examples", ^{
 
 QuickSpecEnd
 
-@interface BeforeEachTests : XCTestCase; @end
+@interface BeforeEachTests_ObjC : XCTestCase; @end
 
-@implementation BeforeEachTests
+@implementation BeforeEachTests_ObjC
 
 - (void)setUp {
     beforeEachOrder = [NSMutableArray array];
@@ -51,7 +51,7 @@ QuickSpecEnd
 }
 
 - (void)testBeforeEachIsExecutedInTheCorrectOrder {
-    qck_runSpec([FunctionalTests_BeforeEachSpec class]);
+    qck_runSpec([FunctionalTests_BeforeEachSpec_ObjC class]);
     NSArray *expectedOrder = @[
         // [1] The outer beforeEach closures are executed from top to bottom.
         @(OuterOne), @(OuterTwo),

--- a/QuickTests/FunctionalTests/BeforeSuiteTests+ObjC.m
+++ b/QuickTests/FunctionalTests/BeforeSuiteTests+ObjC.m
@@ -6,7 +6,7 @@
 
 static BOOL beforeSuiteWasExecuted = NO;
 
-QuickSpecBegin(FunctionalTests_BeforeSuite_BeforeSuiteSpec)
+QuickSpecBegin(FunctionalTests_BeforeSuite_BeforeSuiteSpec_ObjC)
 
 beforeSuite(^{
     beforeSuiteWasExecuted = YES;
@@ -14,7 +14,7 @@ beforeSuite(^{
 
 QuickSpecEnd
 
-QuickSpecBegin(FunctionalTests_BeforeSuite_Spec)
+QuickSpecBegin(FunctionalTests_BeforeSuite_Spec_ObjC)
 
 it(@"is executed after beforeSuite", ^{
     expect(@(beforeSuiteWasExecuted)).to(beTruthy());
@@ -22,15 +22,15 @@ it(@"is executed after beforeSuite", ^{
 
 QuickSpecEnd
 
-@interface BeforeSuiteTests : XCTestCase; @end
+@interface BeforeSuiteTests_ObjC : XCTestCase; @end
 
-@implementation BeforeSuiteTests
+@implementation BeforeSuiteTests_ObjC
 
 - (void)testBeforeSuiteIsExecutedBeforeAnyExamples {
     // Execute the spec with an assertion before the one with a beforeSuite
     NSArray *specs = @[
-        [FunctionalTests_BeforeSuite_Spec class],
-        [FunctionalTests_BeforeSuite_BeforeSuiteSpec class]
+        [FunctionalTests_BeforeSuite_Spec_ObjC class],
+        [FunctionalTests_BeforeSuite_BeforeSuiteSpec_ObjC class]
     ];
     XCTestRun *result = qck_runSpecs(specs);
     XCTAssert(result.hasSucceeded);

--- a/QuickTests/FunctionalTests/FailureTests+ObjC.m
+++ b/QuickTests/FunctionalTests/FailureTests+ObjC.m
@@ -9,7 +9,7 @@ static BOOL isRunningFunctionalTests = NO;
 
 #pragma mark - Spec
 
-QuickSpecBegin(FunctionalTests_FailureSpec)
+QuickSpecBegin(FunctionalTests_FailureSpec_ObjC)
 
 describe(@"a group of failing examples", ^{
     it(@"passes", ^{
@@ -29,9 +29,9 @@ QuickSpecEnd
 
 #pragma mark - Tests
 
-@interface FailureTests : XCTestCase; @end
+@interface FailureTests_ObjC : XCTestCase; @end
 
-@implementation FailureTests
+@implementation FailureTests_ObjC
 
 - (void)setUp {
     [super setUp];
@@ -44,17 +44,17 @@ QuickSpecEnd
 }
 
 - (void)testFailureSpecHasSucceededIsFalse {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec_ObjC class]);
     XCTAssertFalse(result.hasSucceeded);
 }
 
 - (void)testFailureSpecExecutedAllExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec_ObjC class]);
     XCTAssertEqual(result.executionCount, 3);
 }
 
 - (void)testFailureSpecFailureCountIsEqualToTheNumberOfFailingExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureSpec_ObjC class]);
     XCTAssertEqual(result.failureCount, 2);
 }
 

--- a/QuickTests/FunctionalTests/FailureUsingXCTAssertTests+ObjC.m
+++ b/QuickTests/FunctionalTests/FailureUsingXCTAssertTests+ObjC.m
@@ -5,7 +5,7 @@
 
 static BOOL isRunningFunctionalTests = NO;
 
-QuickSpecBegin(FunctionalTests_FailureUsingXCTAssertSpec)
+QuickSpecBegin(FunctionalTests_FailureUsingXCTAssertSpec_ObjC)
 
 it(@"fails using an XCTAssert (but only when running the functional tests)", ^{
     XCTAssertFalse(isRunningFunctionalTests);
@@ -38,17 +38,17 @@ QuickSpecEnd
 }
 
 - (void)testFailureUsingXCTAssertSpecHasSucceededIsFalse {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec_ObjC class]);
     XCTAssertFalse(result.hasSucceeded);
 }
 
 - (void)testFailureUsingXCTAssertSpecExecutedAllExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec_ObjC class]);
     XCTAssertEqual(result.executionCount, 3);
 }
 
 - (void)testFailureUsingXCTAssertSpecFailureCountIsEqualToTheNumberOfFailingExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_FailureUsingXCTAssertSpec_ObjC class]);
     XCTAssertEqual(result.failureCount, 2);
 }
 

--- a/QuickTests/FunctionalTests/ItTests+ObjC.m
+++ b/QuickTests/FunctionalTests/ItTests+ObjC.m
@@ -4,7 +4,7 @@
 
 #import "QCKSpecRunner.h"
 
-QuickSpecBegin(FunctionalTests_ItSpec)
+QuickSpecBegin(FunctionalTests_ItSpec_ObjC)
 
 __block ExampleMetadata *exampleMetadata = nil;
 beforeEachWithMetadata(^(ExampleMetadata *metadata) {
@@ -22,12 +22,12 @@ it(@"has a description with セレクター名に使えない文字が入って�
 
 QuickSpecEnd
 
-@interface ItTests : XCTestCase; @end
+@interface ItTests_ObjC : XCTestCase; @end
 
-@implementation ItTests
+@implementation ItTests_ObjC
 
 - (void)testAllExamplesAreExecuted {
-    XCTestRun *result = qck_runSpec([FunctionalTests_ItSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_ItSpec_ObjC class]);
     XCTAssertEqual(result.executionCount, 2);
 }
 

--- a/QuickTests/FunctionalTests/PendingTests+ObjC.m
+++ b/QuickTests/FunctionalTests/PendingTests+ObjC.m
@@ -7,7 +7,7 @@
 static NSUInteger oneExampleBeforeEachExecutedCount = 0;
 static NSUInteger onlyPendingExamplesBeforeEachExecutedCount = 0;
 
-QuickSpecBegin(FunctionalTests_PendingSpec)
+QuickSpecBegin(FunctionalTests_PendingSpec_ObjC)
 
 pending(@"an example that will not run", ^{
     expect(@YES).to(beFalsy());
@@ -26,9 +26,9 @@ describe(@"a describe block containing only pending examples", ^{
 
 QuickSpecEnd
 
-@interface PendingTests : XCTestCase; @end
+@interface PendingTests_ObjC : XCTestCase; @end
 
-@implementation PendingTests
+@implementation PendingTests_ObjC
 
 - (void)setUp {
     [super setUp];
@@ -43,17 +43,17 @@ QuickSpecEnd
 }
 
 - (void)testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail {
-    XCTestRun *result = qck_runSpec([FunctionalTests_PendingSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_PendingSpec_ObjC class]);
     XCTAssert(result.hasSucceeded);
 }
 
 - (void)testBeforeEachOnlyRunForEnabledExamples {
-    qck_runSpec([FunctionalTests_PendingSpec class]);
+    qck_runSpec([FunctionalTests_PendingSpec_ObjC class]);
     XCTAssertEqual(oneExampleBeforeEachExecutedCount, 1);
 }
 
 - (void)testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples {
-    qck_runSpec([FunctionalTests_PendingSpec class]);
+    qck_runSpec([FunctionalTests_PendingSpec_ObjC class]);
     XCTAssertEqual(onlyPendingExamplesBeforeEachExecutedCount, 0);
 }
 

--- a/QuickTests/FunctionalTests/SharedExamples+BeforeEachTests+ObjC.m
+++ b/QuickTests/FunctionalTests/SharedExamples+BeforeEachTests+ObjC.m
@@ -7,7 +7,7 @@
 static NSUInteger specBeforeEachExecutedCount = 0;
 static NSUInteger sharedExamplesBeforeEachExecutedCount = 0;
 
-QuickConfigurationBegin(FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples)
+QuickConfigurationBegin(FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples_ObjC)
 
 + (void)configure:(Configuration *)configuration {
     sharedExamples(@"a group of three shared examples with a beforeEach in Obj-C",
@@ -21,7 +21,7 @@ QuickConfigurationBegin(FunctionalTests_SharedExamples_BeforeEachTests_SharedExa
 
 QuickConfigurationEnd
 
-QuickSpecBegin(FunctionalTests_SharedExamples_BeforeEachSpec)
+QuickSpecBegin(FunctionalTests_SharedExamples_BeforeEachSpec_ObjC)
 
 beforeEach(^{ specBeforeEachExecutedCount += 1; });
 it(@"executes the spec beforeEach once", ^{});
@@ -30,9 +30,9 @@ itBehavesLike(@"a group of three shared examples with a beforeEach in Obj-C",
 
 QuickSpecEnd
 
-@interface SharedExamples_BeforeEachTests : XCTestCase; @end
+@interface SharedExamples_BeforeEachTests_ObjC : XCTestCase; @end
 
-@implementation SharedExamples_BeforeEachTests
+@implementation SharedExamples_BeforeEachTests_ObjC
 
 - (void)setUp {
     [super setUp];
@@ -47,12 +47,12 @@ QuickSpecEnd
 }
 
 - (void)testBeforeEachOutsideOfSharedExamplesExecutedOnceBeforeEachExample {
-    qck_runSpec([FunctionalTests_SharedExamples_BeforeEachSpec class]);
+    qck_runSpec([FunctionalTests_SharedExamples_BeforeEachSpec_ObjC class]);
     XCTAssertEqual(specBeforeEachExecutedCount, 4);
 }
 
 - (void)testBeforeEachInSharedExamplesExecutedOnceBeforeEachSharedExample {
-    qck_runSpec([FunctionalTests_SharedExamples_BeforeEachSpec class]);
+    qck_runSpec([FunctionalTests_SharedExamples_BeforeEachSpec_ObjC class]);
     XCTAssertEqual(sharedExamplesBeforeEachExecutedCount, 3);
 }
 

--- a/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
+++ b/QuickTests/FunctionalTests/SharedExamplesTests+ObjC.m
@@ -4,13 +4,13 @@
 
 #import "QCKSpecRunner.h"
 
-QuickSpecBegin(FunctionalTests_SharedExamples_Spec)
+QuickSpecBegin(FunctionalTests_SharedExamples_Spec_ObjC)
 
 itBehavesLike(@"a group of three shared examples", ^NSDictionary*{ return @{}; });
 
 QuickSpecEnd
 
-QuickSpecBegin(FunctionalTests_SharedExamples_ContextSpec)
+QuickSpecBegin(FunctionalTests_SharedExamples_ContextSpec_ObjC)
 
 itBehavesLike(@"shared examples that take a context", ^NSDictionary *{
     return @{ @"callsite": @"SharedExamplesSpec" };
@@ -18,7 +18,7 @@ itBehavesLike(@"shared examples that take a context", ^NSDictionary *{
 
 QuickSpecEnd
 
-QuickSpecBegin(FunctionalTests_SharedExamples_SameContextSpec)
+QuickSpecBegin(FunctionalTests_SharedExamples_SameContextSpec_ObjC)
 
 __block NSInteger counter = 0;
 
@@ -47,18 +47,18 @@ itBehavesLike(@"gets called with a different context from within the same spec f
 QuickSpecEnd
 
 
-@interface SharedExamplesTests : XCTestCase; @end
+@interface SharedExamplesTests_ObjC : XCTestCase; @end
 
-@implementation SharedExamplesTests
+@implementation SharedExamplesTests_ObjC
 
 - (void)testAGroupOfThreeSharedExamplesExecutesThreeExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_SharedExamples_Spec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_SharedExamples_Spec_ObjC class]);
     XCTAssert(result.hasSucceeded);
     XCTAssertEqual(result.executionCount, 3);
 }
 
 - (void)testSharedExamplesWithContextPassContextToExamples {
-    XCTestRun *result = qck_runSpec([FunctionalTests_SharedExamples_ContextSpec class]);
+    XCTestRun *result = qck_runSpec([FunctionalTests_SharedExamples_ContextSpec_ObjC class]);
     XCTAssert(result.hasSucceeded);
 }
 


### PR DESCRIPTION
When investigating #373, I ran into an issue in which
`+[XCTestCase testInvocations]` would return the **wrong set of
invocations** when two test cases shared the same class name!

This sounds absolutely insane, but it's true! Notice that if you define
two test cases, one in Swift and one in Objective-C, but with the same
name, their test methods are grouped in Xcode's test navigator:

![](http://f.cl.ly/items/17412d0p291d0p0H2u30/Screen%20Shot%202015-09-23%20at%2011.03.03%20PM.png)

The test case class names don't collide when defined in Swift and
Objective-C respectively, but end up behaving very erratically. To
prevent this issue, make sure Objective-C and Swift tests are named
"namespaced" by affixing "_ObjC" to Objective-C test classes.

This probably deserves an Apple radar.