### PR TITLE
Adds search path in podspec for XCTest

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -33,5 +33,6 @@ Pod::Spec.new do |s|
 
   s.framework = "XCTest"
   s.requires_arc = true
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
Continued from #529 and #530 

As pointed out by @briancroom in #530, podspec needs a Search Path in order to locate XCTest.