### PR TITLE
Update function prototype in docs for shared examples

### DIFF
--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -17,7 +17,7 @@ import Quick
 import Nimble
 
 class EdibleSharedExamplesConfiguration: QuickConfiguration {
-  override class func configure(configuration: Configuration) {
+  override class func configure(_ configuration: Configuration) {
     sharedExamples("something edible") { (sharedExampleContext: SharedExampleContext) in
       it("makes dolphins happy") {
         let dolphin = Dolphin(happy: false)


### PR DESCRIPTION
It was not fully up-to date for Swift 3 GM and as such would fail to compile if compiled as-is.