### PR TITLE
Shorten selector names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
   - linux
 language: generic
-osx_image: xcode7.2
+osx_image: xcode7.1
 sudo: required
 dist: trusty
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
   - linux
 language: generic
-osx_image: xcode7.1
+osx_image: xcode7.2
 sudo: required
 dist: trusty
 install:

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -109,6 +109,12 @@
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
+		96327C631C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */; };
+		96327C641C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */; };
+		96327C651C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */; };
+		96327C661C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
+		96327C671C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
+		96327C681C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
 		DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
 		DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
@@ -412,6 +418,8 @@
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
+		96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QuickSpec+QuickSpec_MethodList.h"; sourceTree = "<group>"; };
+		96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "QuickSpec+QuickSpec_MethodList.m"; sourceTree = "<group>"; };
 		DA02C91819A8073100093156 /* ExampleMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleMetadata.swift; sourceTree = "<group>"; };
 		DA05D60F19F73A3800771050 /* AfterEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterEachTests.swift; sourceTree = "<group>"; };
 		DA169E4719FF5DF100619816 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -587,6 +595,8 @@
 				DA8F919619F31680006F6675 /* QCKSpecRunner.m */,
 				34ACFB7B1C34859300942064 /* XCTestCaseProvider.swift */,
 				DA8F919819F31680006F6675 /* XCTestObservationCenter+QCKSuspendObservation.h */,
+				96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */,
+				96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -773,6 +783,7 @@
 			files = (
 				1F118D2B1BDCA5B6005013A2 /* Quick.h in Headers */,
 				1F118D261BDCA5AF005013A2 /* World+DSL.h in Headers */,
+				96327C651C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */,
 				1F118D271BDCA5AF005013A2 /* World.h in Headers */,
 				1F118D2A1BDCA5B6005013A2 /* QCKDSL.h in Headers */,
 				1F118D2C1BDCA5B6005013A2 /* QuickSpec.h in Headers */,
@@ -787,6 +798,7 @@
 			files = (
 				34F375B019515CA700CE1B99 /* NSString+QCKSelectorName.h in Headers */,
 				DAE714FF19FF6A62005905B8 /* QuickConfiguration.h in Headers */,
+				96327C641C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */,
 				DA3124E919FCAEE8002858A7 /* QCKDSL.h in Headers */,
 				DAED1ECB1B110699006F61EC /* World+DSL.h in Headers */,
 				DAED1EC51B1105BC006F61EC /* World.h in Headers */,
@@ -801,6 +813,7 @@
 			files = (
 				34F375AF19515CA700CE1B99 /* NSString+QCKSelectorName.h in Headers */,
 				DAE714FE19FF6A62005905B8 /* QuickConfiguration.h in Headers */,
+				96327C631C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h in Headers */,
 				DA3124E819FCAEE8002858A7 /* QCKDSL.h in Headers */,
 				DAED1ECA1B110699006F61EC /* World+DSL.h in Headers */,
 				DAED1EC41B1105BC006F61EC /* World.h in Headers */,
@@ -1133,6 +1146,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96327C681C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */,
 				1F118D031BDCA536005013A2 /* World.swift in Sources */,
 				1F118CFC1BDCA536005013A2 /* Configuration.swift in Sources */,
 				1F118D021BDCA536005013A2 /* SuiteHooks.swift in Sources */,
@@ -1202,6 +1216,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96327C671C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */,
 				34F375B219515CA700CE1B99 /* NSString+QCKSelectorName.m in Sources */,
 				DA3124EB19FCAEE8002858A7 /* QCKDSL.m in Sources */,
 				DA408BE319FF5599005DF92A /* Closures.swift in Sources */,
@@ -1282,6 +1297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96327C661C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */,
 				34F375B119515CA700CE1B99 /* NSString+QCKSelectorName.m in Sources */,
 				DA3124EA19FCAEE8002858A7 /* QCKDSL.m in Sources */,
 				DA408BE219FF5599005DF92A /* Closures.swift in Sources */,

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace "test" do
   task xctool: %w[test:xctool:ios test:xctool:osx]
   namespace :xctool do
     desc "Run unit tests for all iOS targets using xctool"
+    run "echo Using xctool v`xctool -v`..."
     task :ios do |t|
       run "xctool -workspace Quick.xcworkspace -scheme Quick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6' clean test"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -18,17 +18,23 @@ namespace "test" do
   end
 
   desc "Run unit tests for all iOS and OS X targets using xctool"
-  task xctool: %w[test:xctool:ios test:xctool:osx]
+  task xctool: %w[test:xctool:version test:xctool:ios test:xctool:osx]
   namespace :xctool do
     desc "Run unit tests for all iOS targets using xctool"
-    run "echo Using xctool v`xctool -v`..."
     task :ios do |t|
+      Rake::Task["test:xctool:version"].invoke
       run "xctool -workspace Quick.xcworkspace -scheme Quick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6' clean test"
     end
 
     desc "Run unit tests for all OS X targets using xctool"
     task :osx do |t|
+      Rake::Task["test:xctool:version"].invoke
       run "xctool -workspace Quick.xcworkspace -scheme Quick-OSX clean test"
+    end
+
+    desc "Print the version of xctool being used"
+    task :version do
+      run "echo Using xctool v`xctool -v`..."
     end
   end
 

--- a/Sources/Quick/NSString+QCKSelectorName.m
+++ b/Sources/Quick/NSString+QCKSelectorName.m
@@ -27,7 +27,11 @@
 
     NSArray *validComponents = [self componentsSeparatedByCharactersInSet:invalidCharacters];
 
-    return [validComponents componentsJoinedByString:@"_"];
+    NSString *result = [validComponents componentsJoinedByString:@"_"];
+    
+    return ([result length] == 0
+            ? @"_"
+            : result);
 }
 
 @end

--- a/Sources/Quick/NSString+QCKSelectorName.m
+++ b/Sources/Quick/NSString+QCKSelectorName.m
@@ -4,12 +4,8 @@
 
 - (NSString *)qck_selectorName {
     static NSMutableCharacterSet *invalidCharacters = nil;
-    static NSString *separator = @"_";
-    static NSCharacterSet *separatorSet = nil;
     static dispatch_once_t onceToken;
-    
     dispatch_once(&onceToken, ^{
-        separatorSet = [NSCharacterSet characterSetWithCharactersInString:separator];
         invalidCharacters = [NSMutableCharacterSet new];
 
         NSCharacterSet *whitespaceCharacterSet = [NSCharacterSet whitespaceCharacterSet];
@@ -31,13 +27,7 @@
 
     NSArray *validComponents = [self componentsSeparatedByCharactersInSet:invalidCharacters];
 
-    NSString *selector = [validComponents componentsJoinedByString:separator];
-    selector = [selector stringByTrimmingCharactersInSet:separatorSet];
-    if ([selector length] == 0) {
-        selector = @"blank";
-    }
-
-    return selector;
+    return [validComponents componentsJoinedByString:@"_"];
 }
 
 @end

--- a/Sources/Quick/NSString+QCKSelectorName.m
+++ b/Sources/Quick/NSString+QCKSelectorName.m
@@ -4,8 +4,12 @@
 
 - (NSString *)qck_selectorName {
     static NSMutableCharacterSet *invalidCharacters = nil;
+    static NSString *separator = @"_";
+    static NSCharacterSet *separatorSet = nil;
     static dispatch_once_t onceToken;
+    
     dispatch_once(&onceToken, ^{
+        separatorSet = [NSCharacterSet characterSetWithCharactersInString:separator];
         invalidCharacters = [NSMutableCharacterSet new];
 
         NSCharacterSet *whitespaceCharacterSet = [NSCharacterSet whitespaceCharacterSet];
@@ -27,7 +31,13 @@
 
     NSArray *validComponents = [self componentsSeparatedByCharactersInSet:invalidCharacters];
 
-    return [validComponents componentsJoinedByString:@"_"];
+    NSString *selector = [validComponents componentsJoinedByString:separator];
+    selector = [selector stringByTrimmingCharactersInSet:separatorSet];
+    if ([selector length] == 0) {
+        selector = @"blank";
+    }
+
+    return selector;
 }
 
 @end

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -122,7 +122,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
     NSUInteger i = 2;
     
     while ([selectorNames containsObject:selectorName]) {
-        selectorName = [NSString stringWithFormat:@"%@_%li", example.name.qck_selectorName, i++];
+        selectorName = [NSString stringWithFormat:@"%@_%lu", example.name.qck_selectorName, i++];
     }
     
     [selectorNames addObject:selectorName];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -5,6 +5,7 @@
 #import <objc/runtime.h>
 
 static QuickSpec *currentSpec = nil;
+static NSMutableSet<NSString *> *selectorNames;
 
 const void * const QCKExampleKey = &QCKExampleKey;
 
@@ -31,6 +32,8 @@ const void * const QCKExampleKey = &QCKExampleKey;
     world.currentExampleGroup = [world rootExampleGroupForSpecClass:[self class]];
     QuickSpec *spec = [self new];
 
+    selectorNames = [[NSMutableSet alloc] init];
+    
     @try {
         [spec spec];
     }
@@ -115,10 +118,15 @@ const void * const QCKExampleKey = &QCKExampleKey;
     }
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
-    NSString *selectorName = [NSString stringWithFormat:@"%@_%@_%ld",
-                              example.name.qck_selectorName,
-                              sanitizedFileName,
-                              (long)example.callsite.line];
+    NSString *selectorName = example.name.qck_selectorName;
+    NSUInteger i = 2;
+    
+    while ([selectorNames containsObject:selectorName]) {
+        selectorName = [NSString stringWithFormat:@"%@_%li", example.name.qck_selectorName, i++];
+    }
+    
+    [selectorNames addObject:selectorName];
+    
     SEL selector = NSSelectorFromString(selectorName);
     class_addMethod(self, selector, implementation, types);
 

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -119,7 +119,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
     NSString *selectorName = example.name.qck_selectorName;
-    NSUInteger i = 2;
+    unsigned long i = 2;
     
     while ([selectorNames containsObject:selectorName]) {
         selectorName = [NSString stringWithFormat:@"%@_%lu", example.name.qck_selectorName, i++];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -118,7 +118,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
     
     NSString *originalName = example.name.qck_selectorName;
     NSString *selectorName = originalName;
-    unsigned int i = 2;
+    NSUInteger i = 2;
     
     static NSMutableSet<NSString *> *selectorNames;
     static dispatch_once_t onceToken;
@@ -127,7 +127,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
     });
     
     while ([selectorNames containsObject:selectorName]) {
-        selectorName = [NSString stringWithFormat:@"%@_%u", originalName, i++];
+        selectorName = [NSString stringWithFormat:@"%@_%lu", originalName, (unsigned long)i++];
     }
     
     [selectorNames addObject:selectorName];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -58,8 +58,11 @@ const void * const QCKExampleKey = &QCKExampleKey;
 + (NSArray *)testInvocations {
     NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
     NSMutableArray *invocations = [NSMutableArray arrayWithCapacity:[examples count]];
+    
+    NSMutableSet<NSString*> *selectorNames = [NSMutableSet set];
+    
     for (Example *example in examples) {
-        SEL selector = [self addInstanceMethodForExample:example];
+        SEL selector = [self addInstanceMethodForExample:example classSelectorNames:selectorNames];
         NSInvocation *invocation = [self invocationForInstanceMethodWithSelector:selector
                                                                          example:example];
         [invocations addObject:invocation];
@@ -100,7 +103,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
 
  @return The selector of the newly defined instance method.
  */
-+ (SEL)addInstanceMethodForExample:(Example *)example {
++ (SEL)addInstanceMethodForExample:(Example *)example classSelectorNames:(NSMutableSet<NSString*> *)selectorNames {
     IMP implementation = imp_implementationWithBlock(^(QuickSpec *self){
         currentSpec = self;
         [example run];
@@ -119,12 +122,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
     NSString *originalName = example.name.qck_selectorName;
     NSString *selectorName = originalName;
     NSUInteger i = 2;
-    
-    static NSMutableSet<NSString *> *selectorNames;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        selectorNames = [[NSMutableSet alloc] init];
-    });
     
     while ([selectorNames containsObject:selectorName]) {
         selectorName = [NSString stringWithFormat:@"%@_%tu", originalName, i++];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -5,7 +5,6 @@
 #import <objc/runtime.h>
 
 static QuickSpec *currentSpec = nil;
-static NSMutableSet<NSString *> *selectorNames;
 
 const void * const QCKExampleKey = &QCKExampleKey;
 
@@ -32,8 +31,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
     world.currentExampleGroup = [world rootExampleGroupForSpecClass:[self class]];
     QuickSpec *spec = [self new];
 
-    selectorNames = [[NSMutableSet alloc] init];
-    
     @try {
         [spec spec];
     }
@@ -122,6 +119,12 @@ const void * const QCKExampleKey = &QCKExampleKey;
     NSString *originalName = example.name.qck_selectorName;
     NSString *selectorName = originalName;
     unsigned int i = 2;
+    
+    static NSMutableSet<NSString *> *selectorNames;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        selectorNames = [[NSMutableSet alloc] init];
+    });
     
     while ([selectorNames containsObject:selectorName]) {
         selectorName = [NSString stringWithFormat:@"%@_%u", originalName, i++];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -127,7 +127,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
     });
     
     while ([selectorNames containsObject:selectorName]) {
-        selectorName = [NSString stringWithFormat:@"%@_%lu", originalName, (unsigned long)i++];
+        selectorName = [NSString stringWithFormat:@"%@_%tu", originalName, i++];
     }
     
     [selectorNames addObject:selectorName];

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -118,11 +118,13 @@ const void * const QCKExampleKey = &QCKExampleKey;
     }
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
-    NSString *selectorName = example.name.qck_selectorName;
-    unsigned long i = 2;
+    
+    NSString *originalName = example.name.qck_selectorName;
+    NSString *selectorName = originalName;
+    unsigned int i = 2;
     
     while ([selectorNames containsObject:selectorName]) {
-        selectorName = [NSString stringWithFormat:@"%@_%lu", example.name.qck_selectorName, i++];
+        selectorName = [NSString stringWithFormat:@"%@_%u", originalName, i++];
     }
     
     [selectorNames addObject:selectorName];

--- a/Sources/QuickTests/FunctionalTests/ItTests+ObjC.m
+++ b/Sources/QuickTests/FunctionalTests/ItTests+ObjC.m
@@ -3,6 +3,7 @@
 #import <Nimble/Nimble.h>
 
 #import "QCKSpecRunner.h"
+#import "QuickSpec+QuickSpec_MethodList.h"
 
 QuickSpecBegin(FunctionalTests_ItSpec_ObjC)
 
@@ -20,6 +21,13 @@ it(@"has a description with セレクター名に使えない文字が入って�
     expect(exampleMetadata.example.name).to(equal(name));
 });
 
+it(@"is a test with a unique name", ^{
+    NSSet<NSString*> *allSelectors = [FunctionalTests_ItSpec_ObjC allSelectors];
+    
+    expect(allSelectors).to(contain(@"is_a_test_with_a_unique_name"));
+    expect(allSelectors).toNot(contain(@"is_a_test_with_a_unique_name_2"));
+});
+
 QuickSpecEnd
 
 @interface ItTests_ObjC : XCTestCase; @end
@@ -28,7 +36,7 @@ QuickSpecEnd
 
 - (void)testAllExamplesAreExecuted {
     XCTestRun *result = qck_runSpec([FunctionalTests_ItSpec_ObjC class]);
-    XCTAssertEqual(result.executionCount, 2);
+    XCTAssertEqual(result.executionCount, 3);
 }
 
 @end

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -14,8 +14,8 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(""))
         }
 
-        it("has a description with セレクター名に使えない文字が入っている ��") {
-            let name = "has a description with セレクター名に使えない文字が入っている ��"
+        it("has a description with セレクター名に使えない文字が入っている 👊💥") {
+            let name = "has a description with セレクター名に使えない文字が入っている 👊💥"
             expect(exampleMetadata!.example.name).to(equal(name))
         }
 

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -18,6 +18,13 @@ class FunctionalTests_ItSpec: QuickSpec {
             let name = "has a description with セレクター名に使えない文字が入っている 👊💥"
             expect(exampleMetadata!.example.name).to(equal(name))
         }
+        
+        it("is a test with a unique name") {
+            let allSelectors: Set<String> = FunctionalTests_ItSpec.allSelectors();
+            
+            expect(allSelectors).to(contain("is_a_test_with_a_unique_name"));
+            expect(allSelectors).toNot(contain("is_a_test_with_a_unique_name_2"));
+        }
     }
 }
 
@@ -30,6 +37,6 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 2 as UInt)
+        XCTAssertEqual(result.executionCount, 3 as UInt)
     }
 }

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -20,11 +20,42 @@ class FunctionalTests_ItSpec: QuickSpec {
         }
 
 #if _runtime(_ObjC)
-        it("is a test with a unique name") {
-            let allSelectors: Set<String> = FunctionalTests_ItSpec.allSelectors();
+
+        describe("when an example has a unique name"){
+            it("has a unique name") {}
             
-            expect(allSelectors).to(contain("is_a_test_with_a_unique_name"));
-            expect(allSelectors).toNot(contain("is_a_test_with_a_unique_name_2"));
+            it("doesn't add multiple selectors for it") {
+                let allSelectors = [String](
+                    FunctionalTests_ItSpec.allSelectors()
+                        .filter { $0.hasPrefix("when_an_example_has_a_unique_name__") }
+                    )
+                    .sort(<)
+                
+                expect(allSelectors) == [
+                    "when_an_example_has_a_unique_name__doesn_t_add_multiple_selectors_for_it",
+                    "when_an_example_has_a_unique_name__has_a_unique_name"
+                ]
+            }
+        }
+    
+        describe("when two examples have the exact name") {
+            it("has exactly the same name") {}
+            it("has exactly the same name") {}
+            
+            it("makes a unique name for each of the above") {
+                let allSelectors = [String](
+                    FunctionalTests_ItSpec.allSelectors()
+                        .filter { $0.hasPrefix("when_two_examples_have_the_exact_name__") }
+                    )
+                    .sort(<)
+                
+                expect(allSelectors) == [
+                    "when_two_examples_have_the_exact_name__has_exactly_the_same_name",
+                    "when_two_examples_have_the_exact_name__has_exactly_the_same_name_2",
+                    "when_two_examples_have_the_exact_name__makes_a_unique_name_for_each_of_the_above"
+                ]
+            }
+            
         }
 
         describe("error handling when misusing ordering") {
@@ -90,7 +121,7 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 #if _runtime(_ObjC)
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 6 as UInt)
+        XCTAssertEqual(result.executionCount, 10 as UInt)
     }
 #else
     func testAllExamplesAreExecuted() {

--- a/Sources/QuickTests/FunctionalTests/ItTests.swift
+++ b/Sources/QuickTests/FunctionalTests/ItTests.swift
@@ -19,6 +19,7 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(name))
         }
         
+#if _runtime(_ObjC)
         it("is a test with a unique name") {
             let allSelectors: Set<String> = FunctionalTests_ItSpec.allSelectors();
             
@@ -26,7 +27,6 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(allSelectors).toNot(contain("is_a_test_with_a_unique_name_2"));
         }
 
-#if _runtime(_ObjC)
         describe("error handling when misusing ordering") {
             it("an it") {
                 expect {
@@ -95,7 +95,7 @@ class ItTests: XCTestCase, XCTestCaseProvider {
 #else
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result.executionCount, 3 as UInt)
+        XCTAssertEqual(result.executionCount, 2 as UInt)
     }
 #endif
 }

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.h
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.h
@@ -1,0 +1,7 @@
+#import <Quick/Quick.h>
+
+@interface QuickSpec (QuickSpec_MethodList)
+
++ (NSSet<NSString*> *)allSelectors;
+
+@end

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.h
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.h
@@ -1,7 +1,11 @@
 #import <Quick/Quick.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface QuickSpec (QuickSpec_MethodList)
 
 + (NSSet<NSString*> *)allSelectors;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
@@ -5,13 +5,13 @@
 @implementation QuickSpec (QuickSpec_MethodList)
 
 + (NSSet<NSString*> *)allSelectors {
-    id t = [[[self class] alloc] init];
+    QuickSpec *specInstance = [[[self class] alloc] init];
     NSMutableSet<NSString*> *allSelectors = [NSMutableSet set];
     
     unsigned int methodCount = 0;
-    Method * mlist = class_copyMethodList(object_getClass(t), &methodCount);
+    Method *mlist = class_copyMethodList(object_getClass(specInstance), &methodCount);
 
-    for(int i = 0; i<methodCount; i++) {
+    for(unsigned int i = 0; i < methodCount; i++) {
         SEL selector = method_getName(mlist[i]);
         [allSelectors addObject:NSStringFromSelector(selector)];
     }

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
@@ -4,6 +4,14 @@
 
 @implementation QuickSpec (QuickSpec_MethodList)
 
+/**
+ *  This method will instantiate an instance of the class on which it is called,
+ *  returning a list of selector names for it.
+ *
+ *  @warning Only intended to be used in test assertions!
+ *
+ *  @return a set of NSStrings representing the list of selectors it contains
+ */
 + (NSSet<NSString*> *)allSelectors {
     QuickSpec *specInstance = [[[self class] alloc] init];
     NSMutableSet<NSString*> *allSelectors = [NSMutableSet set];

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
@@ -1,0 +1,23 @@
+#import "QuickSpec+QuickSpec_MethodList.h"
+#import <objc/runtime.h>
+
+
+@implementation QuickSpec (QuickSpec_MethodList)
+
++ (NSSet<NSString*> *)allSelectors {
+    id t = [[[self class] alloc] init];
+    NSMutableSet<NSString*> *allSelectors = [NSMutableSet set];
+    
+    unsigned int methodCount = 0;
+    Method * mlist = class_copyMethodList(object_getClass(t), &methodCount);
+    NSLog(@"%d methods", methodCount);
+    for(int i = 0; i<methodCount; i++) {
+        SEL selector = method_getName(mlist[i]);
+        NSLog(@"Method no #%d: %s", i, sel_getName(selector));
+        [allSelectors addObject:NSStringFromSelector(selector)];
+    }
+    
+    return [allSelectors copy];
+}
+
+@end

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
@@ -24,6 +24,7 @@
         [allSelectors addObject:NSStringFromSelector(selector)];
     }
     
+    free(mlist);
     return [allSelectors copy];
 }
 

--- a/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
+++ b/Sources/QuickTests/Helpers/QuickSpec+QuickSpec_MethodList.m
@@ -10,10 +10,9 @@
     
     unsigned int methodCount = 0;
     Method * mlist = class_copyMethodList(object_getClass(t), &methodCount);
-    NSLog(@"%d methods", methodCount);
+
     for(int i = 0; i<methodCount; i++) {
         SEL selector = method_getName(mlist[i]);
-        NSLog(@"Method no #%d: %s", i, sel_getName(selector));
         [allSelectors addObject:NSStringFromSelector(selector)];
     }
     

--- a/Sources/QuickTests/Helpers/QuickTestsBridgingHeader.h
+++ b/Sources/QuickTests/Helpers/QuickTestsBridgingHeader.h
@@ -1,1 +1,2 @@
 #import "QCKSpecRunner.h"
+#import "QuickSpec+QuickSpec_MethodList.h"


### PR DESCRIPTION
I followed the approach suggested in issue #392's thread, using an `NSSet` to track the existing unique selector names and append a number onto the end of additional ones to keep them unique.