### PR TITLE
Avoid using `#if _runtime(_ObjC)` check

### DIFF
--- a/Sources/Quick/Configuration/Configuration.swift
+++ b/Sources/Quick/Configuration/Configuration.swift
@@ -72,7 +72,7 @@ final public class Configuration: NSObject {
         provided with metadata on the example that the closure is being run
         prior to.
     */
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(beforeEachWithMetadata:)
     public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         exampleHooks.appendBefore(closure)
@@ -109,7 +109,7 @@ final public class Configuration: NSObject {
         is provided with metadata on the example that the closure is being
         run after.
     */
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(afterEachWithMetadata:)
     public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
         exampleHooks.appendAfter(closure)

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -10,7 +10,7 @@ open class QuickConfiguration: NSObject {
     open class func configure(_ configuration: Configuration) {}
 }
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.Type) -> Void) {
     var classesCount = objc_getClassList(nil, 0)

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -56,7 +56,7 @@ extension World {
         currentExampleGroup.hooks.appendBefore(closure)
     }
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(beforeEachWithMetadata:)
     internal func beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
         currentExampleGroup.hooks.appendBefore(closure)
@@ -74,7 +74,7 @@ extension World {
         currentExampleGroup.hooks.appendAfter(closure)
     }
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(afterEachWithMetadata:)
     internal func afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
         currentExampleGroup.hooks.appendAfter(closure)
@@ -167,7 +167,7 @@ extension World {
         self.itBehavesLike(behavior, context: context, flags: pendingFlags, file: file, line: line)
     }
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(itWithDescription:flags:file:line:closure:)
     private func objc_it(_ description: String, flags: FilterFlags, file: String, line: UInt, closure: @escaping () -> Void) {
         it(description, flags: flags, file: file, line: line, closure: closure)

--- a/Sources/Quick/ErrorUtility.swift
+++ b/Sources/Quick/ErrorUtility.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal func raiseError(_ message: String) -> Never {
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     NSException(name: .internalInconsistencyException, reason: message, userInfo: nil).raise()
 #endif
 

--- a/Sources/Quick/NSBundle+CurrentTestBundle.swift
+++ b/Sources/Quick/NSBundle+CurrentTestBundle.swift
@@ -1,4 +1,4 @@
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
 import Foundation
 

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -1,4 +1,4 @@
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 
 public extension NSString {

--- a/Sources/Quick/QuickSelectedTestSuiteBuilder.swift
+++ b/Sources/Quick/QuickSelectedTestSuiteBuilder.swift
@@ -1,4 +1,4 @@
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 
 /**

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -5,7 +5,7 @@ import XCTest
 
 #if SWIFT_PACKAGE
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import QuickSpecBase
 
 public typealias QuickSpecBase = _QuickSpecBase
@@ -16,7 +16,7 @@ public typealias QuickSpecBase = XCTestCase
 open class QuickSpec: QuickSpecBase {
     open func spec() {}
 
-#if !_runtime(_ObjC)
+#if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
     public required init() {
         super.init(name: "", testClosure: { _ in })
     }

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -1,4 +1,4 @@
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
 import XCTest
 

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -44,7 +44,7 @@ final internal class World: NSObject {
         within this test suite. This is only true within the context of Quick
         functional tests.
     */
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     // Convention of generating Objective-C selector has been changed on Swift 3
     @objc(isRunningAdditionalSuites)
     internal var isRunningAdditionalSuites = false
@@ -144,7 +144,7 @@ final internal class World: NSObject {
         }
     }
 
-#if _runtime(_ObjC)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     @objc(examplesForSpecClass:)
     private func objc_examples(_ specClass: AnyClass) -> [Example] {
         return examples(specClass)

--- a/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
+++ b/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
@@ -30,7 +30,7 @@ public extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
     }
 }
 
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     extension XCTestCase {
         override open func tearDown() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -50,7 +50,7 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
                 afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
             }
         }
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including afterEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -35,7 +35,7 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
                 beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
             }
         }
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including beforeEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -17,7 +17,7 @@ class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
     }
 }
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 class FunctionalTests_BehaviorTests_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Quick
 import Nimble
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 class QuickContextTests: QuickSpec {
     override func spec() {
         describe("Context") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 import Quick
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
 final class DescribeTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (DescribeTests) -> () throws -> Void)] {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -16,7 +16,7 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(name))
         }
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
         describe("when an example has a unique name") {
             it("has a unique name") {}
@@ -113,7 +113,7 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
         XCTAssertEqual(result?.executionCount, 10 as UInt)

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -15,7 +15,7 @@ class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
     }
 }
 
-#if _runtime(_ObjC) && !SWIFT_PACKAGE
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {


### PR DESCRIPTION
Use `#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)` instead.

See #718 for the details.