### PR TITLE
Updated Nimble to 3.1.0 in Podfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use_frameworks!
 
 def testing_pods
     pod 'Quick', '~> 0.9.0'
-    pod 'Nimble', '3.0.0'
+    pod 'Nimble', '3.1.0'
 end
 
 target 'MyTests' do


### PR DESCRIPTION
Also is there a reason why the example points to a specific Nimble version instead of ~>