### PR TITLE
Remove unused code.

### DIFF
--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -108,14 +108,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
         currentSpec = self;
         [example run];
     });
-    NSCharacterSet *characterSet = [NSCharacterSet alphanumericCharacterSet];
-    NSMutableString *sanitizedFileName = [NSMutableString string];
-    for (NSUInteger i = 0; i < example.callsite.file.length; i++) {
-        unichar ch = [example.callsite.file characterAtIndex:i];
-        if ([characterSet characterIsMember:ch]) {
-            [sanitizedFileName appendFormat:@"%c", ch];
-        }
-    }
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
     


### PR DESCRIPTION
Some unused code was present in the Objective-C QuickSpec class. The resulting `sanitizedFileName` was used, but then stop being used in 08b4bee51441ee64ab91794bb48076f26a9b0ef8.

The code should work exactly the same as before (maybe slightly faster). No tests nor documentation, but the change doesn’t modify the behaviour.
