### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,23 +53,23 @@ All documentation can be found in the [Documentation folder](./Documentation), i
 
 use_frameworks!
 
-def testing_pods
+target "MyApp" do
+  # Normal libraries
+
+  abstract_target 'Tests' do
+    inherit! :search_paths
+    target "MyAppTests"
+    target "MyAppUITests"
+
     pod 'Quick'
     pod 'Nimble'
-end
-
-target 'MyTests' do
-    testing_pods
-end
-
-target 'MyUITests' do
-    testing_pods
+  end
 end
 ```
 
 ## Projects using Quick
 
-Many apps use both Quick and Nimble however, as they are not included in the app binary, neither appear in “Top Used Libraries” blog posts. Therefore, it would be greatly appreciated to remind contributors that their efforts are valued by compiling a list of organizations and projects that use them. 
+Over ten-thousand apps use either Quick and Nimble however, as they are not included in the app binary, neither appear in “Top Used Libraries” blog posts. Therefore, it would be greatly appreciated to remind contributors that their efforts are valued by compiling a list of organizations and projects that use them. 
 
 Does your organization or project use Quick and Nimble? If yes, [please add your project to the list](https://github.com/Quick/Quick/wiki/Projects-using-Quick).
 


### PR DESCRIPTION
Originally I just wanted to update the README to CocoaPods 1.0 syntax, but I figured you could use CP numbers too

When you run `pod init` on a project with unit + integration tests, it would look like this:

``` ruby
# Uncomment the next line to define a global platform for your project
# platform :ios, '9.0'

target 'MyApp' do
  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
  use_frameworks!

  # Pods for MyApp

  target 'MyAppTests' do
    inherit! :search_paths
    # Pods for testing
  end

  target 'MyAppUITests' do
    inherit! :search_paths
    # Pods for testing
  end

end
```

But we can go a bit better,

```ruby
# Podfile

use_frameworks!

target "MyApp" do
  # Normal libraries

  abstract_target 'Tests' do
    inherit! :search_paths
    target "MyAppTests"
    target "MyAppUITests"

    pod 'Quick'
    pod 'Nimble'
  end
end
```

Which fixes the DRY problem that the method was fixing in the current README.

---

I checked how many downloads you have too, both Quick and Nimble have over 10k unique installs on CocoaPods - so I set that as your baseline.

Quick
![screen shot 2016-11-22 at 10 01 34](https://cloud.githubusercontent.com/assets/49038/20519525/29eb18e4-b09b-11e6-9fe9-d5ba58695b00.png)

Nimble
![screen shot 2016-11-22 at 10 01 26](https://cloud.githubusercontent.com/assets/49038/20519530/2e47d472-b09b-11e6-82bc-bfb5d9b9eef3.png)
