### PR TITLE
Change iOS Deployment Target to 7.0

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -2005,7 +2005,7 @@
 				);
 				INFOPLIST_FILE = Sources/Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -2035,7 +2035,7 @@
 				);
 				INFOPLIST_FILE = Sources/Quick/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";


### PR DESCRIPTION
Causes a warning in Xcode, but users still have minimum deployment targets at 7 that still work for tests.

Fixes #541.

---------------

 - [ ] Does this have tests? **No. (Ideally, we should have some verification to prevent regression since this is the 3rd-time).**
 - [x] Does this have documentation? No.
 - [x] Does this break the public API (Requires major version bump)? No.
 - [x] Is this a new feature (Requires minor version bump)? No.

