### PR TITLE
Cache the included example count on Example.run()

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 private var numberOfExamplesRun = 0
+private var numberOfIncludedExamples = 0
 
 /**
     Examples, defined with the `it` function, use assertions to
@@ -57,6 +58,10 @@ final public class Example: NSObject {
     public func run() {
         let world = World.sharedWorld
 
+        if numberOfIncludedExamples == 0 {
+            numberOfIncludedExamples = world.includedExampleCount
+        }
+
         if numberOfExamplesRun == 0 {
             world.suiteHooks.executeBefores()
         }
@@ -82,7 +87,7 @@ final public class Example: NSObject {
 
         numberOfExamplesRun += 1
 
-        if !world.isRunningAdditionalSuites && numberOfExamplesRun >= world.includedExampleCount {
+        if !world.isRunningAdditionalSuites && numberOfExamplesRun >= numberOfIncludedExamples {
             world.suiteHooks.executeAfters()
         }
     }


### PR DESCRIPTION
Due to the fact that world.includedExamples is a computed property that does  a filter on all the tests, performing `numberOfExamplesRun >= world.includedExampleCount` is not very efficient
with a very large number of tests.

This patch caches the result of world.includedExampleCount and uses the cached value to perform the comparison.

Fix #696