### PR TITLE
Adds Travis CI status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](http://f.cl.ly/items/0r1E192C1R0b2g2Q3h2w/QuickLogo_Color.png)
 
+[![Build Status](https://travis-ci.org/Quick/Quick.svg?branch=master)](https://travis-ci.org/Quick/Quick)
+
 Quick is a behavior-driven development framework for Swift and Objective-C.
 Inspired by [RSpec](https://github.com/rspec/rspec), [Specta](https://github.com/specta/specta), and [Ginkgo](https://github.com/onsi/ginkgo).
 


### PR DESCRIPTION
We used to have a status badge for Circle CI, not sure why it was removed.
Added the Travis one because it's seems to be most updated one.