### PR TITLE
Adjust the way that test observation suspension works.

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -121,6 +121,12 @@
 		96327C661C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
 		96327C671C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
 		96327C681C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m in Sources */ = {isa = PBXBuildFile; fileRef = 96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */; };
+		AE4E58131C73097A00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AE4E58141C73097A00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AE4E58151C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AE4E58161C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AE4E58171C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AE4E58181C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
 		CE57CEDD1C430BD200D63004 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CED81C430BD200D63004 /* NSBundle+CurrentTestBundle.swift */; };
 		CE57CEDE1C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CED91C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift */; };
 		CE57CEDF1C430BD200D63004 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CEDA1C430BD200D63004 /* QuickTestSuite.swift */; };
@@ -443,6 +449,7 @@
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QuickSpec+QuickSpec_MethodList.h"; sourceTree = "<group>"; };
 		96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "QuickSpec+QuickSpec_MethodList.m"; sourceTree = "<group>"; };
+		AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestObservationCenter+QCKSuspendObservation.m"; sourceTree = "<group>"; };
 		CE57CED81C430BD200D63004 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
 		CE57CED91C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
 		CE57CEDA1C430BD200D63004 /* QuickTestSuite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickTestSuite.swift; sourceTree = "<group>"; };
@@ -626,6 +633,7 @@
 				DA8F919819F31680006F6675 /* XCTestObservationCenter+QCKSuspendObservation.h */,
 				96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */,
 				96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */,
+				AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1228,6 +1236,7 @@
 				1F118D131BDCA556005013A2 /* ItTests+ObjC.m in Sources */,
 				1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */,
 				1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */,
+				AE4E58171C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
 				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
 				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
@@ -1251,6 +1260,7 @@
 				34C586061C4ABD4100D4F057 /* XCTestCaseProvider.swift in Sources */,
 				1F118D241BDCA561005013A2 /* FocusedTests.swift in Sources */,
 				1F118D251BDCA561005013A2 /* FocusedTests+ObjC.m in Sources */,
+				AE4E58181C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1305,6 +1315,7 @@
 				4748E8951A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FB19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
+				AE4E58151C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 				471590411A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919E19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
@@ -1328,6 +1339,7 @@
 				34C586021C4ABD3F00D4F057 /* XCTestCaseProvider.swift in Sources */,
 				DA5663F41A4C8D9A00193C88 /* FocusedTests.swift in Sources */,
 				DAF28BC31A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */,
+				AE4E58141C73097A00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1339,6 +1351,7 @@
 				34C586041C4ABD4000D4F057 /* XCTestCaseProvider.swift in Sources */,
 				DA9876C11A4C87200004AA17 /* FocusedTests.swift in Sources */,
 				DAF28BC41A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */,
+				AE4E58161C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1393,6 +1406,7 @@
 				4748E8941A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FA19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
+				AE4E58131C73097A00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
 				471590401A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919D19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,

--- a/Sources/QuickTests/Helpers/QCKSpecRunner.m
+++ b/Sources/QuickTests/Helpers/QCKSpecRunner.m
@@ -8,7 +8,7 @@ XCTestRun *qck_runSuite(XCTestSuite *suite) {
     [World sharedWorld].isRunningAdditionalSuites = YES;
 
     __block XCTestRun *result = nil;
-    [[XCTestObservationCenter sharedTestObservationCenter] _suspendObservationForBlock:^{
+    [[XCTestObservationCenter sharedTestObservationCenter] qck_suspendObservationForBlock:^{
         if ([suite respondsToSelector:@selector(runTest)]) {
             [suite runTest];
             result = suite.testRun;

--- a/Sources/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.h
+++ b/Sources/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.h
@@ -1,24 +1,20 @@
 #import <XCTest/XCTest.h>
 
 /**
- Expose internal XCTest class and methods in order to run isolated XCTestSuite
- instances while the QuickTests test suite is running.
-
- If an Xcode upgrade causes QuickTests to crash when executing, or for tests to fail
- with the message "Timed out waiting for IDE barrier message to complete", it is
- likely that this internal interface has been changed.
+ Add the ability to temporarily disable internal XCTest execution observation in
+ order to run isolated XCTestSuite instances while the QuickTests test suite is running.
  */
 @interface XCTestObservationCenter (QCKSuspendObservation)
 
 /**
- Suspends test suite observation for the duration that the block is executing.
- Any test suites that are executed within the block do not generate any log output.
- Failures are still reported.
+ Suspends test suite observation for XCTest-provided observers for the duration that
+ the block is executing. Any test suites that are executed within the block do not 
+ generate any log output. Failures are still reported.
 
  Use this method to run XCTestSuite objects while another XCTestSuite is running.
  Without this method, tests fail with the message: "Timed out waiting for IDE
- barrier message to complete".
+ barrier message to complete" or "Unexpected TestSuiteDidStart".
  */
-- (void)_suspendObservationForBlock:(void (^)(void))block;
+- (void)qck_suspendObservationForBlock:(void (^)(void))block;
 
 @end

--- a/Sources/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.m
+++ b/Sources/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.m
@@ -1,0 +1,23 @@
+@import XCTest;
+#import <objc/runtime.h>
+
+@interface XCTestObservationCenter (Redeclaration)
+- (NSMutableSet *)observers;
+@end
+
+@implementation XCTestObservationCenter (QCKSuspendObservation)
+
+static BOOL (^isFromApple)(id, BOOL *) = ^BOOL(id observer, BOOL *stop){
+    return [[NSBundle bundleForClass:[observer class]].bundleIdentifier containsString:@"com.apple.dt.XCTest"];
+};
+
+- (void)qck_suspendObservationForBlock:(void (^)(void))block {
+    NSSet *observersToSuspend = [[self observers] objectsPassingTest:isFromApple];
+    [[self observers] minusSet:observersToSuspend];
+
+    block();
+
+    [[self observers] unionSet:observersToSuspend];
+}
+
+@end


### PR DESCRIPTION
When I updated the Nimble submodule to fix compilation on Xcode 7.3, I discovered that the changes made in https://github.com/Quick/Nimble/pull/244 break the Quick tests because of the way that we use `+[XCTestObservationCenter _suspendObservationForBlock:]` to enable running `XCTestSuite` instances during the middle of an existing run. The problem is that Nimble now relies on a test observer of its own in order to be able to report failures to XCTest (see the CI failure [here](https://travis-ci.org/Quick/Quick/jobs/109524574)). 

This PR changes the `QCKSpecRunner` behavior so that, instead of using private API on XCTestObservationCenter, it swizzles public methods to keep track of XCTest's own observers, then temporarily removes them from the center to implement the suspension behavior. I'm not convinced that this is necessarily any more future-proof than the old mechanism, because it relies on being able to add and remove observers at arbitrary times during an ongoing test run, but it does work with current XCTest versions, at least.

Any concerns, @Quick/contributors?