### PR TITLE
RFC: Introduce 'qck' tool

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,2 @@
+set expandtab
+set ts=4 sts=4 sw=4

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -5,13 +5,25 @@ import PackageDescription
 let package = Package(
     name: "Quick",
     products: [
+        .executable(name: "qck", targets: ["qck"]),
         .library(name: "Quick", targets: ["Quick"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/kylef/Commander.git", from: "0.6.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
     ],
     targets: {
         var targets: [Target] = [
+            .target(
+                name: "qck",
+                dependencies: [
+                    "Commander",
+                    "Cpaths",
+                    "PathKit",
+                ]
+            ),
+            .target(name: "Cpaths", dependencies: []),
             .testTarget(
                 name: "QuickTests",
                 dependencies: [ "Quick", "Nimble" ],

--- a/Sources/Cpaths/include/shim.h
+++ b/Sources/Cpaths/include/shim.h
@@ -1,0 +1,1 @@
+#include <paths.h>

--- a/Sources/Cpaths/paths.c
+++ b/Sources/Cpaths/paths.c
@@ -1,0 +1,5 @@
+int
+qck_paths_stub(void)
+{
+  return 0;
+}

--- a/Sources/qck/Dictionary+grouped.swift
+++ b/Sources/qck/Dictionary+grouped.swift
@@ -1,0 +1,11 @@
+extension Sequence {
+  func grouped<Key: Hashable, Value>() -> [Key: [Value]] where Iterator.Element == Dictionary<Key, Value>.Iterator.Element {
+    var grouped: [Key: [Value]] = [:]
+    for (key, value) in self {
+      var values = grouped[key] ?? []
+      values.append(value)
+      grouped[key] = values
+    }
+    return grouped
+  }
+}

--- a/Sources/qck/QckError.swift
+++ b/Sources/qck/QckError.swift
@@ -17,5 +17,6 @@ extension QckError {
     return QckError(message: "\(name): Command not found.")
   }
 
+  static let internalError = QckError(message: "Unexpected error.")
   static let notAPackage = QckError(message: "The current directory is not a Swift package.")
 }

--- a/Sources/qck/QckError.swift
+++ b/Sources/qck/QckError.swift
@@ -1,0 +1,21 @@
+struct QckError: Error {
+  let message: String
+}
+
+extension QckError: CustomStringConvertible {
+  var description: String {
+    return message
+  }
+}
+
+extension QckError {
+  static func badEncoding(expected encoding: String.Encoding) -> QckError {
+    return QckError(message: "Bad encoding: expected \(encoding)")
+  }
+
+  static func commandNotFound(_ name: String) -> QckError {
+    return QckError(message: "\(name): Command not found.")
+  }
+
+  static let notAPackage = QckError(message: "The current directory is not a Swift package.")
+}

--- a/Sources/qck/String+lines.swift
+++ b/Sources/qck/String+lines.swift
@@ -1,0 +1,19 @@
+extension String {
+  var lines: LazySequence<AnySequence<String>> {
+    return AnySequence { () -> AnyIterator<String> in
+      var searchRange = self.startIndex..<self.endIndex
+
+      return AnyIterator {
+        var nextLine: String?
+
+        self.enumerateSubstrings(in: searchRange, options: .byLines) { line, _, lineRange, stop in
+          nextLine = line
+          searchRange = lineRange.upperBound..<searchRange.upperBound
+          stop = true
+        }
+
+        return nextLine
+      }
+    }.lazy
+  }
+}

--- a/Sources/qck/TestCaseGroup.swift
+++ b/Sources/qck/TestCaseGroup.swift
@@ -1,0 +1,51 @@
+enum TestCaseGroup: String {
+  case configurations
+  case specs
+  case testCases
+
+  static let all: [TestCaseGroup] = [.specs, .configurations, .testCases]
+
+  init?(baseClass: String) {
+    if baseClass == "QuickConfiguration" {
+      self = .configurations
+    } else if baseClass.hasSuffix("Spec") {
+      self = .specs
+    } else if baseClass.hasSuffix("TestCase") {
+      self = .testCases
+    } else {
+      return nil
+    }
+  }
+
+  func description(for classes: [String]) -> String {
+    var lines: [String] = []
+
+    if let label = parameterLabel {
+      lines.append("\(label): [")
+    } else {
+      lines.append("[")
+    }
+
+    for name in classes {
+      switch self {
+      case .specs, .configurations:
+        lines.append("    \(name).self,")
+      case .testCases:
+        lines.append("    testCase(\(name).allTests),")
+      }
+    }
+
+    lines.append("]")
+
+    return lines.joined(separator: "\n")
+  }
+
+  var parameterLabel: String? {
+    switch self {
+    case .configurations, .testCases:
+      return rawValue
+    case .specs:
+      return nil
+    }
+  }
+}

--- a/Sources/qck/executable.swift
+++ b/Sources/qck/executable.swift
@@ -1,0 +1,10 @@
+import Cpaths
+import Foundation
+import PathKit
+
+func executable(named name: String) -> Path? {
+  let path = ProcessInfo.processInfo.environment["PATH"] ?? _PATH_DEFPATH
+  let components = path.split(separator: ":").lazy.map { String($0) }
+  let candidates = components.map { Path($0) + "find" }
+  return candidates.first { $0.isExecutable }?.normalize()
+}

--- a/Sources/qck/generateMain.swift
+++ b/Sources/qck/generateMain.swift
@@ -1,0 +1,25 @@
+import PathKit
+
+func generateMain() throws {
+  let testRoot = try packageRoot() + "Tests"
+
+  let io = try popen([
+    "find",
+    testRoot.string,
+    "-name", "*.swift",
+    "-exec", "sed", "-nE", "s/^.*class[[:space:]]+([[:alnum:]_]+(Spec|Tests))[[:>:]].*/\\1/p", "{}", ";",
+  ])
+
+  let data = io.output.readDataToEndOfFile()
+  guard let output = String(data: data, encoding: .utf8) else {
+    throw QckError.badEncoding(expected: .utf8)
+  }
+
+  print("import Quick")
+  print()
+  print("QCKMain([")
+  for spec in output.lines.sorted() {
+    print("  \(spec).self,")
+  }
+  print("])")
+}

--- a/Sources/qck/generateMain.swift
+++ b/Sources/qck/generateMain.swift
@@ -28,8 +28,20 @@ func generateMain() throws {
     throw QckError.badEncoding(expected: .utf8)
   }
 
+  let testModules = try testRoot.children().filter { path in
+    path.isDirectory && path.lastComponent.hasSuffix("Tests")
+  }
+
   print("import Quick")
   print()
+
+  if testModules.count > 0 {
+    for module in testModules {
+      print("@testable import \(module.lastComponent)")
+    }
+    print()
+  }
+
   print("QCKMain([")
   for spec in output.lines.sorted() {
     print("  \(spec).self,")

--- a/Sources/qck/generateMain.swift
+++ b/Sources/qck/generateMain.swift
@@ -19,6 +19,11 @@ func generateMain() throws {
   ])
 
   let data = io.output.readDataToEndOfFile()
+
+  guard io.process.terminationStatus == 0 else {
+    throw QckError.internalError
+  }
+
   guard let output = String(data: data, encoding: .utf8) else {
     throw QckError.badEncoding(expected: .utf8)
   }

--- a/Sources/qck/generateMain.swift
+++ b/Sources/qck/generateMain.swift
@@ -1,5 +1,13 @@
 import PathKit
 
+private enum Pattern {
+  static let space = "[[:space:]]"
+  static let identifier = "[[:alnum:]_]+"
+  static let className = "class\(space)+(\(identifier))"
+  static let baseClass = "(\(identifier)(Configuration|Spec|TestCase))"
+  static let testClassDeclaration = "\(className)\(space)*:\(space)*\(baseClass)"
+}
+
 func generateMain() throws {
   let testRoot = try packageRoot() + "Tests"
 
@@ -7,7 +15,7 @@ func generateMain() throws {
     "find",
     testRoot.string,
     "-name", "*.swift",
-    "-exec", "sed", "-nE", "s/^.*class[[:space:]]+([[:alnum:]_]+(Spec|Tests))[[:>:]].*/\\1/p", "{}", ";",
+    "-exec", "sed", "-nE", "s/^.*\(Pattern.testClassDeclaration).*$/\\1/p", "{}", ";",
   ])
 
   let data = io.output.readDataToEndOfFile()

--- a/Sources/qck/main.swift
+++ b/Sources/qck/main.swift
@@ -1,0 +1,7 @@
+import Commander
+
+let main = Group {
+  $0.command("generate-main", generateMain)
+}
+
+main.run()

--- a/Sources/qck/packageRoot.swift
+++ b/Sources/qck/packageRoot.swift
@@ -1,0 +1,21 @@
+import PathKit
+
+func packageRoot(relativeTo path: Path = .current) throws -> Path {
+  var path = path
+  var found: Path?
+
+  repeat {
+    let isPackageDirectory = try path.children().contains { $0.lastComponent == "Package.swift" }
+
+    if isPackageDirectory {
+      found = path
+      break
+    }
+
+    path = path.parent()
+  } while path != "/"
+
+  guard let root = found else { throw QckError.notAPackage }
+
+  return root
+}

--- a/Sources/qck/popen.swift
+++ b/Sources/qck/popen.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+func popen(_ command: [String]) throws -> (process: Process, output: FileHandle) {
+  precondition(command.count > 0, "invalid command")
+  var arguments = command
+  var path = arguments.removeFirst()
+
+  if !path.contains("/") {
+    guard let found = executable(named: path) else { throw QckError.commandNotFound(path) }
+    path = found.string
+  }
+
+  let output = Pipe()
+  let process = Process()
+  process.launchPath = path
+  process.arguments = arguments
+  process.standardOutput = output
+
+  process.launch()
+
+  return (process, output.fileHandleForReading)
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,45 +1,51 @@
-import XCTest
 import Quick
+import XCTest
 
 @testable import QuickTests
 
 Quick.QCKMain([
-    FunctionalTests_AfterEachSpec.self,
     AfterSuiteTests.self,
+    BundleModuleNameSpecs.self,
+    Configuration_AfterEachSpec.self,
+    Configuration_BeforeEachSpec.self,
+    FunctionalTests_AfterEachSpec.self,
     FunctionalTests_BeforeEachSpec.self,
     FunctionalTests_BeforeSuite_BeforeSuiteSpec.self,
     FunctionalTests_BeforeSuite_Spec.self,
+    FunctionalTests_BehaviorTests_ContextSpec.self,
+    FunctionalTests_BehaviorTests_ErrorSpec.self,
+    FunctionalTests_BehaviorTests_Spec.self,
+    FunctionalTests_CrossReferencingSpecA.self,
+    FunctionalTests_CrossReferencingSpecB.self,
     FunctionalTests_ItSpec.self,
     FunctionalTests_PendingSpec.self,
     FunctionalTests_SharedExamples_BeforeEachSpec.self,
-    FunctionalTests_SharedExamples_Spec.self,
     FunctionalTests_SharedExamples_ContextSpec.self,
-    Configuration_AfterEachSpec.self,
-    Configuration_BeforeEachSpec.self,
-    FunctionalTests_CrossReferencingSpecA.self,
-    FunctionalTests_CrossReferencingSpecB.self,
+    FunctionalTests_SharedExamples_ErrorSpec.self,
+    FunctionalTests_SharedExamples_Spec.self,
+    QuickContextTests.self,
+    QuickDescribeTests.self,
     _FunctionalTests_FocusedSpec_Focused.self,
-    _FunctionalTests_FocusedSpec_Unfocused.self
+    _FunctionalTests_FocusedSpec_Unfocused.self,
 ],
 configurations: [
-    FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,
-    FunctionalTests_SharedExamplesTests_SharedExamples.self,
     FunctionalTests_Configuration_AfterEach.self,
     FunctionalTests_Configuration_BeforeEach.self,
-    FunctionalTests_FocusedSpec_SharedExamplesConfiguration.self
+    FunctionalTests_FocusedSpec_SharedExamplesConfiguration.self,
+    FunctionalTests_SharedExamplesTests_SharedExamples.self,
+    FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,
 ],
 testCases: [
     testCase(AfterEachTests.allTests),
     testCase(BeforeEachTests.allTests),
     testCase(BeforeSuiteTests.allTests),
-    // testCase(DescribeTests.allTests),
-    testCase(ItTests.allTests),
-    testCase(PendingTests.allTests),
-    testCase(SharedExamples_BeforeEachTests.allTests),
-    testCase(SharedExamplesTests.allTests),
+    testCase(BehaviorTests.allTests),
     testCase(Configuration_AfterEachTests.allTests),
     testCase(Configuration_BeforeEachTests.allTests),
+    testCase(DescribeTests.allTests),
     testCase(FocusedTests.allTests),
-    testCase(FunctionalTests_CrossReferencingSpecA.allTests),
-    testCase(FunctionalTests_CrossReferencingSpecB.allTests)
+    testCase(ItTests.allTests),
+    testCase(PendingTests.allTests),
+    testCase(SharedExamplesTests.allTests),
+    testCase(SharedExamples_BeforeEachTests.allTests),
 ])


### PR DESCRIPTION
I think it would be pretty cool for Quick to ship a command line tool to automate some common tasks. This PR is a working example of one of the ideas I've had: it generates a `LinuxMain.swift` file for you. To demonstrate it in use, this change regenerates Quick's own `LinuxMain.swift` file. This change builds on #721, and currently only builds under Swift 4 (because `swift run` is super great, and I haven't touched the Swift 3 manifest).

I chose the name `qck` because `quick` would conflict with the framework name (case insensitivity!).

Here are a couple of other (poorly thought out) ideas for what a command line tool could do:

- Generate templates for new specs
- Generate a randomized `LinuxMain`
- Format test output
- Run tests outside of XCTest??

In any case, until `LinuxMain.swift` is deprecated, this seems like a useful tool for automation on Linux.

Thoughts?