### PR TITLE
Fix NSInternalInconsistencyException when running a test from test navigator

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -68,6 +68,9 @@ final public class Example: NSObject {
 
         let exampleMetadata = ExampleMetadata(example: self, exampleIndex: numberOfExamplesRun)
         world.currentExampleMetadata = exampleMetadata
+        defer {
+            world.currentExampleMetadata = nil
+        }
 
         world.exampleHooks.executeBefores(exampleMetadata)
         group!.phase = .beforesExecuting


### PR DESCRIPTION
If you select only one test case to run in xcode test navigator, the test can fail with error:
```
'NSInternalInconsistencyException', reason: ''beforeEach' cannot be used inside 'it', 'beforeEach' may only be used inside 'context' or 'describe'. ', userInfo: '(null)'
```

During test run `world.currentExampleMetadata` is set to current example, but it's never cleared. So once an example runs, no `beforeEach` can be called after it.

 - What behavior was changed?
Before the example finishes running, clear Clear world.currentExampleMetadata.
 - What code was refactored / updated to support this change?
Example.run()
 - What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
