### PR TITLE
Fixes typo in SharedExamples.md

### DIFF
--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -81,7 +81,7 @@ beforeEach(^{
   mackerel = [[Mackerel alloc] init];
 });
 
-itBehavesLike(@"someting edible", ^{ return @{ @"edible": mackerel }; });
+itBehavesLike(@"something edible", ^{ return @{ @"edible": mackerel }; });
 
 QuickSpecEnd
 
@@ -92,7 +92,7 @@ beforeEach(^{
   cod = [[Cod alloc] init];
 });
 
-itBehavesLike(@"someting edible", ^{ return @{ @"edible": cod }; });
+itBehavesLike(@"something edible", ^{ return @{ @"edible": cod }; });
 
 QuickSpecEnd
 ```


### PR DESCRIPTION
`someting` -> `something`

Found while working on #681 