### PR TITLE
add descriptive error when describe is used out of context

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
 		5A5D118719473F2100F6D13D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
+		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
+		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
@@ -397,6 +400,7 @@
 		47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BeforeEachTests+ObjC.m"; sourceTree = "<group>"; };
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
 		DA169E4719FF5DF100619816 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -581,6 +585,7 @@
 				DAE714E919FF65A6005905B8 /* Configuration */,
 				DA7AE6F019FC493F000AFDCE /* ItTests.swift */,
 				479C31E11A36156E00DA8718 /* ItTests+ObjC.m */,
+				8D010A561C11726F00633E2B /* DescribeTests.swift */,
 				DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */,
 				DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */,
 				DA87078219F48775008C04AC /* BeforeEachTests.swift */,
@@ -1157,6 +1162,7 @@
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
 				1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */,
+				8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */,
 				1F118D1E1BDCA556005013A2 /* AfterSuiteTests.swift in Sources */,
 				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
 				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
@@ -1222,6 +1228,7 @@
 				DA8F91A919F32556006F6675 /* AfterSuiteTests.swift in Sources */,
 				4772173B1A59C1B00022013E /* AfterSuiteTests+ObjC.m in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
+				8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */,
 				47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECC1A43442900043E50 /* AfterEachTests+ObjC.m in Sources */,
 				47876F7E1A49AD71002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
@@ -1297,6 +1304,7 @@
 				DA8F91A819F32556006F6675 /* AfterSuiteTests.swift in Sources */,
 				4772173A1A59C1B00022013E /* AfterSuiteTests+ObjC.m in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,
+				8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */,
 				47FAEA361A3F49E6005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECB1A43442400043E50 /* AfterEachTests+ObjC.m in Sources */,
 				47876F7D1A49AD63002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,

--- a/Quick/DSL/DSL.swift
+++ b/Quick/DSL/DSL.swift
@@ -9,7 +9,7 @@
     - parameter closure: The closure to be run prior to any examples in the test suite.
 */
 public func beforeSuite(closure: BeforeSuiteClosure) {
-    World.sharedWorld().beforeSuite(closure)
+    World.sharedWorld.beforeSuite(closure)
 }
 
 /**
@@ -23,7 +23,7 @@ public func beforeSuite(closure: BeforeSuiteClosure) {
     - parameter closure: The closure to be run after all of the examples in the test suite.
 */
 public func afterSuite(closure: AfterSuiteClosure) {
-    World.sharedWorld().afterSuite(closure)
+    World.sharedWorld.afterSuite(closure)
 }
 
 /**
@@ -37,7 +37,7 @@ public func afterSuite(closure: AfterSuiteClosure) {
                     and `afterEach` closures, as well as any number of examples (defined using `it`).
 */
 public func sharedExamples(name: String, closure: () -> ()) {
-    World.sharedWorld().sharedExamples(name, closure: { (NSDictionary) in closure() })
+    World.sharedWorld.sharedExamples(name, closure: { (NSDictionary) in closure() })
 }
 
 /**
@@ -54,7 +54,7 @@ public func sharedExamples(name: String, closure: () -> ()) {
                     that can be executed to retrieve parameters passed in via an `itBehavesLike` function.
 */
 public func sharedExamples(name: String, closure: SharedExampleClosure) {
-    World.sharedWorld().sharedExamples(name, closure: closure)
+    World.sharedWorld.sharedExamples(name, closure: closure)
 }
 
 /**
@@ -66,7 +66,7 @@ public func sharedExamples(name: String, closure: SharedExampleClosure) {
     - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
 */
 public func describe(description: String, flags: FilterFlags = [:], closure: () -> ()) {
-    World.sharedWorld().describe(description, flags: flags, closure: closure)
+    World.sharedWorld.describe(description, flags: flags, closure: closure)
 }
 
 /**
@@ -85,7 +85,7 @@ public func context(description: String, flags: FilterFlags = [:], closure: () -
     - parameter closure: The closure to be run prior to each example.
 */
 public func beforeEach(closure: BeforeExampleClosure) {
-    World.sharedWorld().beforeEach(closure)
+    World.sharedWorld.beforeEach(closure)
 }
 
 /**
@@ -93,7 +93,7 @@ public func beforeEach(closure: BeforeExampleClosure) {
     metadata on the example that the closure is being run prior to.
 */
 public func beforeEach(closure: BeforeExampleWithMetadataClosure) {
-    World.sharedWorld().beforeEach(closure: closure)
+    World.sharedWorld.beforeEach(closure: closure)
 }
 
 /**
@@ -105,7 +105,7 @@ public func beforeEach(closure: BeforeExampleWithMetadataClosure) {
     - parameter closure: The closure to be run after each example.
 */
 public func afterEach(closure: AfterExampleClosure) {
-    World.sharedWorld().afterEach(closure)
+    World.sharedWorld.afterEach(closure)
 }
 
 /**
@@ -113,7 +113,7 @@ public func afterEach(closure: AfterExampleClosure) {
     metadata on the example that the closure is being run after.
 */
 public func afterEach(closure: AfterExampleWithMetadataClosure) {
-    World.sharedWorld().afterEach(closure: closure)
+    World.sharedWorld.afterEach(closure: closure)
 }
 
 /**
@@ -128,7 +128,7 @@ public func afterEach(closure: AfterExampleWithMetadataClosure) {
     - parameter line: The line containing the example. A sensible default is provided.
 */
 public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
-    World.sharedWorld().it(description, flags: flags, file: file, line: line, closure: closure)
+    World.sharedWorld.it(description, flags: flags, file: file, line: line, closure: closure)
 }
 
 /**
@@ -164,7 +164,7 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     - parameter line: The line containing the current example group. A sensible default is provided.
 */
 public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, sharedExampleContext: SharedExampleContext) {
-    World.sharedWorld().itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
+    World.sharedWorld.itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
 }
 
 /**
@@ -175,7 +175,7 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     - parameter closure: A closure that will not be evaluated.
 */
 public func pending(description: String, closure: () -> ()) {
-    World.sharedWorld().pending(description, closure: closure)
+    World.sharedWorld.pending(description, closure: closure)
 }
 
 /**
@@ -183,7 +183,7 @@ public func pending(description: String, closure: () -> ()) {
     This disables all examples within the closure.
 */
 public func xdescribe(description: String, flags: FilterFlags, closure: () -> ()) {
-    World.sharedWorld().xdescribe(description, flags: flags, closure: closure)
+    World.sharedWorld.xdescribe(description, flags: flags, closure: closure)
 }
 
 /**
@@ -199,7 +199,7 @@ public func xcontext(description: String, flags: FilterFlags, closure: () -> ())
     This disables the example and ensures the code within the closure is never run.
 */
 public func xit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
-    World.sharedWorld().xit(description, flags: flags, file: file, line: line, closure: closure)
+    World.sharedWorld.xit(description, flags: flags, file: file, line: line, closure: closure)
 }
 
 /**
@@ -208,7 +208,7 @@ public func xit(description: String, flags: FilterFlags = [:], file: String = __
     This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
 */
 public func fdescribe(description: String, flags: FilterFlags = [:], closure: () -> ()) {
-    World.sharedWorld().fdescribe(description, flags: flags, closure: closure)
+    World.sharedWorld.fdescribe(description, flags: flags, closure: closure)
 }
 
 /**
@@ -223,5 +223,5 @@ public func fcontext(description: String, flags: FilterFlags = [:], closure: () 
     If any examples in the test suite are focused, only those examples are executed.
 */
 public func fit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
-    World.sharedWorld().fit(description, flags: flags, file: file, line: line, closure: closure)
+    World.sharedWorld.fit(description, flags: flags, file: file, line: line, closure: closure)
 }

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -18,7 +18,7 @@ extension World {
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         let group = ExampleGroup(description: description, flags: flags)
-        currentExampleGroup!.appendExampleGroup(group)
+        currentExampleGroup.appendExampleGroup(group)
         currentExampleGroup = group
         closure()
         currentExampleGroup = group.parent
@@ -41,28 +41,28 @@ extension World {
     }
 
     internal func beforeEach(closure: BeforeExampleClosure) {
-        currentExampleGroup!.hooks.appendBefore(closure)
+        currentExampleGroup.hooks.appendBefore(closure)
     }
 
     @objc(beforeEachWithMetadata:)
     internal func beforeEach(closure closure: BeforeExampleWithMetadataClosure) {
-        currentExampleGroup!.hooks.appendBefore(closure)
+        currentExampleGroup.hooks.appendBefore(closure)
     }
 
     internal func afterEach(closure: AfterExampleClosure) {
-        currentExampleGroup!.hooks.appendAfter(closure)
+        currentExampleGroup.hooks.appendAfter(closure)
     }
 
     @objc(afterEachWithMetadata:)
     internal func afterEach(closure closure: AfterExampleWithMetadataClosure) {
-        currentExampleGroup!.hooks.appendAfter(closure)
+        currentExampleGroup.hooks.appendAfter(closure)
     }
 
     @objc(itWithDescription:flags:file:line:closure:)
     internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
         let callsite = Callsite(file: file, line: line)
         let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
-        currentExampleGroup!.appendExample(example)
+        currentExampleGroup.appendExample(example)
     }
 
     @objc(fitWithDescription:flags:file:line:closure:)
@@ -82,13 +82,13 @@ extension World {
     @objc(itBehavesLikeSharedExampleNamed:sharedExampleContext:flags:file:line:)
     internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: UInt) {
         let callsite = Callsite(file: file, line: line)
-        let closure = World.sharedWorld().sharedExample(name)
+        let closure = World.sharedWorld.sharedExample(name)
 
         let group = ExampleGroup(description: name, flags: flags)
-        currentExampleGroup!.appendExampleGroup(group)
+        currentExampleGroup.appendExampleGroup(group)
         currentExampleGroup = group
         closure(sharedExampleContext)
-        currentExampleGroup!.walkDownExamples { (example: Example) in
+        currentExampleGroup.walkDownExamples { (example: Example) in
             example.isSharedExample = true
             example.callsite = callsite
         }

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -17,6 +17,9 @@ extension World {
     }
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
+        guard currentExampleGroup != nil else {
+            fatalError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
+        }
         let group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         currentExampleGroup = group

--- a/Quick/DSL/World+DSL.swift
+++ b/Quick/DSL/World+DSL.swift
@@ -18,7 +18,8 @@ extension World {
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         guard currentExampleGroup != nil else {
-            fatalError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
+            NSException(name: NSInternalInconsistencyException, reason:"Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)", userInfo: nil).raise()
+            return
         }
         let group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup.appendExampleGroup(group)

--- a/Quick/Example.swift
+++ b/Quick/Example.swift
@@ -55,7 +55,7 @@ final public class Example: NSObject {
         closures defined in the its surrounding example groups.
     */
     public func run() {
-        let world = World.sharedWorld()
+        let world = World.sharedWorld
 
         if numberOfExamplesRun == 0 {
             world.suiteHooks.executeBefores()

--- a/Quick/QuickSpec.m
+++ b/Quick/QuickSpec.m
@@ -46,6 +46,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
                            exception.name, exception.reason, exception.userInfo];
     }
     [self testInvocations];
+    world.currentExampleGroup = nil;
 }
 
 /**

--- a/Quick/World.swift
+++ b/Quick/World.swift
@@ -29,7 +29,7 @@ final internal class World: NSObject {
         The DSL requires that this group is correctly set in order to build a
         correct hierarchy of example groups and their examples.
     */
-    internal var currentExampleGroup: ExampleGroup?
+    internal var currentExampleGroup: ExampleGroup!
 
     /**
         The example metadata of the test that is currently being run.
@@ -57,12 +57,7 @@ final internal class World: NSObject {
     // MARK: Singleton Constructor
 
     private override init() {}
-    private struct Shared {
-        static let instance = World()
-    }
-    internal class func sharedWorld() -> World {
-        return Shared.instance
-    }
+    static let sharedWorld = World()
 
     // MARK: Public Interface
 

--- a/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/QuickTests/FunctionalTests/DescribeTests.swift
@@ -1,0 +1,19 @@
+//
+//  DescribeTests.swift
+//  Quick
+//
+//  Created by Morgan Chen on 12/3/15.
+//  Copyright © 2015 Brian Ivan Gesiak. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import Quick
+
+class DescribeTests: XCTestCase {
+    
+    func testDescribeThrowsIfUsedOutsideOfQuickSpec() {
+        expect { describe("this should throw an exception", {}) }.to(raiseException())
+    }
+    
+}


### PR DESCRIPTION
Add a (hopefully) more informative error message when crashing in `describe` to make [crashes like this one](https://github.com/Quick/Nimble/issues/219) more straightforward. From what I can tell the only time the current example group can be `nil` is if the root group was never instantiated.

Includes some minor code changes that don't affect behavior as well.