### PR TITLE
[QuickSpec] Track the current example within `imp_implementationWithBlock`

### DIFF
--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -1,12 +1,9 @@
 #import "QuickSpec.h"
 #import "QuickConfiguration.h"
 #import "World.h"
-#import <objc/runtime.h>
 #import <Quick/Quick-Swift.h>
 
 static QuickSpec *currentSpec = nil;
-
-const void * const QCKExampleKey = &QCKExampleKey;
 
 @interface QuickSpec ()
 @property (nonatomic, strong) Example *example;
@@ -71,16 +68,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
     return invocations;
 }
 
-/**
- XCTest sets the invocation for the current test case instance using this setter.
- QuickSpec hooks into this event to give the test case a reference to the current example.
- It will need this reference to correctly report its name to XCTest.
- */
-- (void)setInvocation:(NSInvocation *)invocation {
-    self.example = objc_getAssociatedObject(invocation, QCKExampleKey);
-    [super setInvocation:invocation];
-}
-
 #pragma mark - Public Interface
 
 - (void)spec { }
@@ -105,6 +92,7 @@ const void * const QCKExampleKey = &QCKExampleKey;
  */
 + (SEL)addInstanceMethodForExample:(Example *)example classSelectorNames:(NSMutableSet<NSString*> *)selectorNames {
     IMP implementation = imp_implementationWithBlock(^(QuickSpec *self){
+        self.example = example;
         currentSpec = self;
         [example run];
     });
@@ -132,10 +120,6 @@ const void * const QCKExampleKey = &QCKExampleKey;
     NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.selector = selector;
-    objc_setAssociatedObject(invocation,
-                             QCKExampleKey,
-                             example,
-                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return invocation;
 }
 


### PR DESCRIPTION
This eliminates Objective-C's associated objects usage and overriding `-setInvocation:`.

There should be no functional changes.