### PR TITLE
Format example spec in doc comment

### DIFF
--- a/Sources/Quick/QuickSpec.h
+++ b/Sources/Quick/QuickSpec.h
@@ -33,13 +33,15 @@
  Override this method in your spec to define a set of example groups
  and examples.
 
-     override func spec() {
-         describe("winter") {
-             it("is coming") {
-                 // ...
-             }
+ @code
+ override func spec() {
+     describe("winter") {
+         it("is coming") {
+             // ...
          }
      }
+ }
+ @endcode
 
  See DSL.swift for more information on what syntax is available.
  */


### PR DESCRIPTION
Wrapped example spec with `@code` and `@endcode` to preserve formatting in help callout.

# Before

![screen_shot_2016-04-06_at_8_15_49_pm](https://cloud.githubusercontent.com/assets/28851/14338426/7882e5d4-fc34-11e5-8e4f-5997e98a9701.png)

# After

![screen shot 2016-04-06 at 8 41 18 pm](https://cloud.githubusercontent.com/assets/28851/14339065/e57868b8-fc38-11e5-82a2-0fd0dbedcdf6.png)