### PR TITLE
Split out a separate Travis job for testing xctool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,26 @@
-os:
-  - osx
-  - linux
-language: generic
 osx_image: xcode7.3
-sudo: required
-dist: trusty
+language: generic
+matrix:
+  include:
+    - os: osx
+      env:
+        - PLATFORM=osx
+    - os: osx
+      env:
+        - PLATFORM=ios
+    - os: osx
+      env: 
+        - XCTOOL=1
+        - PLATFORM=osx
+    - os: osx
+      env: 
+        - XCTOOL=1
+        - PLATFORM=ios
+    - os: linux
+      env:
+        - PLATFORM=linux
+      sudo: required
+      dist: trusty
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then ./script/travis-install-osx;   fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./script/travis-install-linux; fi

--- a/script/travis-script-osx
+++ b/script/travis-script-osx
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 
-rake test:ios
-rake test:osx
-rake test:xctool:ios
-rake test:xctool:osx
+TASK="test"
+if [ "$XCTOOL" ]; then TASK="$TASK:xctool"; fi
+TASK="$TASK:$PLATFORM"
+
+echo "Executing rake task: $TASK"
+rake "$TASK"


### PR DESCRIPTION
This is my attempt at implementing option 2 as discussed at #520. [Here](https://travis-ci.org/briancroom/Quick/builds/125160996) is the build Travis made against this commit already, where it can be seen how the `xctool` job failed while the Linux and basic OS X jobs passed, as expected.