### PR TITLE
Adds instructions for putting the QUICK_DISABLE_SHORT_SYNTAX macro in project config

### DIFF
--- a/Documentation/en-us/QuickInObjectiveC.md
+++ b/Documentation/en-us/QuickInObjectiveC.md
@@ -27,6 +27,10 @@ QuickSpecEnd
 You must define the `QUICK_DISABLE_SHORT_SYNTAX` macro *before*
 importing the Quick header.
 
+Alternatively, you may define the macro in your test target's build configuration:
+
+![](http://d.twobitlabs.com/VFEamhvixX.png)
+
 ## Your Test Target Must Include At Least One Swift File
 
 The Swift stdlib will not be linked into your test target, and thus


### PR DESCRIPTION
We have a long-lived project with both Objective-C and Swift tests. The Ojective-C specs use Specta, which conflicts with Quick. For some reason no matter what header I add the `QUICK_DISABLE_SHORT_SYNTAX` macro to, it does not apply. The only way I was able to get it to work was by creating the macro in the test target's build configuration.

This PR just adds instructions for how to do that.