### PR TITLE
Enable xctool for OS X target in CI 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,9 +8,7 @@ checkout:
 
 dependencies:
   pre:
-    # There is a bug in a formula resulting in update failing if run once, but not the second time
-    # See https://github.com/Homebrew/homebrew/issues/45616
-    - brew update || brew update
+    - brew update
     - brew outdated xctool || brew upgrade xctool
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -18,11 +18,6 @@ test:
     - rake test:ios
     - rake test:osx
     - rake test:xctool:ios
-    # Due to the `pending` specs using a `print` xctool fails generating the report,
-    # which in turn makes the tests fail.
-    # See https://github.com/facebook/xctool/issues/314#issuecomment-152988101 and comments
-    # for details.
-    # See https://circleci.com/gh/mokagio/Quick/12 for a proof that without `print` the test pass.
-    # - rake test:xctool_osx
+    - rake test:xctool:osx
 
 

--- a/script/travis-install-osx
+++ b/script/travis-install-osx
@@ -3,7 +3,5 @@ set -e
 
 git submodule update --init --recursive
 
-# There is a bug in a formula resulting in update failing if run once, but not the second time
-# See https://github.com/Homebrew/homebrew/issues/45616
-brew update || brew update
+brew update
 brew outdated xctool || brew upgrade xctool

--- a/script/travis-script-osx
+++ b/script/travis-script-osx
@@ -3,10 +3,4 @@
 rake test:ios
 rake test:osx
 rake test:xctool:ios
-
-# Due to the `pending` specs using a `print` xctool fails generating the report,
-# which in turn makes the tests fail.
-# See https://github.com/facebook/xctool/issues/314#issuecomment-152988101 and comments
-# for details.
-# See https://circleci.com/gh/mokagio/Quick/12 for a proof that without `print` the test pass.
-#rake test:xctool:osx
+rake test:xctool:osx


### PR DESCRIPTION
This PR completes the work started in https://github.com/Quick/Quick/pull/417.

The issues with `xctool` that prevented us from running the tests for the OS X on CI have been fixed by a recent release. We're good to go :rocket: 

**Note** the tests are failing on Linux, but that's unrelated with `xctool`.