### PR TITLE
[Package.swift] Don't lock Nimble version to exact v5.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     // be `testDependencies:` instead. For now it has to be done like this for the library to get linked with the test targets.
     // See: https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md
     dependencies: [
-        .Package(url: "https://github.com/Quick/Nimble", "5.0.0")
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5)
     ],
     exclude: [
       "Sources/QuickObjectiveC",


### PR DESCRIPTION
See also https://github.com/ReactiveCocoa/ReactiveSwift/pull/68.