### PR TITLE
Swift 2.2 and Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
   - linux
 language: generic
-osx_image: xcode7.2
+osx_image: xcode7.3
 sudo: required
 dist: trusty
 install:

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -127,7 +127,7 @@ public func afterEach(closure: AfterExampleWithMetadataClosure) {
     - parameter file: The absolute path to the file containing the example. A sensible default is provided.
     - parameter line: The line containing the example. A sensible default is provided.
 */
-public func it(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
+public func it(description: String, flags: FilterFlags = [:], file: String = #file, line: UInt = #line, closure: () -> ()) {
     World.sharedWorld.it(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -143,7 +143,7 @@ public func it(description: String, flags: FilterFlags = [:], file: String = __F
     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
     - parameter line: The line containing the current example group. A sensible default is provided.
 */
-public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__) {
+public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = #file, line: UInt = #line) {
     itBehavesLike(name, flags: flags, file: file, line: line, sharedExampleContext: { return [:] })
 }
 
@@ -163,7 +163,7 @@ public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String =
     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
     - parameter line: The line containing the current example group. A sensible default is provided.
 */
-public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, sharedExampleContext: SharedExampleContext) {
+public func itBehavesLike(name: String, flags: FilterFlags = [:], file: String = #file, line: UInt = #line, sharedExampleContext: SharedExampleContext) {
     World.sharedWorld.itBehavesLike(name, sharedExampleContext: sharedExampleContext, flags: flags, file: file, line: line)
 }
 
@@ -198,7 +198,7 @@ public func xcontext(description: String, flags: FilterFlags, closure: () -> ())
     Use this to quickly mark an `it` closure as pending.
     This disables the example and ensures the code within the closure is never run.
 */
-public func xit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
+public func xit(description: String, flags: FilterFlags = [:], file: String = #file, line: UInt = #line, closure: () -> ()) {
     World.sharedWorld.xit(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -222,6 +222,6 @@ public func fcontext(description: String, flags: FilterFlags = [:], closure: () 
     Use this to quickly focus an `it` closure, focusing the example.
     If any examples in the test suite are focused, only those examples are executed.
 */
-public func fit(description: String, flags: FilterFlags = [:], file: String = __FILE__, line: UInt = __LINE__, closure: () -> ()) {
+public func fit(description: String, flags: FilterFlags = [:], file: String = #file, line: UInt = #line, closure: () -> ()) {
     World.sharedWorld.fit(description, flags: flags, file: file, line: line, closure: closure)
 }

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ checkout:
 dependencies:
   pre:
     - brew update
-    - brew outdated xctool || brew upgrade xctool
+    - brew uninstall xctool && brew install --HEAD xctool
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.0"
+    version: "7.3"
 
 checkout:
   post:
@@ -17,5 +17,3 @@ test:
     - rake test:osx
     - rake test:xctool:ios
     - rake test:xctool:osx
-
-

--- a/script/travis-install-osx
+++ b/script/travis-install-osx
@@ -4,4 +4,4 @@ set -e
 git submodule update --init --recursive
 
 brew update
-brew outdated xctool || brew upgrade xctool
+brew uninstall xctool && brew install --HEAD xctool


### PR DESCRIPTION
General changes to get Quick to build on Xcode 7.3 without warnings.

- Replace deprecated `__FILE__` and `__LINE__` with `#file` and `#line`, respectively

:warning: These changes require Xcode 7.3 and Swift 2.2 or better.

I didn't update the Nimble submodule yet, but can once Quick/Nimble#269 is merged.