### PR TITLE
Fix the test counting used to determine when to execute `afterSuite` hooks

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -84,7 +84,7 @@ final public class Example: NSObject {
 
         numberOfExamplesRun += 1
 
-        if !world.isRunningAdditionalSuites && numberOfExamplesRun >= world.exampleCount {
+        if !world.isRunningAdditionalSuites && numberOfExamplesRun >= world.includedExampleCount {
             world.suiteHooks.executeAfters()
         }
     }

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -160,8 +160,8 @@ final internal class World: NSObject {
         return sharedExamples[name]!
     }
 
-    internal var exampleCount: Int {
-        return allExamples.count
+    internal var includedExampleCount: Int {
+        return includedExamples.count
     }
     
     internal var beforesCurrentlyExecuting: Bool {


### PR DESCRIPTION
Fixes #482.

I had really been hoping to introduce test coverage around this (cf. [here](https://github.com/Quick/Quick/blob/master/Sources/QuickTests/FunctionalTests/AfterSuiteTests.swift#L41)), but came to the conclusion that it would require more extra infrastructure in the test suite (because the assertion would have to run *after* Quick's test suite finishes, clearly) than I have time to build right now.