### PR TITLE
Adds link to Swift version in installation doc

### DIFF
--- a/Documentation/en-us/InstallingQuick.md
+++ b/Documentation/en-us/InstallingQuick.md
@@ -1,9 +1,6 @@
 # Installing Quick
 
-> **If you're using Xcode 7.1,** use the latest version of Quick--`v0.9.0` at the time of writing.
-> New releases are developed on the `swift-2.0` branch.
-
-
+>Before starting, check [here](../../README.md#swift-version) which versions of Quick and Nimble are compatible with your version of Swift.
 
 Quick provides the syntax to define examples and example groups. Nimble
 provides the `expect(...).to` assertion syntax. You may use either one,


### PR DESCRIPTION
There is also a section on using Swift 1.2 which I'm not sure if it's worth keeping (maybe the versions needed for 1.2 should be added on README?)

Thoughts?