### PR TITLE
Change test method encoding to return void.

### DIFF
--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -117,7 +117,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
         }
     }
 
-    const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(id), @encode(id), @encode(SEL)] UTF8String];
+    const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];
     
     NSString *originalName = example.name.qck_selectorName;
     NSString *selectorName = originalName;


### PR DESCRIPTION
The implementation above uses a block that return void.

Probably the code from XCTestCase doesn't try to inspect the return
value, but it is probably better to include the right type
information just in case.

No new tests or documentation. The change is internal and should not affect the current behaviour. Test pass.
