### PR TITLE
Prevent last executed example from disappearing after test

### DIFF
--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -2,7 +2,6 @@
 #import "QuickConfiguration.h"
 #import "NSString+QCKSelectorName.h"
 #import "World.h"
-#import <objc/runtime.h>
 
 static QuickSpec *currentSpec = nil;
 
@@ -30,18 +29,13 @@ const void * const QCKExampleKey = &QCKExampleKey;
     if ([testSuite isKindOfClass:XCTestCaseSuite]) {
         return testSuite;
     } else {
-        Ivar ivar = class_getInstanceVariable([testSuite class], "_tests");
-        NSMutableArray *tests = object_getIvar(testSuite, ivar);
-        return [self findLastExecutedSuite:tests.lastObject];
+        return [self findLastExecutedSuite:testSuite.tests.lastObject];
     }
 }
 
 - (void)injectDummyToTestSuite:(XCTestSuite *)testSuite {
-    Ivar ivar = class_getInstanceVariable([testSuite class], "_tests");
-    NSMutableArray *tests = object_getIvar(testSuite, ivar);
-    
     XCTestCase *dummyCase = [QuickSpec testCaseWithSelector:@selector(dummyExample)];
-    [tests addObject:dummyCase];
+    [testSuite addTest:dummyCase];
 }
 
 @end

--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -8,6 +8,27 @@ static QuickSpec *currentSpec = nil;
 
 const void * const QCKExampleKey = &QCKExampleKey;
 
+@interface Observer : NSObject <XCTestObservation>
+
+@end
+
+@implementation Observer
+
+- (void)testSuiteWillStart:(XCTestSuite *)testSuite {
+    Class k = NSClassFromString(@"XCTestCaseSuite");
+    if ([testSuite isKindOfClass:k]) {
+        Ivar ivar = class_getInstanceVariable([testSuite class], "_tests");
+        NSMutableArray *tests = object_getIvar(testSuite, ivar);
+        
+        XCTestCase *dummyCase = [QuickSpec testCaseWithSelector:@selector(dummyExample)];
+        [tests addObject:dummyCase];
+    }
+}
+
+@end
+
+static Observer *observer = nil;
+
 @interface QuickSpec ()
 @property (nonatomic, strong) Example *example;
 @end
@@ -47,6 +68,11 @@ const void * const QCKExampleKey = &QCKExampleKey;
     }
     [self testInvocations];
     world.currentExampleGroup = nil;
+    
+    if (!observer) {
+        observer = [Observer new];
+        [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:observer];
+    }
 }
 
 /**
@@ -155,6 +181,10 @@ const void * const QCKExampleKey = &QCKExampleKey;
                                                inFile:filePath
                                                atLine:lineNumber
                                              expected:expected];
+}
+
+- (void)dummyExample {
+    
 }
 
 @end


### PR DESCRIPTION
This is a workaround for https://github.com/Quick/Quick/issues/373.

The issues is the last executed example disappears after test. And this patch adds another test case which does nothing on every test suites via observer. The cause of disappearing is not clear to me, but we will have complete set of examples in Test navigator.

The behavior looks like a bug of Xcode to me. This is just a workaround and I'm not sure what will happen once the bug got fixed...