### PR TITLE
Better handling of unsupported tvOS devices

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -1584,6 +1584,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -1610,6 +1611,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -1595,7 +1595,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Quick;
-				SDKROOT = appletvos;
+				SDKROOT = appletvsimulator;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1621,7 +1621,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Quick;
-				SDKROOT = appletvos;
+				SDKROOT = appletvsimulator;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
Quick cannot currently be used on tvOS devices since bitcode is required but the XCTest framework does not contain bitcode. By changing the `SDKROOT` to `appletvsimulator` on the Quick-tvOS target, this has no effect on simulator builds, but provides an immediate and much more informative error on device builds instead of linker errors.

## Before

![screen shot 2016-04-24 at 10 11 07 am](https://cloud.githubusercontent.com/assets/28851/14768636/df7eb064-0a04-11e6-8b13-4912bf17def8.png)

## After

![screen shot 2016-04-23 at 5 48 43 pm](https://cloud.githubusercontent.com/assets/28851/14768627/a4fc8eb6-0a04-11e6-8e7c-44248e015cc3.png)

# Carthage

Carthage currently cannot build Quick since it attempts to build for both the simulator and device (#422). I've proposed a fix for this in Carthage/Carthage#1268 which keys off of the `ENABLE_BITCODE` setting being `NO` to skip building for the device since bitcode is required to build for tvOS devices. This setting has no effect on simulator builds where bitcode is not used.