### PR TITLE
[SwiftLint] Suppress unused closure parameter and colon violation

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -37,7 +37,7 @@ public func afterSuite(_ closure: @escaping AfterSuiteClosure) {
                     and `afterEach` closures, as well as any number of examples (defined using `it`).
 */
 public func sharedExamples(_ name: String, closure: @escaping () -> Void) {
-    World.sharedWorld.sharedExamples(name, closure: { (NSDictionary) in closure() })
+    World.sharedWorld.sharedExamples(name, closure: { (_) in closure() })
 }
 
 /**

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -11,7 +11,7 @@ final internal class ExampleHooks {
     }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleClosure) {
-        befores.append { (exampleMetadata: ExampleMetadata) in closure() }
+        befores.append { (_: ExampleMetadata) in closure() }
     }
 
     internal func appendAfter(_ closure: @escaping AfterExampleWithMetadataClosure) {
@@ -19,7 +19,7 @@ final internal class ExampleHooks {
     }
 
     internal func appendAfter(_ closure: @escaping AfterExampleClosure) {
-        afters.append { (exampleMetadata: ExampleMetadata) in closure() }
+        afters.append { (_: ExampleMetadata) in closure() }
     }
 
     internal func executeBefores(_ exampleMetadata: ExampleMetadata) {

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -19,7 +19,7 @@ open class QuickSpec: XCTestCase {
     }
 #endif
 
-    static var allTestsCache = [String : [(String, (XCTestCase) -> () throws -> Void)]]()
+    static var allTestsCache = [String: [(String, (XCTestCase) -> () throws -> Void)]]()
 
     public class var allTests: [(String, (XCTestCase) -> () throws -> Void)] {
         if let cached = allTestsCache[String(describing: self)] {

--- a/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
+++ b/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
@@ -24,7 +24,7 @@ public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProv
 
 public extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
     var allTestNames: [String] {
-        return type(of: self).allTests.map({ name, test in
+        return type(of: self).allTests.map({ name, _ in
             return name
         })
     }


### PR DESCRIPTION
Related to #641 