### PR TITLE
[SwiftLint] Enable some disabled rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,7 @@
-
 disabled_rules:
   - line_length
   - type_name
   - valid_docs
-  - empty_count
   - force_unwrapping
   - function_body_length
   - variable_name

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,7 +2,6 @@ disabled_rules:
   - line_length
   - type_name
   - valid_docs
-  - force_unwrapping
   - function_body_length
   - variable_name
 included:


### PR DESCRIPTION
There is no violations for the rules. Related to #641.