### PR TITLE
Fix crash caused by currentExampleGroup being unexpectedly nil

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -127,6 +127,9 @@
 		AE4E58161C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
 		AE4E58171C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
 		AE4E58181C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */; };
+		AED9C8631CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */; };
+		AED9C8641CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */; };
+		AED9C8651CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */; };
 		CE57CEDD1C430BD200D63004 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CED81C430BD200D63004 /* NSBundle+CurrentTestBundle.swift */; };
 		CE57CEDE1C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CED91C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift */; };
 		CE57CEDF1C430BD200D63004 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57CEDA1C430BD200D63004 /* QuickTestSuite.swift */; };
@@ -450,6 +453,7 @@
 		96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QuickSpec+QuickSpec_MethodList.h"; sourceTree = "<group>"; };
 		96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "QuickSpec+QuickSpec_MethodList.m"; sourceTree = "<group>"; };
 		AEB080BB1C72F028004917D3 /* XCTestObservationCenter+QCKSuspendObservation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestObservationCenter+QCKSuspendObservation.m"; sourceTree = "<group>"; };
+		AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrossReferencingSpecs.swift; sourceTree = "<group>"; };
 		CE57CED81C430BD200D63004 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
 		CE57CED91C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
 		CE57CEDA1C430BD200D63004 /* QuickTestSuite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickTestSuite.swift; sourceTree = "<group>"; };
@@ -662,6 +666,7 @@
 				DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */,
 				4748E8931A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m */,
 				7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */,
+				AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1237,6 +1242,7 @@
 				1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */,
 				1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */,
 				AE4E58171C73097E00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
+				AED9C8651CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
 				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
 				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
@@ -1316,6 +1322,7 @@
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FB19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
 				AE4E58151C73097C00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
+				AED9C8641CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590411A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919E19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
@@ -1407,6 +1414,7 @@
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FA19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
 				AE4E58131C73097A00420A2E /* XCTestObservationCenter+QCKSuspendObservation.m in Sources */,
+				AED9C8631CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590401A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919D19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -27,9 +27,7 @@ extension World {
         }
         let group = ExampleGroup(description: description, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
-        currentExampleGroup = group
-        closure()
-        currentExampleGroup = group.parent
+        performWithCurrentExampleGroup(group, closure: closure)
     }
 
     internal func context(description: String, flags: FilterFlags, closure: () -> ()) {
@@ -123,14 +121,14 @@ extension World {
 
         let group = ExampleGroup(description: name, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
-        currentExampleGroup = group
-        closure(sharedExampleContext)
-        currentExampleGroup.walkDownExamples { (example: Example) in
+        performWithCurrentExampleGroup(group) {
+            closure(sharedExampleContext)
+        }
+
+        group.walkDownExamples { (example: Example) in
             example.isSharedExample = true
             example.callsite = callsite
         }
-
-        currentExampleGroup = group.parent
     }
 
 #if _runtime(_ObjC)

--- a/Sources/Quick/QuickSpec.m
+++ b/Sources/Quick/QuickSpec.m
@@ -28,25 +28,25 @@ const void * const QCKExampleKey = &QCKExampleKey;
     [QuickConfiguration initialize];
 
     World *world = [World sharedWorld];
-    world.currentExampleGroup = [world rootExampleGroupForSpecClass:[self class]];
-    QuickSpec *spec = [self new];
+    [world performWithCurrentExampleGroup:[world rootExampleGroupForSpecClass:self] closure:^{
+        QuickSpec *spec = [self new];
 
-    @try {
-        [spec spec];
-    }
-    @catch (NSException *exception) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"An exception occurred when building Quick's example groups.\n"
-                           @"Some possible reasons this might happen include:\n\n"
-                           @"- An 'expect(...).to' expectation was evaluated outside of "
-                           @"an 'it', 'context', or 'describe' block\n"
-                           @"- 'sharedExamples' was called twice with the same name\n"
-                           @"- 'itBehavesLike' was called with a name that is not registered as a shared example\n\n"
-                           @"Here's the original exception: '%@', reason: '%@', userInfo: '%@'",
-                           exception.name, exception.reason, exception.userInfo];
-    }
-    [self testInvocations];
-    world.currentExampleGroup = nil;
+        @try {
+            [spec spec];
+        }
+        @catch (NSException *exception) {
+            [NSException raise:NSInternalInconsistencyException
+                        format:@"An exception occurred when building Quick's example groups.\n"
+             @"Some possible reasons this might happen include:\n\n"
+             @"- An 'expect(...).to' expectation was evaluated outside of "
+             @"an 'it', 'context', or 'describe' block\n"
+             @"- 'sharedExamples' was called twice with the same name\n"
+             @"- 'itBehavesLike' was called with a name that is not registered as a shared example\n\n"
+             @"Here's the original exception: '%@', reason: '%@', userInfo: '%@'",
+             exception.name, exception.reason, exception.userInfo];
+        }
+        [self testInvocations];
+    }];
 }
 
 /**

--- a/Sources/Quick/World.h
+++ b/Sources/Quick/World.h
@@ -14,4 +14,5 @@ SWIFT_CLASS("_TtC5Quick5World")
 - (void)finalizeConfiguration;
 - (ExampleGroup * __nonnull)rootExampleGroupForSpecClass:(Class __nonnull)cls;
 - (NSArray * __nonnull)examplesForSpecClass:(Class __nonnull)specClass;
+- (void)performWithCurrentExampleGroup:(ExampleGroup * __nonnull)group closure:(void (^ __nonnull)(void))closure;
 @end

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -186,6 +186,15 @@ final internal class World: NSObject {
         return suiteAftersExecuting || exampleAftersExecuting || groupAftersExecuting
     }
 
+    internal func performWithCurrentExampleGroup(group: ExampleGroup, closure: () -> Void) {
+        let previousExampleGroup = currentExampleGroup
+        currentExampleGroup = group
+
+        closure()
+
+        currentExampleGroup = previousExampleGroup
+    }
+
     private var allExamples: [Example] {
         var all: [Example] = []
         for (_, group) in specs {

--- a/Sources/QuickTests/FunctionalTests/CrossReferencingSpecs.swift
+++ b/Sources/QuickTests/FunctionalTests/CrossReferencingSpecs.swift
@@ -1,0 +1,19 @@
+import Quick
+import Nimble
+
+// This is a functional test ensuring that no crash occurs when a spec class
+// references another spec class during its spec setup.
+
+class FunctionalTests_CrossReferencingSpecA: QuickSpec {
+    override func spec() {
+        let _ = FunctionalTests_CrossReferencingSpecB()
+        it("does not crash") {}
+    }
+}
+
+class FunctionalTests_CrossReferencingSpecB: QuickSpec {
+    override func spec() {
+        let _ = FunctionalTests_CrossReferencingSpecA()
+        it("does not crash") {}
+    }
+}

--- a/Sources/QuickTests/main.swift
+++ b/Sources/QuickTests/main.swift
@@ -25,6 +25,8 @@ QCKMain([
     Configuration_AfterEachTests(),
     Configuration_BeforeEachSpec(),
     Configuration_BeforeEachTests(),
+    FunctionalTests_CrossReferencingSpecA(),
+    FunctionalTests_CrossReferencingSpecB(),
 ],
 configurations: [
     FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,


### PR DESCRIPTION
This could occur because `+[QuickSpec initialize]` was being called recursively when a new `QuickSpec` subclass was being referenced for the first time while another spec was in the middle of gathering examples.

Fixes #506, #515 