### PR TITLE
Adds podspec lint on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
       env:
         - PLATFORM=osx
     - os: osx
+      sudo: required
+      env:
+        - PODSPEC=1
+    - os: osx
       env:
         - PLATFORM=ios
     - os: osx
@@ -24,6 +28,7 @@ matrix:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then ./script/travis-install-osx;   fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./script/travis-install-linux; fi
+  - if [[ "$PODSPEC" ]]; then sudo gem install bundler; bundle install; fi
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then ./script/travis-script-osx;   fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./script/travis-script-linux; fi

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'cocoapods', '1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,67 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (1.0.0)
+    cocoapods (1.0.0)
+      activesupport (>= 4.0.2)
+      claide (>= 1.0.0, < 2.0)
+      cocoapods-core (= 1.0.0)
+      cocoapods-deintegrate (>= 1.0.0, < 2.0)
+      cocoapods-downloader (>= 1.0.0, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.0.0, < 2.0)
+      cocoapods-try (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      fourflusher (~> 0.3.0)
+      molinillo (~> 0.4.5)
+      nap (~> 1.0)
+      xcodeproj (>= 1.0.0, < 2.0)
+    cocoapods-core (1.0.0)
+      activesupport (>= 4.0.2)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.0)
+    cocoapods-downloader (1.0.0)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.0.0)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (1.0.0)
+    colored (1.2)
+    escape (0.0.4)
+    fourflusher (0.3.0)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.4)
+    molinillo (0.4.5)
+    nap (1.1.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (1.0.0)
+      activesupport (>= 3)
+      claide (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (= 1.0)
+
+BUNDLED WITH
+   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,13 @@ def has_xcodebuild
   system "which xcodebuild >/dev/null"
 end
 
+namespace "podspec" do
+  desc "Run lint for podspec"
+  task :lint do
+    run "bundle exec pod lib lint"
+  end
+end
+
 namespace "test" do
   desc "Run unit tests for all iOS targets"
   task :ios do |t|

--- a/script/travis-script-osx
+++ b/script/travis-script-osx
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 
-TASK="test"
-if [ "$XCTOOL" ]; then TASK="$TASK:xctool"; fi
-TASK="$TASK:$PLATFORM"
+if [ "$PODSPEC" ]; then
+  TASK="podspec:lint"
+else
+  TASK="test"
+
+  if [ "$XCTOOL" ]; then TASK="$TASK:xctool"; fi
+  TASK="$TASK:$PLATFORM"
+fi
 
 echo "Executing rake task: $TASK"
 rake "$TASK"


### PR DESCRIPTION
* Created a new build process just for lint (similar approach used in https://github.com/Quick/Nimble/pull/288)
* ~~Travis claims that [cocoapods is already installed on OS X instances](https://docs.travis-ci.com/user/osx-ci-environment#Gems-in-the-global-gem-set), so I didn't bother using `gem` or `bundle` to install it.~~
* Added a task `podspec:lint` on Rakefile
* Changed `travis-script-osx` to run either `podspec:lint` or `tests` (not sure if that's the best approach tho)

This fixes #521 