### PR TITLE
Add Carthage/Build to gitignore for better support of Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,13 @@ DerivedData
 #
 # Pods/
 
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
 # Mac OS X
 .DS_Store
 


### PR DESCRIPTION
Added `Carthage/Build` to gitignore to solve the following problem with Carthage.

## Problem

After running `carthage update --use-submodules` or `carthage bootstrap --use-submodules`, untracked contents are detected by Git because Quick does not ignore `Carthage/Build` directory. The directory has to be removed not to be committed.

```
$ git status
On branch master
Changes not staged for commit:

	modified:   Carthage/Checkouts/Quick (untracked content)
```

## Modification

Added `Carthage/Build` to gitignore. The added part of gitignore was taken from the following example.
https://github.com/github/gitignore/blob/master/Swift.gitignore

This modification has no impact to CocoaPods users. With the gitignore, Carthage users will be more comfortable to use Quick in their projects.