### PR TITLE
Fix non-modular include

### DIFF
--- a/Quick/Quick.h
+++ b/Quick/Quick.h
@@ -5,5 +5,3 @@ FOUNDATION_EXPORT double QuickVersionNumber;
 
 //! Project version string for Quick.
 FOUNDATION_EXPORT const unsigned char QuickVersionString[];
-
-#import <Quick/QuickSpec.h>


### PR DESCRIPTION
**WHAT:** Fixes  the build error "Include of non-modular header inside framework module 'Quick.Quick'" that occurs when building using Xcode 7.1 and cocoapods.

Fixes  #406