### PR TITLE
fix issue 693, Fail compiling Quick using Carthage because of SwiftLint

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		732D8D691E516780008558BD /* SwiftLint */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 732D8D6A1E516780008558BD /* Build configuration list for PBXAggregateTarget "SwiftLint" */;
+			buildPhases = (
+				732D8D6D1E516789008558BD /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = SwiftLint;
+			productName = SwiftLint;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		1F118CDF1BDCA4AB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
 		1F118CF51BDCA4BB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
@@ -1223,7 +1237,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0810;
-				LastUpgradeCheck = 0810;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Brian Ivan Gesiak";
 				TargetAttributes = {
 					1F118CD41BDCA4AB005013A2 = {
@@ -1246,6 +1260,10 @@
 						CreatedOnToolsVersion = 6.0;
 						LastSwiftMigration = 0800;
 						TestTargetID = 5A5D117B19473F2100F6D13D;
+					};
+					732D8D691E516780008558BD = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
 					};
 					DA5663E71A4C8D8500193C88 = {
 						CreatedOnToolsVersion = 6.2;
@@ -1290,6 +1308,7 @@
 				1F118CDD1BDCA4AB005013A2 /* Quick - tvOSTests */,
 				1F118CEF1BDCA4BB005013A2 /* QuickFocused - tvOSTests */,
 				64076D0A1D6D7CEA00E2B499 /* QuickAfterSuite - tvOSTests */,
+				732D8D691E516780008558BD /* SwiftLint */,
 			);
 		};
 /* End PBXProject section */
@@ -1380,6 +1399,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		732D8D6D1E516789008558BD /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		1F118CD01BDCA4AB005013A2 /* Sources */ = {
@@ -2192,6 +2227,20 @@
 			};
 			name = Release;
 		};
+		732D8D6B1E516780008558BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		732D8D6C1E516780008558BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		DA5663F11A4C8D8500193C88 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2552,6 +2601,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		732D8D6A1E516780008558BD /* Build configuration list for PBXAggregateTarget "SwiftLint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				732D8D6B1E516780008558BD /* Debug */,
+				732D8D6C1E516780008558BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		DA5663F31A4C8D8500193C88 /* Build configuration list for PBXNativeTarget "QuickFocused - macOSTests" */ = {
 			isa = XCConfigurationList;

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -986,7 +986,6 @@
 				1F118CD11BDCA4AB005013A2 /* Frameworks */,
 				1F118CD21BDCA4AB005013A2 /* Headers */,
 				1F118CD31BDCA4AB005013A2 /* Resources */,
-				A870E6171DE00FC7006891AD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1041,7 +1040,6 @@
 				5A5D117819473F2100F6D13D /* Frameworks */,
 				5A5D117919473F2100F6D13D /* Headers */,
 				5A5D117A19473F2100F6D13D /* Resources */,
-				A870E6161DE00E50006891AD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1178,7 +1176,6 @@
 				DAEB6B8A1943873100289F44 /* Frameworks */,
 				DAEB6B8B1943873100289F44 /* Headers */,
 				DAEB6B8C1943873100289F44 /* Resources */,
-				A870E6151DE00E37006891AD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1383,48 +1380,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		A870E6151DE00E37006891AD /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint; fi";
-		};
-		A870E6161DE00E50006891AD /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint; fi";
-		};
-		A870E6171DE00FC7006891AD /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint; fi";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		1F118CD01BDCA4AB005013A2 /* Sources */ = {

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "5A5D117B19473F2100F6D13D"
                BuildableName = "Quick.framework"
                BlueprintName = "Quick-iOS"
+               ReferencedContainer = "container:Quick.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "732D8D691E516780008558BD"
+               BuildableName = "SwiftLint"
+               BlueprintName = "SwiftLint"
                ReferencedContainer = "container:Quick.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "DAEB6B8D1943873100289F44"
                BuildableName = "Quick.framework"
                BlueprintName = "Quick-macOS"
+               ReferencedContainer = "container:Quick.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "732D8D691E516780008558BD"
+               BuildableName = "SwiftLint"
+               BlueprintName = "SwiftLint"
                ReferencedContainer = "container:Quick.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "1F118CD41BDCA4AB005013A2"
                BuildableName = "Quick.framework"
                BlueprintName = "Quick-tvOS"
+               ReferencedContainer = "container:Quick.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "732D8D691E516780008558BD"
+               BuildableName = "SwiftLint"
+               BlueprintName = "SwiftLint"
                ReferencedContainer = "container:Quick.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>


### PR DESCRIPTION
close #693 

## What behavior was changed?
- SwiftLint will be execute only in Test(It isn't executed in Build).

## What I did
- delete SwiftLint Run Script Phase from Quick-macOS/Quick-iOS/Quick-tvOS target.
- add Aggregate to execute SwiftLint Run Script

The reason why I submit this PR is written on #693, so please refer it.
