### PR TITLE
Using `[String: Any]` as return type of `SharedExampleContext`

### DIFF
--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -4,7 +4,7 @@ import Foundation
     A closure that, when evaluated, returns a dictionary of key-value
     pairs that can be accessed from within a group of shared examples.
 */
-public typealias SharedExampleContext = () -> (NSDictionary)
+public typealias SharedExampleContext = () -> [String: Any]
 
 /**
     A closure that is used to define a group of shared examples. This


### PR DESCRIPTION
Changed the return type of `SharedExampleContext ` from `NSDictionary` to `[String: Any]`.
This fixes issue #653.