### PR TITLE
Add xctool tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ script:
   - rake test:ios
   - rake test:osx
   - rake test:xctool_ios
-  - rake test:xctool_osx
-
+  # Due to the `pending` specs using a `print` xctool fails generating the report,
+  # which in turn makes the tests fail.
+  # See https://github.com/facebook/xctool/issues/314#issuecomment-152988101 and comments
+  # for details.
+  # See https://circleci.com/gh/mokagio/Quick/12 for a proof that without `print` the test pass.
+  # - rake test:xctool_osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 osx_image: xcode7
 language: objective-c
 
-before_install: git submodule update --init --recursive
-script: "rake"
+before_install:
+  - git submodule update --init --recursive
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+script:
+  - rake test:ios
+  - rake test:osx
+  - rake test:xctool_ios
+  - rake test:xctool_osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: objective-c
 
 before_install:
   - git submodule update --init --recursive
-  - brew update
+  # There is a bug in a formula resulting in update failing if run once, but not the second time
+  # See https://github.com/Homebrew/homebrew/issues/45616
+  - brew update || brew update
   - brew outdated xctool || brew upgrade xctool
 script:
   - rake test:ios

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,11 @@ namespace "test" do
   task :osx do |t|
     run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-OSX clean test"
   end
+
+  desc "Run unit tests for all iOS targets using xctool"
+  task :xctool_ios do |t|
+    run "xctool -workspace Quick.xcworkspace -scheme Quick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6' clean test"
+  end
 end
 
 namespace "templates" do

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ namespace "test" do
   task :xctool_ios do |t|
     run "xctool -workspace Quick.xcworkspace -scheme Quick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6' clean test"
   end
+
+  desc "Run unit tests for all OS X targets using xctool"
+  task :xctool_osx do |t|
+    run "xctool -workspace Quick.xcworkspace -scheme Quick-OSX clean test"
+  end
 end
 
 namespace "templates" do

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,6 @@ dependencies:
   pre:
     - brew upgrade xctool
 
-# despite what circle ci says, xctool 0.2.3 cannot run
-# ios simulator tests on iOS frameworks for whatever reason.
-#
-# See: https://github.com/facebook/xctool/issues/415
 test:
   override:
     - rake test:ios

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,10 @@ checkout:
   post:
     - git submodule update --init --recursive
 
+dependencies:
+  pre:
+    - brew upgrade xctool
+
 # despite what circle ci says, xctool 0.2.3 cannot run
 # ios simulator tests on iOS frameworks for whatever reason.
 #

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,8 @@ checkout:
 
 dependencies:
   pre:
-    - brew upgrade xctool
+    - brew update
+    - brew outdated xctool || brew upgrade xctool
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -19,5 +19,6 @@ test:
     - rake test:ios
     - rake test:osx
     - rake test:xctool_ios
+    - rake test:xctool_osx
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,5 +14,6 @@ test:
   override:
     - rake test:ios
     - rake test:osx
+    - rake test:xctool_ios
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,11 @@ test:
     - rake test:ios
     - rake test:osx
     - rake test:xctool_ios
-    - rake test:xctool_osx
+    # Due to the `pending` specs using a `print` xctool fails generating the report,
+    # which in turn makes the tests fail.
+    # See https://github.com/facebook/xctool/issues/314#issuecomment-152988101 and comments
+    # for details.
+    # See https://circleci.com/gh/mokagio/Quick/12 for a proof that without `print` the test pass.
+    # - rake test:xctool_osx
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,9 @@ checkout:
 
 dependencies:
   pre:
-    - brew update
+    # There is a bug in a formula resulting in update failing if run once, but not the second time
+    # See https://github.com/Homebrew/homebrew/issues/45616
+    - brew update || brew update
     - brew outdated xctool || brew upgrade xctool
 
 test:


### PR DESCRIPTION
See https://github.com/Quick/Quick/issues/389

For some reason my CircleCI setup has decided that I cannot run Xcode tests anymore, so I thought I might as well open the PR anyway and see if the tests will run for the Quick organization.