### PR TITLE
Add missing headers to the umbrella header

### DIFF
--- a/Quick/Quick.h
+++ b/Quick/Quick.h
@@ -7,3 +7,5 @@ FOUNDATION_EXPORT double QuickVersionNumber;
 FOUNDATION_EXPORT const unsigned char QuickVersionString[];
 
 #import <Quick/QuickSpec.h>
+#import <Quick/QCKDSL.h>
+#import <Quick/QuickConfiguration.h>


### PR DESCRIPTION
These headers were removed from the umbrella header so tests in Objective-C stopped working.