### PR TITLE
Fix example description in QuickSpec.h

### DIFF
--- a/Sources/Quick/QuickSpec.h
+++ b/Sources/Quick/QuickSpec.h
@@ -33,7 +33,7 @@
  Override this method in your spec to define a set of example groups
  and examples.
 
-     override class func spec() {
+     override func spec() {
          describe("winter") {
              it("is coming") {
                  // ...


### PR DESCRIPTION
QuickSpec.spec() is instance method.
