### PR TITLE
Initial support to implicit errors

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -129,7 +129,7 @@ public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
     - parameter file: The absolute path to the file containing the example. A sensible default is provided.
     - parameter line: The line containing the example. A sensible default is provided.
 */
-public func it(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () -> Void) {
+public func it(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
     World.sharedWorld.it(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -216,7 +216,7 @@ public func xcontext(_ description: String, flags: FilterFlags = [:], closure: (
     Use this to quickly mark an `it` closure as pending.
     This disables the example and ensures the code within the closure is never run.
 */
-public func xit(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () -> Void) {
+public func xit(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
     World.sharedWorld.xit(description, flags: flags, file: file, line: line, closure: closure)
 }
 
@@ -247,7 +247,7 @@ public func fcontext(_ description: String, flags: FilterFlags = [:], closure: (
     Use this to quickly focus an `it` closure, focusing the example.
     If any examples in the test suite are focused, only those examples are executed.
 */
-public func fit(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () -> Void) {
+public func fit(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
     World.sharedWorld.fit(description, flags: flags, file: file, line: line, closure: closure)
 }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -87,7 +87,7 @@ extension World {
 #endif
 
     @nonobjc
-    internal func it(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () -> Void) {
+    internal func it(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         if beforesCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'.")
         }
@@ -103,14 +103,14 @@ extension World {
     }
 
     @nonobjc
-    internal func fit(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () -> Void) {
+    internal func fit(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
         self.it(description, flags: focusedFlags, file: file, line: line, closure: closure)
     }
 
     @nonobjc
-    internal func xit(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () -> Void) {
+    internal func xit(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
         self.it(description, flags: pendingFlags, file: file, line: line, closure: closure)

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -85,7 +85,7 @@ final public class Example: _ExampleBase {
             try closure()
         } catch {
             let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
-            QuickSpec.current.recordFailure(withDescription: description, inFile: callsite.file, atLine: callsite.line, expected: false)
+            QuickSpec.current.recordFailure(withDescription: description, inFile: callsite.file, atLine: Int(callsite.line), expected: false)
         }
 
         group!.phase = .aftersExecuting

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -85,7 +85,17 @@ final public class Example: _ExampleBase {
             try closure()
         } catch {
             let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
-            QuickSpec.current.recordFailure(withDescription: description, inFile: callsite.file, atLine: Int(callsite.line), expected: false)
+            #if SWIFT_PACKAGE
+            let file = callsite.file.description
+            #else
+            let file = callsite.file
+            #endif
+            QuickSpec.current.recordFailure(
+                withDescription: description,
+                inFile: file,
+                atLine: Int(callsite.line),
+                expected: false
+            )
         }
 
         group!.phase = .aftersExecuting

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -84,7 +84,8 @@ final public class Example: _ExampleBase {
         do {
             try closure()
         } catch {
-            print("Test \(name) threw unexpected error: \(error.localizedDescription)")
+            let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
+            QuickSpec.current.recordFailure(withDescription: description, inFile: callsite.file, atLine: callsite.line, expected: false)
         }
 
         group!.phase = .aftersExecuting

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -30,10 +30,10 @@ final public class Example: _ExampleBase {
     weak internal var group: ExampleGroup?
 
     private let internalDescription: String
-    private let closure: () -> Void
+    private let closure: () throws -> Void
     private let flags: FilterFlags
 
-    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () -> Void) {
+    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () throws -> Void) {
         self.internalDescription = description
         self.closure = closure
         self.callsite = callsite
@@ -81,7 +81,11 @@ final public class Example: _ExampleBase {
         }
         group!.phase = .beforesFinished
 
-        closure()
+        do {
+            try closure()
+        } catch {
+            print("Test \(name) threw unexpected error: \(error.localizedDescription)")
+        }
 
         group!.phase = .aftersExecuting
         for after in group!.afters {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -101,6 +101,26 @@ class FunctionalTests_ItSpec: QuickSpec {
 
                 it("should throw an exception with the correct message after this 'it' block executes") {  }
             }
+
+            describe("implicit error handling") {
+                enum ExampleError: Error {
+                    case error
+                }
+
+                func nonThrowingFunc() throws { }
+
+                func throwingFunc() throws {
+                    throw ExampleError.error
+                }
+
+                it("supports calling functions marked as throws") {
+                    try nonThrowingFunc()
+                }
+
+                it("supports calling functions that actually throws") {
+                    try throwingFunc()
+                }
+            }
         }
 #endif
 #endif

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -101,29 +101,33 @@ class FunctionalTests_ItSpec: QuickSpec {
 
                 it("should throw an exception with the correct message after this 'it' block executes") {  }
             }
-
-            describe("implicit error handling") {
-                enum ExampleError: Error {
-                    case error
-                }
-
-                func nonThrowingFunc() throws { }
-
-                func throwingFunc() throws {
-                    throw ExampleError.error
-                }
-
-                it("supports calling functions marked as throws") {
-                    try nonThrowingFunc()
-                }
-
-                it("supports calling functions that actually throws") {
-                    try throwingFunc()
-                }
-            }
         }
 #endif
 #endif
+    }
+}
+
+class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
+    override func spec() {
+        describe("implicit error handling") {
+            enum ExampleError: Error {
+                case error
+            }
+
+            func nonThrowingFunc() throws { }
+
+            func throwingFunc() throws {
+                throw ExampleError.error
+            }
+
+            it("supports calling functions marked as throws") {
+                try nonThrowingFunc()
+            }
+
+            it("supports calling functions that actually throws") {
+                try throwingFunc()
+            }
+        }
     }
 }
 
@@ -131,6 +135,7 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [
             ("testAllExamplesAreExecuted", testAllExamplesAreExecuted),
+            ("testImplicitErrorHandling", testAllExamplesAreExecuted),
         ]
     }
 
@@ -145,5 +150,11 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         #else
         XCTAssertEqual(result?.executionCount, 2)
         #endif
+    }
+
+    func testImplicitErrorHandling() {
+        let result = qck_runSpec(FunctionalTests_ImplicitErrorItSpec.self)
+        XCTAssertEqual(result?.executionCount, 2)
+        XCTAssertEqual(result?.totalFailureCount, 1)
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -107,6 +107,8 @@ class FunctionalTests_ItSpec: QuickSpec {
     }
 }
 
+private var isRunningFunctionalTests = false
+
 class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
     override func spec() {
         describe("implicit error handling") {
@@ -114,10 +116,12 @@ class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
                 case error
             }
 
-            func nonThrowingFunc() throws { }
+            func nonThrowingFunc() throws {}
 
-            func throwingFunc() throws {
-                throw ExampleError.error
+            func throwingFunc(shouldThrow: Bool) throws {
+                if shouldThrow {
+                    throw ExampleError.error
+                }
             }
 
             it("supports calling functions marked as throws") {
@@ -125,7 +129,7 @@ class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
             }
 
             it("supports calling functions that actually throws") {
-                try throwingFunc()
+                try throwingFunc(shouldThrow: isRunningFunctionalTests)
             }
         }
     }
@@ -137,6 +141,16 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
             ("testAllExamplesAreExecuted", testAllExamplesAreExecuted),
             ("testImplicitErrorHandling", testAllExamplesAreExecuted),
         ]
+    }
+
+    override func setUp() {
+        super.setUp()
+        isRunningFunctionalTests = true
+    }
+
+    override func tearDown() {
+        isRunningFunctionalTests = false
+        super.tearDown()
     }
 
     func testAllExamplesAreExecuted() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -139,7 +139,7 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [
             ("testAllExamplesAreExecuted", testAllExamplesAreExecuted),
-            ("testImplicitErrorHandling", testAllExamplesAreExecuted),
+            ("testImplicitErrorHandling", testImplicitErrorHandling),
         ]
     }
 
@@ -167,8 +167,11 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testImplicitErrorHandling() {
-        let result = qck_runSpec(FunctionalTests_ImplicitErrorItSpec.self)
-        XCTAssertEqual(result?.executionCount, 2)
-        XCTAssertEqual(result?.totalFailureCount, 1)
+        let result = qck_runSpec(FunctionalTests_ImplicitErrorItSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.failureCount, 0)
+        XCTAssertEqual(result.unexpectedExceptionCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 1)
     }
 }


### PR DESCRIPTION
This adds support to catching thrown errors inside `it` blocks. Will fix #403.

Currently, you'd have to use one of Nimble's matchers such as 

```swift
it("works") {
    expect { try foo }.toNot(throwError())
}
```

With this, you'd just have:
```swift
it("works") {
    try foo
}
```

This also is similar to `XCTest`, which supports functions being marked as `throws` (and the test fails if they do throw). 

This is still WIP because I don't know how to proceed on some places (will add comments).

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests? Not yet
 - [ ] Does this have documentation? Not yet
 - [x] Does this break the public API (Requires major version bump)? No
 - [x] Is this a new feature (Requires minor version bump)? Yes

