### PR TITLE
[SwiftPM] Remove test dependencies from `Package.swift`

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -1,0 +1,18 @@
+import PackageDescription
+
+let package = Package(
+    name: "Quick",
+    // TODO: Once the `test` command has been implemented in the Swift Package Manager, this should be changed to
+    // be `testDependencies:` instead. For now it has to be done like this for the library to get linked with the test targets.
+    // See: https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md
+    dependencies: [
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5)
+    ],
+    exclude: [
+      "Sources/QuickObjectiveC",
+      "Tests/QuickTests/QuickFocusedTests/FocusedTests+ObjC.m",
+      "Tests/QuickTests/QuickTests/FunctionalTests/ObjC",
+      "Tests/QuickTests/QuickTests/Helpers",
+      "Tests/QuickTests/QuickTests/QuickConfigurationTests.m",
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -2,12 +2,6 @@ import PackageDescription
 
 let package = Package(
     name: "Quick",
-    // TODO: Once the `test` command has been implemented in the Swift Package Manager, this should be changed to
-    // be `testDependencies:` instead. For now it has to be done like this for the library to get linked with the test targets.
-    // See: https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md
-    dependencies: [
-        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5)
-    ],
     exclude: [
       "Sources/QuickObjectiveC",
       "Tests/QuickTests/QuickFocusedTests/FocusedTests+ObjC.m",

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,9 @@ namespace "test" do
 
   desc "Run unit tests for the current platform built by the Swift Package Manager"
   task :swiftpm do |t|
+    run "mv Package.swift .Package.swift && cp .Package.test.swift Package.swift"
     run "swift build --clean && swift build && swift test"
+    run "mv .Package.swift Package.swift"
   end
 end
 


### PR DESCRIPTION
We still run `swift test` on CI using separated `.Package.test.swift`.

This is the same as https://github.com/Carthage/Commandant/pull/83.