### PR TITLE
Remove public headers from umbrella header

### DIFF
--- a/Quick/Quick.h
+++ b/Quick/Quick.h
@@ -6,8 +6,4 @@ FOUNDATION_EXPORT double QuickVersionNumber;
 //! Project version string for Quick.
 FOUNDATION_EXPORT const unsigned char QuickVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <Quick/PublicHeader.h>
-
 #import <Quick/QuickSpec.h>
-#import <Quick/QCKDSL.h>
-#import <Quick/QuickConfiguration.h>


### PR DESCRIPTION
This seems to be the root cause for new projects created in Xcode 7.1
to report "Include of non-modular header inside framework Module
'Quick'".

Infer: It seems like the swift compiler in Xcode 7.1 now prevents
non-modular includes in umbrella header files. The public headers are
assumed to be imported in modules.

Context: #395