### PR TITLE
Fixed swift example of shared tests for swift 3

### DIFF
--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -18,10 +18,16 @@ import Nimble
 
 class EdibleSharedExamplesConfiguration: QuickConfiguration {
   override class func configure(_ configuration: Configuration) {
-    sharedExamples("something edible") { (sharedExampleContext: SharedExampleContext) in
+    sharedExamples("something edible") { (sharedExampleContext: @escaping SharedExampleContext) in
+
+      var dolphin: Dolpin!
+      var edible: Edible!
+      beforeEach {
+        dolphin = Dolphin(happy: false)
+        edible = sharedExampleContext()["edible"] as! Edible
+      }
+
       it("makes dolphins happy") {
-        let dolphin = Dolphin(happy: false)
-        let edible = sharedExampleContext()["edible"]
         dolphin.eat(edible)
         expect(dolphin.isHappy).to(beTruthy())
       }
@@ -36,7 +42,7 @@ class MackerelSpec: QuickSpec {
       mackerel = Mackerel()
     }
 
-    itBehavesLike("something edible") { ["edible": mackerel] }
+    itBehavesLike("something edible") { ["edible": mackerel!] }
   }
 }
 
@@ -47,7 +53,7 @@ class CodSpec: QuickSpec {
       cod = Cod()
     }
 
-    itBehavesLike("something edible") { ["edible": cod] }
+    itBehavesLike("something edible") { ["edible": cod!] }
   }
 }
 ```


### PR DESCRIPTION
Fixed example for shared tests. The swift example didn't work for me on Xcode 8.3.2 using Swift 3.1. Updated it according to #536 . Also updated the code based on the new behaviour of implicitly unwrapped opitionals in Swift 3 where they are treated as optionals unless explicity declared as implicityly unwrapped at the point of use.