### PR TITLE
Replaces deprecated property in podspec (changes xcconfig to user_target_xcconfig)

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -33,6 +33,6 @@ Pod::Spec.new do |s|
 
   s.framework = "XCTest"
   s.requires_arc = true
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
+  s.user_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
As called out in #531, `xcconfig` is deprecated and `user_target_xcconfig` should be used instead.