### PR TITLE
Error out with more specific messages when misusing DSL functions

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
 		5A5D118719473F2100F6D13D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B44ADBE1C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
+		7B44ADBF1C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
+		7B44ADC01C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
 		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
@@ -414,6 +417,7 @@
 		47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BeforeEachTests+ObjC.m"; sourceTree = "<group>"; };
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
@@ -579,6 +583,7 @@
 				DA408BDF19FF5599005DF92A /* Closures.swift */,
 				DA408BE019FF5599005DF92A /* ExampleHooks.swift */,
 				DA408BE119FF5599005DF92A /* SuiteHooks.swift */,
+				7B44ADBD1C5444940007AF2E /* HooksPhase.swift */,
 			);
 			path = Hooks;
 			sourceTree = "<group>";
@@ -1150,6 +1155,7 @@
 				1F118CFD1BDCA536005013A2 /* World+DSL.swift in Sources */,
 				1F118D0A1BDCA536005013A2 /* NSString+QCKSelectorName.m in Sources */,
 				1F118CFE1BDCA536005013A2 /* DSL.swift in Sources */,
+				7B44ADC01C5444940007AF2E /* HooksPhase.swift in Sources */,
 				1F118D001BDCA536005013A2 /* Closures.swift in Sources */,
 				1F118D051BDCA536005013A2 /* ExampleMetadata.swift in Sources */,
 				1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */,
@@ -1220,6 +1226,7 @@
 				34F375AE19515CA700CE1B99 /* ExampleGroup.swift in Sources */,
 				34F375BC19515CA700CE1B99 /* World.swift in Sources */,
 				DA169E4919FF5DF100619816 /* Configuration.swift in Sources */,
+				7B44ADBF1C5444940007AF2E /* HooksPhase.swift in Sources */,
 				DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				34F375AC19515CA700CE1B99 /* Example.swift in Sources */,
@@ -1301,6 +1308,7 @@
 				34F375AD19515CA700CE1B99 /* ExampleGroup.swift in Sources */,
 				34F375BB19515CA700CE1B99 /* World.swift in Sources */,
 				DA169E4819FF5DF100619816 /* Configuration.swift in Sources */,
+				7B44ADBE1C5444940007AF2E /* HooksPhase.swift in Sources */,
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				DA408BE419FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				34F375AB19515CA700CE1B99 /* Example.swift in Sources */,

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
 		5A5D118719473F2100F6D13D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
@@ -411,6 +414,7 @@
 		47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BeforeEachTests+ObjC.m"; sourceTree = "<group>"; };
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
@@ -614,6 +618,7 @@
 				4728253A1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m */,
 				DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */,
 				4748E8931A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m */,
+				7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1184,6 +1189,7 @@
 				1F118D1E1BDCA556005013A2 /* AfterSuiteTests.swift in Sources */,
 				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
 				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
+				7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1253,6 +1259,7 @@
 				47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECC1A43442900043E50 /* AfterEachTests+ObjC.m in Sources */,
 				47876F7E1A49AD71002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
+				7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1333,6 +1340,7 @@
 				47FAEA361A3F49E6005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECB1A43442400043E50 /* AfterEachTests+ObjC.m in Sources */,
 				47876F7D1A49AD63002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
+				7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QuickTests/FunctionalTests/ContextTests.swift
+++ b/QuickTests/FunctionalTests/ContextTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import Quick
+import Nimble
+
+class QuickContextTests: QuickSpec {
+    override func spec() {
+        describe("Context") {
+            it("should throw an exception if used in an it block") {
+                expect {
+                    context("A nested context that should throw") { }
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
+        }
+    }
+}

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -73,7 +73,7 @@ public func describe(description: String, flags: FilterFlags = [:], closure: () 
     Defines an example group. Equivalent to `describe`.
 */
 public func context(description: String, flags: FilterFlags = [:], closure: () -> ()) {
-    describe(description, flags: flags, closure: closure)
+    World.sharedWorld.context(description, flags: flags, closure: closure)
 }
 
 /**

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -96,6 +96,10 @@ extension World {
             NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
             return
         }
+        if aftersCurrentlyExecuting() {
+            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         guard currentExampleMetadata == nil else {
             NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
             return

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -20,8 +20,7 @@ extension World {
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. ")
         }
         guard currentExampleGroup != nil else {
             raiseError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
@@ -35,8 +34,7 @@ extension World {
 
     internal func context(description: String, flags: FilterFlags, closure: () -> ()) {
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. ")
         }
         self.describe(description, flags: flags, closure: closure)
     }
@@ -55,8 +53,7 @@ extension World {
 
     internal func beforeEach(closure: BeforeExampleClosure) {
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendBefore(closure)
     }
@@ -74,8 +71,7 @@ extension World {
 
     internal func afterEach(closure: AfterExampleClosure) {
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendAfter(closure)
     }
@@ -93,16 +89,13 @@ extension World {
 
     internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
         if beforesCurrentlyExecuting {
-            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. ")
         }
         if aftersCurrentlyExecuting {
-            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. ")
         }
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. ")
         }
         let callsite = Callsite(file: file, line: line)
         let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
@@ -123,8 +116,7 @@ extension World {
 
     internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: UInt) {
         guard currentExampleMetadata == nil else {
-            NSException(name: "Invalid DSL Exception", reason: "'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
-            return
+            raiseError("'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. ")
         }
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld.sharedExample(name)

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -92,11 +92,11 @@ extension World {
 #endif
 
     internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
-        if beforesCurrentlyExecuting() {
+        if beforesCurrentlyExecuting {
             NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
             return
         }
-        if aftersCurrentlyExecuting() {
+        if aftersCurrentlyExecuting {
             NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
             return
         }

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -73,6 +73,10 @@ extension World {
 #endif
 
     internal func afterEach(closure: AfterExampleClosure) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         currentExampleGroup.hooks.appendAfter(closure)
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -19,6 +19,10 @@ extension World {
     }
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         guard currentExampleGroup != nil else {
             raiseError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
         }

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -34,6 +34,10 @@ extension World {
     }
 
     internal func context(description: String, flags: FilterFlags, closure: () -> ()) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         self.describe(description, flags: flags, closure: closure)
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -92,6 +92,10 @@ extension World {
 #endif
 
     internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         let callsite = Callsite(file: file, line: line)
         let example = Example(description: description, callsite: callsite, flags: flags, closure: closure)
         currentExampleGroup.appendExample(example)

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -20,7 +20,7 @@ extension World {
 
     internal func describe(description: String, flags: FilterFlags, closure: () -> ()) {
         guard currentExampleMetadata == nil else {
-            raiseError("'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. ")
+            raiseError("'describe' cannot be used inside '\(currentPhase)', 'describe' may only be used inside 'context' or 'describe'. ")
         }
         guard currentExampleGroup != nil else {
             raiseError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
@@ -34,7 +34,7 @@ extension World {
 
     internal func context(description: String, flags: FilterFlags, closure: () -> ()) {
         guard currentExampleMetadata == nil else {
-            raiseError("'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. ")
+            raiseError("'context' cannot be used inside '\(currentPhase)', 'context' may only be used inside 'context' or 'describe'. ")
         }
         self.describe(description, flags: flags, closure: closure)
     }
@@ -53,7 +53,7 @@ extension World {
 
     internal func beforeEach(closure: BeforeExampleClosure) {
         guard currentExampleMetadata == nil else {
-            raiseError("'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. ")
+            raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendBefore(closure)
     }
@@ -71,7 +71,7 @@ extension World {
 
     internal func afterEach(closure: AfterExampleClosure) {
         guard currentExampleMetadata == nil else {
-            raiseError("'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. ")
+            raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendAfter(closure)
     }
@@ -116,7 +116,7 @@ extension World {
 
     internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: UInt) {
         guard currentExampleMetadata == nil else {
-            raiseError("'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. ")
+            raiseError("'itBehavesLike' cannot be used inside '\(currentPhase)', 'itBehavesLike' may only be used inside 'context' or 'describe'. ")
         }
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld.sharedExample(name)
@@ -157,5 +157,19 @@ extension World {
 
     internal func pending(description: String, closure: () -> ()) {
         print("Pending: \(description)")
+    }
+
+    private var currentPhase: String {
+        if currentExampleMetadata != nil {
+            if beforesCurrentlyExecuting {
+                return "beforeEach"
+            } else if aftersCurrentlyExecuting {
+                return "afterEach"
+            }
+
+            return "it"
+        }
+
+        return ""
     }
 }

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -92,6 +92,10 @@ extension World {
 #endif
 
     internal func it(description: String, flags: FilterFlags, file: String, line: UInt, closure: () -> ()) {
+        if beforesCurrentlyExecuting() {
+            NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         guard currentExampleMetadata == nil else {
             NSException(name: "Invalid DSL Exception", reason: "'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
             return

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -54,6 +54,10 @@ extension World {
     }
 
     internal func beforeEach(closure: BeforeExampleClosure) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         currentExampleGroup.hooks.appendBefore(closure)
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -114,6 +114,10 @@ extension World {
     }
 
     internal func itBehavesLike(name: String, sharedExampleContext: SharedExampleContext, flags: FilterFlags, file: String, line: UInt) {
+        guard currentExampleMetadata == nil else {
+            NSException(name: "Invalid DSL Exception", reason: "'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. ", userInfo: nil).raise()
+            return
+        }
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld.sharedExample(name)
 

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -67,9 +67,11 @@ final public class Example: NSObject {
         world.currentExampleMetadata = exampleMetadata
 
         world.exampleHooks.executeBefores(exampleMetadata)
+        group!.beforesStartedExecuting = true
         for before in group!.befores {
             before(exampleMetadata: exampleMetadata)
         }
+        group!.beforesAlreadyExecuted = true
 
         closure()
 

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -67,19 +67,19 @@ final public class Example: NSObject {
         world.currentExampleMetadata = exampleMetadata
 
         world.exampleHooks.executeBefores(exampleMetadata)
-        group!.beforesStartedExecuting = true
+        group!.phase = .BeforesExecuting
         for before in group!.befores {
             before(exampleMetadata: exampleMetadata)
         }
-        group!.beforesAlreadyExecuted = true
+        group!.phase = .BeforesFinished
 
         closure()
 
-        group!.aftersStartedExecuting = true
+        group!.phase = .AftersExecuting
         for after in group!.afters {
             after(exampleMetadata: exampleMetadata)
         }
-        group!.aftersAlreadyExecuted = true
+        group!.phase = .AftersFinished
         world.exampleHooks.executeAfters(exampleMetadata)
 
         numberOfExamplesRun += 1

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -75,9 +75,11 @@ final public class Example: NSObject {
 
         closure()
 
+        group!.aftersStartedExecuting = true
         for after in group!.afters {
             after(exampleMetadata: exampleMetadata)
         }
+        group!.aftersAlreadyExecuted = true
         world.exampleHooks.executeAfters(exampleMetadata)
 
         numberOfExamplesRun += 1

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -8,6 +8,8 @@ import Foundation
 final public class ExampleGroup: NSObject {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
+    internal var beforesStartedExecuting = false
+    internal var beforesAlreadyExecuted = false
 
     private let internalDescription: String
     private let flags: FilterFlags

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -8,8 +8,11 @@ import Foundation
 final public class ExampleGroup: NSObject {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
+    
     internal var beforesStartedExecuting = false
     internal var beforesAlreadyExecuted = false
+    internal var aftersStartedExecuting = false
+    internal var aftersAlreadyExecuted = false
 
     private let internalDescription: String
     private let flags: FilterFlags

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -9,10 +9,7 @@ final public class ExampleGroup: NSObject {
     weak internal var parent: ExampleGroup?
     internal let hooks = ExampleHooks()
     
-    internal var beforesStartedExecuting = false
-    internal var beforesAlreadyExecuted = false
-    internal var aftersStartedExecuting = false
-    internal var aftersAlreadyExecuted = false
+    internal var phase: HooksPhase = .NothingExecuted
 
     private let internalDescription: String
     private let flags: FilterFlags
@@ -25,7 +22,7 @@ final public class ExampleGroup: NSObject {
         self.flags = flags
         self.isInternalRootExampleGroup = isInternalRootExampleGroup
     }
-    
+
     public override var description: String {
         return internalDescription
     }

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -4,6 +4,9 @@
 final internal class ExampleHooks {
 
     internal var befores: [BeforeExampleWithMetadataClosure] = []
+    internal var beforesStartedExecuting = false
+    internal var beforesAlreadyExecuted = false
+
     internal var afters: [AfterExampleWithMetadataClosure] = []
 
     internal func appendBefore(closure: BeforeExampleWithMetadataClosure) {
@@ -23,9 +26,12 @@ final internal class ExampleHooks {
     }
 
     internal func executeBefores(exampleMetadata: ExampleMetadata) {
+        beforesStartedExecuting = true
         for before in befores {
             before(exampleMetadata: exampleMetadata)
         }
+        
+        beforesAlreadyExecuted = true
     }
 
     internal func executeAfters(exampleMetadata: ExampleMetadata) {

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -8,6 +8,8 @@ final internal class ExampleHooks {
     internal var beforesAlreadyExecuted = false
 
     internal var afters: [AfterExampleWithMetadataClosure] = []
+    internal var aftersStartedExecuting = false
+    internal var aftersAlreadyExecuted = false
 
     internal func appendBefore(closure: BeforeExampleWithMetadataClosure) {
         befores.append(closure)
@@ -35,8 +37,11 @@ final internal class ExampleHooks {
     }
 
     internal func executeAfters(exampleMetadata: ExampleMetadata) {
+        aftersStartedExecuting = true
         for after in afters {
             after(exampleMetadata: exampleMetadata)
         }
+        
+        aftersAlreadyExecuted = true
     }
 }

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -2,14 +2,9 @@
     A container for closures to be executed before and after each example.
 */
 final internal class ExampleHooks {
-
     internal var befores: [BeforeExampleWithMetadataClosure] = []
-    internal var beforesStartedExecuting = false
-    internal var beforesAlreadyExecuted = false
-
     internal var afters: [AfterExampleWithMetadataClosure] = []
-    internal var aftersStartedExecuting = false
-    internal var aftersAlreadyExecuted = false
+    internal var phase: HooksPhase = .NothingExecuted
 
     internal func appendBefore(closure: BeforeExampleWithMetadataClosure) {
         befores.append(closure)
@@ -28,20 +23,20 @@ final internal class ExampleHooks {
     }
 
     internal func executeBefores(exampleMetadata: ExampleMetadata) {
-        beforesStartedExecuting = true
+        phase = .BeforesExecuting
         for before in befores {
             before(exampleMetadata: exampleMetadata)
         }
         
-        beforesAlreadyExecuted = true
+        phase = .BeforesFinished
     }
 
     internal func executeAfters(exampleMetadata: ExampleMetadata) {
-        aftersStartedExecuting = true
+        phase = .AftersExecuting
         for after in afters {
             after(exampleMetadata: exampleMetadata)
         }
-        
-        aftersAlreadyExecuted = true
+
+        phase = .AftersFinished
     }
 }

--- a/Sources/Quick/Hooks/HooksPhase.swift
+++ b/Sources/Quick/Hooks/HooksPhase.swift
@@ -1,0 +1,11 @@
+/**
+ A description of the execution cycle of the current example with
+ respect to the hooks of that example.
+ */
+internal enum HooksPhase: Int {
+    case NothingExecuted = 0
+    case BeforesExecuting
+    case BeforesFinished
+    case AftersExecuting
+    case AftersFinished
+}

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -7,6 +7,7 @@ final internal class SuiteHooks {
     internal var beforesAlreadyExecuted = false
 
     internal var afters: [AfterSuiteClosure] = []
+    internal var aftersStartedExecuting = false
     internal var aftersAlreadyExecuted = false
 
     internal func appendBefore(closure: BeforeSuiteClosure) {
@@ -26,6 +27,7 @@ final internal class SuiteHooks {
     }
 
     internal func executeAfters() {
+        aftersStartedExecuting = true
         for after in afters {
             after()
         }

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -3,6 +3,7 @@
 */
 final internal class SuiteHooks {
     internal var befores: [BeforeSuiteClosure] = []
+    internal var beforesStartedExecuting = false
     internal var beforesAlreadyExecuted = false
 
     internal var afters: [AfterSuiteClosure] = []
@@ -17,7 +18,7 @@ final internal class SuiteHooks {
     }
 
     internal func executeBefores() {
-        assert(!beforesAlreadyExecuted)
+        beforesStartedExecuting = true
         for before in befores {
             before()
         }
@@ -25,7 +26,6 @@ final internal class SuiteHooks {
     }
 
     internal func executeAfters() {
-        assert(!aftersAlreadyExecuted)
         for after in afters {
             after()
         }

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -3,12 +3,8 @@
 */
 final internal class SuiteHooks {
     internal var befores: [BeforeSuiteClosure] = []
-    internal var beforesStartedExecuting = false
-    internal var beforesAlreadyExecuted = false
-
     internal var afters: [AfterSuiteClosure] = []
-    internal var aftersStartedExecuting = false
-    internal var aftersAlreadyExecuted = false
+    internal var phase: HooksPhase = .NothingExecuted
 
     internal func appendBefore(closure: BeforeSuiteClosure) {
         befores.append(closure)
@@ -19,18 +15,18 @@ final internal class SuiteHooks {
     }
 
     internal func executeBefores() {
-        beforesStartedExecuting = true
+        phase = .BeforesExecuting
         for before in befores {
             before()
         }
-        beforesAlreadyExecuted = true
+        phase = .BeforesFinished
     }
 
     internal func executeAfters() {
-        aftersStartedExecuting = true
+        phase = .AftersExecuting
         for after in afters {
             after()
         }
-        aftersAlreadyExecuted = true
+        phase = .AftersFinished
     }
 }

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -174,6 +174,17 @@ final internal class World: NSObject {
         
         return suiteBeforesExecuting || exampleBeforesExecuting || groupBeforesExecuting
     }
+    
+    internal func aftersCurrentlyExecuting() -> Bool {
+        let suiteAftersExecuting = (suiteHooks.aftersStartedExecuting && !(suiteHooks.aftersAlreadyExecuted))
+        let exampleAftersExecuting = (exampleHooks.aftersStartedExecuting && !(exampleHooks.aftersAlreadyExecuted))
+        var groupAftersExecuting = false
+        if let runningExampleGroup = currentExampleMetadata?.example.group {
+            groupAftersExecuting = (runningExampleGroup.aftersStartedExecuting && !(runningExampleGroup.aftersAlreadyExecuted))
+        }
+        
+        return suiteAftersExecuting || exampleAftersExecuting || groupAftersExecuting
+    }
 
     private var allExamples: [Example] {
         var all: [Example] = []

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -164,7 +164,7 @@ final internal class World: NSObject {
         return allExamples.count
     }
     
-    internal func beforesCurrentlyExecuting() -> Bool {
+    internal var beforesCurrentlyExecuting: Bool {
         let suiteBeforesExecuting = (suiteHooks.beforesStartedExecuting && !(suiteHooks.beforesAlreadyExecuted))
         let exampleBeforesExecuting = (exampleHooks.beforesStartedExecuting && !(exampleHooks.beforesAlreadyExecuted))
         var groupBeforesExecuting = false
@@ -175,7 +175,7 @@ final internal class World: NSObject {
         return suiteBeforesExecuting || exampleBeforesExecuting || groupBeforesExecuting
     }
     
-    internal func aftersCurrentlyExecuting() -> Bool {
+    internal var aftersCurrentlyExecuting: Bool {
         let suiteAftersExecuting = (suiteHooks.aftersStartedExecuting && !(suiteHooks.aftersAlreadyExecuted))
         let exampleAftersExecuting = (exampleHooks.aftersStartedExecuting && !(exampleHooks.aftersAlreadyExecuted))
         var groupAftersExecuting = false

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -165,22 +165,22 @@ final internal class World: NSObject {
     }
     
     internal var beforesCurrentlyExecuting: Bool {
-        let suiteBeforesExecuting = (suiteHooks.beforesStartedExecuting && !(suiteHooks.beforesAlreadyExecuted))
-        let exampleBeforesExecuting = (exampleHooks.beforesStartedExecuting && !(exampleHooks.beforesAlreadyExecuted))
+        let suiteBeforesExecuting = suiteHooks.phase == .BeforesExecuting
+        let exampleBeforesExecuting = exampleHooks.phase == .BeforesExecuting
         var groupBeforesExecuting = false
         if let runningExampleGroup = currentExampleMetadata?.example.group {
-            groupBeforesExecuting = (runningExampleGroup.beforesStartedExecuting && !(runningExampleGroup.beforesAlreadyExecuted))
+            groupBeforesExecuting = runningExampleGroup.phase == .BeforesExecuting
         }
         
         return suiteBeforesExecuting || exampleBeforesExecuting || groupBeforesExecuting
     }
     
     internal var aftersCurrentlyExecuting: Bool {
-        let suiteAftersExecuting = (suiteHooks.aftersStartedExecuting && !(suiteHooks.aftersAlreadyExecuted))
-        let exampleAftersExecuting = (exampleHooks.aftersStartedExecuting && !(exampleHooks.aftersAlreadyExecuted))
+        let suiteAftersExecuting = suiteHooks.phase == .AftersExecuting
+        let exampleAftersExecuting = exampleHooks.phase == .AftersExecuting
         var groupAftersExecuting = false
         if let runningExampleGroup = currentExampleMetadata?.example.group {
-            groupAftersExecuting = (runningExampleGroup.aftersStartedExecuting && !(runningExampleGroup.aftersAlreadyExecuted))
+            groupAftersExecuting = runningExampleGroup.phase == .AftersExecuting
         }
         
         return suiteAftersExecuting || exampleAftersExecuting || groupAftersExecuting

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -163,6 +163,17 @@ final internal class World: NSObject {
     internal var exampleCount: Int {
         return allExamples.count
     }
+    
+    internal func beforesCurrentlyExecuting() -> Bool {
+        let suiteBeforesExecuting = (suiteHooks.beforesStartedExecuting && !(suiteHooks.beforesAlreadyExecuted))
+        let exampleBeforesExecuting = (exampleHooks.beforesStartedExecuting && !(exampleHooks.beforesAlreadyExecuted))
+        var groupBeforesExecuting = false
+        if let runningExampleGroup = currentExampleMetadata?.example.group {
+            groupBeforesExecuting = (runningExampleGroup.beforesStartedExecuting && !(runningExampleGroup.beforesAlreadyExecuted))
+        }
+        
+        return suiteBeforesExecuting || exampleBeforesExecuting || groupBeforesExecuting
+    }
 
     private var allExamples: [Example] {
         var all: [Example] = []

--- a/Sources/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Sources/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -18,38 +18,51 @@ private var afterEachOrder = [AfterEachType]()
 
 class FunctionalTests_AfterEachSpec: QuickSpec {
     override func spec() {
-        afterEach { afterEachOrder.append(AfterEachType.OuterOne) }
-        afterEach { afterEachOrder.append(AfterEachType.OuterTwo) }
-        afterEach { afterEachOrder.append(AfterEachType.OuterThree) }
-
-        it("executes the outer afterEach closures once, but not before this closure [1]") {
-            // No examples have been run, so no afterEach will have been run either.
-            // The list should be empty.
-            expect(afterEachOrder).to(beEmpty())
-        }
-
-        it("executes the outer afterEach closures a second time, but not before this closure [2]") {
-            // The afterEach for the previous example should have been run.
-            // The list should contain the afterEach for that example, executed from top to bottom.
-            expect(afterEachOrder).to(equal([AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree]))
-        }
-
-        context("when there are nested afterEach") {
-            afterEach { afterEachOrder.append(AfterEachType.InnerOne) }
-            afterEach { afterEachOrder.append(AfterEachType.InnerTwo) }
-
-            it("executes the outer and inner afterEach closures, but not before this closure [3]") {
-                // The afterEach for the previous two examples should have been run.
-                // The list should contain the afterEach for those example, executed from top to bottom.
-                expect(afterEachOrder).to(equal([
-                    AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
-                    AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
-                ]))
+        describe("afterEach ordering") {
+            afterEach { afterEachOrder.append(AfterEachType.OuterOne) }
+            afterEach { afterEachOrder.append(AfterEachType.OuterTwo) }
+            afterEach { afterEachOrder.append(AfterEachType.OuterThree) }
+            
+            it("executes the outer afterEach closures once, but not before this closure [1]") {
+                // No examples have been run, so no afterEach will have been run either.
+                // The list should be empty.
+                expect(afterEachOrder).to(beEmpty())
+            }
+            
+            it("executes the outer afterEach closures a second time, but not before this closure [2]") {
+                // The afterEach for the previous example should have been run.
+                // The list should contain the afterEach for that example, executed from top to bottom.
+                expect(afterEachOrder).to(equal([AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree]))
+            }
+            
+            context("when there are nested afterEach") {
+                afterEach { afterEachOrder.append(AfterEachType.InnerOne) }
+                afterEach { afterEachOrder.append(AfterEachType.InnerTwo) }
+                
+                it("executes the outer and inner afterEach closures, but not before this closure [3]") {
+                    // The afterEach for the previous two examples should have been run.
+                    // The list should contain the afterEach for those example, executed from top to bottom.
+                    expect(afterEachOrder).to(equal([
+                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+                        ]))
+                }
+            }
+            
+            context("when there are nested afterEach without examples") {
+                afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
             }
         }
-
-        context("when there are nested afterEach without examples") {
-            afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
+        
+        describe("error handling when misusing ordering") {
+            it("should throw an exception when including afterEach in it block") {
+                expect {
+                    afterEach { }
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
         }
     }
 }

--- a/Sources/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Sources/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -53,17 +53,18 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
                 afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
             }
         }
-        
+#if _runtime(_ObjC)
         describe("error handling when misusing ordering") {
             it("should throw an exception when including afterEach in it block") {
                 expect {
                     afterEach { }
                     }.to(raiseException { (exception: NSException) in
-                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.name).to(equal(NSInternalInconsistencyException))
                         expect(exception.reason).to(equal("'afterEach' cannot be used inside 'it', 'afterEach' may only be used inside 'context' or 'describe'. "))
                         })
             }
         }
+#endif
     }
 }
 

--- a/Sources/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Sources/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -38,17 +38,18 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
                 beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
             }
         }
-        
+#if _runtime(_ObjC)
         describe("error handling when misusing ordering") {
             it("should throw an exception when including beforeEach in it block") {
                 expect {
                     beforeEach { }
                     }.to(raiseException { (exception: NSException) in
-                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.name).to(equal(NSInternalInconsistencyException))
                         expect(exception.reason).to(equal("'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. "))
                         })
             }
         }
+#endif
     }
 }
 

--- a/Sources/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Sources/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -18,22 +18,36 @@ private var beforeEachOrder = [BeforeEachType]()
 
 class FunctionalTests_BeforeEachSpec: QuickSpec {
     override func spec() {
-        beforeEach { beforeEachOrder.append(BeforeEachType.OuterOne) }
-        beforeEach { beforeEachOrder.append(BeforeEachType.OuterTwo) }
-
-        it("executes the outer beforeEach closures once [1]") {}
-        it("executes the outer beforeEach closures a second time [2]") {}
-
-        context("when there are nested beforeEach") {
-            beforeEach { beforeEachOrder.append(BeforeEachType.InnerOne) }
-            beforeEach { beforeEachOrder.append(BeforeEachType.InnerTwo) }
-            beforeEach { beforeEachOrder.append(BeforeEachType.InnerThree) }
-
-            it("executes the outer and inner beforeEach closures [3]") {}
+        
+        describe("beforeEach ordering") {
+            beforeEach { beforeEachOrder.append(BeforeEachType.OuterOne) }
+            beforeEach { beforeEachOrder.append(BeforeEachType.OuterTwo) }
+            
+            it("executes the outer beforeEach closures once [1]") {}
+            it("executes the outer beforeEach closures a second time [2]") {}
+            
+            context("when there are nested beforeEach") {
+                beforeEach { beforeEachOrder.append(BeforeEachType.InnerOne) }
+                beforeEach { beforeEachOrder.append(BeforeEachType.InnerTwo) }
+                beforeEach { beforeEachOrder.append(BeforeEachType.InnerThree) }
+                
+                it("executes the outer and inner beforeEach closures [3]") {}
+            }
+            
+            context("when there are nested beforeEach without examples") {
+                beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
+            }
         }
-
-        context("when there are nested beforeEach without examples") {
-            beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
+        
+        describe("error handling when misusing ordering") {
+            it("should throw an exception when including beforeEach in it block") {
+                expect {
+                    beforeEach { }
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
         }
     }
 }

--- a/Sources/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ContextTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import Quick
+import Nimble
+
+class QuickContextTests: QuickSpec {
+    override func spec() {
+        describe("Context") {
+            it("should throw an exception if used in an it block") {
+                expect {
+                    context("A nested context that should throw") { }
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
+        }
+    }
+}

--- a/Sources/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ContextTests.swift
@@ -1,7 +1,11 @@
 import XCTest
 import Quick
 import Nimble
+#if SWIFT_PACKAGE
+import QuickTestHelpers
+#endif
 
+#if _runtime(_ObjC)
 class QuickContextTests: QuickSpec {
     override func spec() {
         describe("Context") {
@@ -9,10 +13,11 @@ class QuickContextTests: QuickSpec {
                 expect {
                     context("A nested context that should throw") { }
                     }.to(raiseException { (exception: NSException) in
-                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.name).to(equal(NSInternalInconsistencyException))
                         expect(exception.reason).to(equal("'context' cannot be used inside 'it', 'context' may only be used inside 'context' or 'describe'. "))
                         })
             }
         }
     }
 }
+#endif

--- a/Sources/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Sources/QuickTests/FunctionalTests/DescribeTests.swift
@@ -1,11 +1,3 @@
-//
-//  DescribeTests.swift
-//  Quick
-//
-//  Created by Morgan Chen on 12/3/15.
-//  Copyright © 2015 Brian Ivan Gesiak. All rights reserved.
-//
-
 import XCTest
 import Nimble
 import Quick
@@ -22,7 +14,21 @@ class DescribeTests: XCTestCase, XCTestCaseProvider {
     func testDescribeThrowsIfUsedOutsideOfQuickSpec() {
         expect { describe("this should throw an exception", {}) }.to(raiseException())
     }
-    
+}
+
+class QuickDescribeTests: QuickSpec {
+    override func spec() {
+        describe("Describe") {
+            it("should throw an exception if used in an it block") {
+                expect {
+                    describe("A nested describe that should throw") { }
+                }.to(raiseException { (exception: NSException) in
+                    expect(exception.name).to(equal("Invalid DSL Exception"))
+                    expect(exception.reason).to(equal("'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. "))
+                })
+            }
+        }
+    }
 }
 
 #endif

--- a/Sources/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Sources/QuickTests/FunctionalTests/DescribeTests.swift
@@ -23,7 +23,7 @@ class QuickDescribeTests: QuickSpec {
                 expect {
                     describe("A nested describe that should throw") { }
                 }.to(raiseException { (exception: NSException) in
-                    expect(exception.name).to(equal("Invalid DSL Exception"))
+                    expect(exception.name).to(equal(NSInternalInconsistencyException))
                     expect(exception.reason).to(equal("'describe' cannot be used inside 'it', 'describe' may only be used inside 'context' or 'describe'. "))
                 })
             }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -20,13 +20,33 @@ class FunctionalTests_ItSpec: QuickSpec {
         }
         
         describe("error handling when misusing ordering") {
-            it("wraps another it that will...") {
+            it("wraps another 'it' that will...") {
                 expect {
                     it("...throw an error") { }
                     }.to(raiseException { (exception: NSException) in
                         expect(exception.name).to(equal("Invalid DSL Exception"))
                         expect(exception.reason).to(equal("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. "))
                         })
+            }
+            
+            describe("behavior with an 'it' inside a 'beforeEach'") {
+                var exception: NSException?
+                
+                beforeEach {
+                    let capture = NMBExceptionCapture(handler: ({ e in
+                        exception = e
+                    }), finally: nil)
+                    
+                    capture.tryBlock {
+                        it("a rouge 'it' inside a 'beforeEach'") { }
+                        return
+                    }
+                }
+                
+                it("should have thrown an exception with the correct error message") {
+                    expect(exception).toNot(beNil())
+                    expect(exception!.reason).to(equal("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. "))
+                }
             }
         }
     }
@@ -41,6 +61,6 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 3 as UInt)
+        XCTAssertEqual(result.executionCount, 4 as UInt)
     }
 }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -9,14 +9,25 @@ class FunctionalTests_ItSpec: QuickSpec {
     override func spec() {
         var exampleMetadata: ExampleMetadata?
         beforeEach { metadata in exampleMetadata = metadata }
-
+        
         it("") {
             expect(exampleMetadata!.example.name).to(equal(""))
         }
-
+        
         it("has a description with セレクター名に使えない文字が入っている 👊💥") {
             let name = "has a description with セレクター名に使えない文字が入っている 👊💥"
             expect(exampleMetadata!.example.name).to(equal(name))
+        }
+        
+        describe("error handling when misusing ordering") {
+            it("wraps another it that will...") {
+                expect {
+                    it("...throw an error") { }
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
         }
     }
 }
@@ -30,6 +41,6 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 2 as UInt)
+        XCTAssertEqual(result.executionCount, 3 as UInt)
     }
 }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -20,9 +20,9 @@ class FunctionalTests_ItSpec: QuickSpec {
         }
         
         describe("error handling when misusing ordering") {
-            it("wraps another 'it' that will...") {
+            it("an it") {
                 expect {
-                    it("...throw an error") { }
+                    it("will throw an error when it is nested in another it") { }
                     }.to(raiseException { (exception: NSException) in
                         expect(exception.name).to(equal("Invalid DSL Exception"))
                         expect(exception.reason).to(equal("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. "))
@@ -38,7 +38,7 @@ class FunctionalTests_ItSpec: QuickSpec {
                     }), finally: nil)
                     
                     capture.tryBlock {
-                        it("a rouge 'it' inside a 'beforeEach'") { }
+                        it("a rogue 'it' inside a 'beforeEach'") { }
                         return
                     }
                 }
@@ -60,7 +60,7 @@ class FunctionalTests_ItSpec: QuickSpec {
                     }), finally: nil)
                     
                     capture.tryBlock {
-                        it("a rouge 'it' inside an 'afterEach'") { }
+                        it("a rogue 'it' inside an 'afterEach'") { }
                         return
                     }
                 }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -19,12 +19,13 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(name))
         }
         
+#if _runtime(_ObjC)
         describe("error handling when misusing ordering") {
             it("an it") {
                 expect {
                     it("will throw an error when it is nested in another it") { }
                     }.to(raiseException { (exception: NSException) in
-                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.name).to(equal(NSInternalInconsistencyException))
                         expect(exception.reason).to(equal("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'. "))
                         })
             }
@@ -68,6 +69,7 @@ class FunctionalTests_ItSpec: QuickSpec {
                 it("should throw an exception with the correct message after this 'it' block executes") {  }
             }
         }
+#endif
     }
 }
 
@@ -78,8 +80,15 @@ class ItTests: XCTestCase, XCTestCaseProvider {
         ]
     }
 
+#if _runtime(_ObjC)
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
         XCTAssertEqual(result.executionCount, 5 as UInt)
     }
+#else
+    func testAllExamplesAreExecuted() {
+        let result = qck_runSpec(FunctionalTests_ItSpec.self)
+        XCTAssertEqual(result.executionCount, 2 as UInt)
+    }
+#endif
 }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -48,6 +48,25 @@ class FunctionalTests_ItSpec: QuickSpec {
                     expect(exception!.reason).to(equal("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'. "))
                 }
             }
+            
+            describe("behavior with an 'it' inside an 'afterEach'") {
+                var exception: NSException?
+                
+                afterEach {
+                    let capture = NMBExceptionCapture(handler: ({ e in
+                        exception = e
+                        expect(exception).toNot(beNil())
+                        expect(exception!.reason).to(equal("'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. "))
+                    }), finally: nil)
+                    
+                    capture.tryBlock {
+                        it("a rouge 'it' inside an 'afterEach'") { }
+                        return
+                    }
+                }
+                
+                it("should throw an exception with the correct message after this 'it' block executes") {  }
+            }
         }
     }
 }
@@ -61,6 +80,6 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 4 as UInt)
+        XCTAssertEqual(result.executionCount, 5 as UInt)
     }
 }

--- a/Sources/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Sources/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -18,6 +18,7 @@ class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
     }
 }
 
+#if _runtime(_ObjC)
 class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {
@@ -25,13 +26,14 @@ class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
                 expect {
                     itBehavesLike("a group of three shared examples")
                     }.to(raiseException { (exception: NSException) in
-                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.name).to(equal(NSInternalInconsistencyException))
                         expect(exception.reason).to(equal("'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. "))
                         })
             }
         }
     }
 }
+#endif
 
 // Shared examples are defined in QuickTests/Fixtures
 class SharedExamplesTests: XCTestCase, XCTestCaseProvider {

--- a/Sources/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Sources/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -18,6 +18,21 @@ class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
     }
 }
 
+class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
+    override func spec() {
+        describe("error handling when misusing ordering") {
+            it("should throw an exception when including itBehavesLike in it block") {
+                expect {
+                    itBehavesLike("a group of three shared examples")
+                    }.to(raiseException { (exception: NSException) in
+                        expect(exception.name).to(equal("Invalid DSL Exception"))
+                        expect(exception.reason).to(equal("'itBehavesLike' cannot be used inside 'it', 'itBehavesLike' may only be used inside 'context' or 'describe'. "))
+                        })
+            }
+        }
+    }
+}
+
 // Shared examples are defined in QuickTests/Fixtures
 class SharedExamplesTests: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {


### PR DESCRIPTION
This is a crack at solving #362. 

I spent a bit of time trying to use the properties that existed on World to reliably deduce where the current DSL function lied contextually. Unfortunately, doing so made it tough to produce exact error messages for, say, a 'beforeEach' within a 'describe' vs one within a 'context', so I had to switch gears. Overall, I'm happy with what resulted -- a new property on World to track the containing DSL function of the executing function, and a helper method that manages the logic of the throwing the error. 

Admittedly, I'm concerned that managing the 'currentExampleContextDescriptor' property might be a little clunky and hard to intuit to someone walking into the code for the first time. I'd love some suggestions here if you agree that it could be better designed.

Additionally, this is my first attempt at a PR. Let me know if there are any improvements to be made to that end, especially in this write-up. 