### PR TITLE
Noted that `context` is a synonym for `describe`

### DIFF
--- a/Documentation/QuickExamplesAndGroups.md
+++ b/Documentation/QuickExamplesAndGroups.md
@@ -299,6 +299,9 @@ describe(@"a dolphin", ^{
 QuickSpecEnd
 ```
 
+Strictly speaking, the `context` keyword is a synonym for `describe`, 
+but thoughtful use will make your spec easier to understand.
+
 ### Test Readability: Quick and XCTest
 
 In [Effective Tests Using XCTest: Arrange, Act, and Assert](ArrangeActAssert.md),


### PR DESCRIPTION
I propose adding this sentence after spending 15+ mins trying to work out if `context` added any new syntax or behaviour beyond `describe`. Digging into the source showed that it is a synonym. I tried to make my addition match the tone of the document (_which is wonderfully written for a broad audience btw!_).