### PR TITLE
Updated main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,22 @@ Certain versions of Quick and Nimble only support certain versions of Swift. Dep
 All documentation can be found in the [Documentation folder](./Documentation), including [detailed installation instructions](./Documentation/en-us/InstallingQuick.md) for CocoaPods, Carthage, Git submodules, and more. For example, you can install Quick and [Nimble](https://github.com/Quick/Nimble) using CocoaPods by adding the following to your Podfile:
 
 ```rb
+
 # Podfile
 
 use_frameworks!
 
-target "MyApp" do
-  # Normal libraries
-
-  abstract_target 'Tests' do
-    inherit! :search_paths
-    target "MyAppTests"
-    target "MyAppUITests"
-
+def testing_pods
     pod 'Quick'
     pod 'Nimble'
-  end
+end
+
+target 'MyTests' do
+    testing_pods
+end
+
+target 'MyUITests' do
+    testing_pods
 end
 ```
 


### PR DESCRIPTION
Updated main README.md, 'installing quick and nimble instructions using CocoaPods' to match current installation instructions found in InstallingQuick.md. This update will create consistency in the documentation for those who are new to Quick. I've also found that the current instructions under README.md do not work on my machine and gave me the following error: 
[!] Invalid `Podfile` file: [!] Cannot set inheritance for abstract target definition.

