### PR TITLE
Ignore Swift Package Manager's `.build` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Carthage/Build
 
 # Quick
 Quick.framework.zip
+
+# Swift Package Manager
+.build


### PR DESCRIPTION
This will be useful with #436 and future work.