### PR TITLE
Enable Swift 3 compatibility mode under Swift 4

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:3.0
+
 import PackageDescription
 
 let package = Package(

--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -22,7 +22,7 @@ let package = Package(
     // be `testDependencies:` instead. For now it has to be done like this for the library to get linked with the test targets.
     // See: https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md
     dependencies: [
-        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 6)
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 7)
     ],
     exclude: {
         var excludes = [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode8.2
+osx_image: xcode8.3
 language: generic
 matrix:
   include:

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:3.0
+
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
See https://github.com/Quick/Nimble/pull/431.

Ideally we should wait for the next Nimble patch release before merging (to avoid pinning `Externals/Nimble` to a branch).