### PR TITLE
Make quick swiftlint compatible

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,7 +3,6 @@ disabled_rules:
   - type_name
   - valid_docs
   - function_body_length
-  - variable_name
 included:
   - Sources
   - Tests

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,6 @@
 disabled_rules:
   - line_length
   - type_name
-  - valid_docs
   - function_body_length
 included:
   - Sources

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,8 +24,8 @@ Quick.QCKMain([
 configurations: [
     FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,
     FunctionalTests_SharedExamplesTests_SharedExamples.self,
-    FunctionalTests_Configuration_AfterEach.self,
-    FunctionalTests_Configuration_BeforeEach.self,
+    FunctionalTestsConfigurationAfterEach.self,
+    FunctionalTestsConfigurationBeforeEach.self,
     FunctionalTests_FocusedSpec_SharedExamplesConfiguration.self
 ],
 testCases: [

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -76,7 +76,7 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
         afterEachOrder = []
 
         qck_runSpec(FunctionalTests_AfterEachSpec.self)
-		let expectedOrder: [AfterEachType] = [
+        let expectedOrder: [AfterEachType] = [
             // [1] The outer afterEach closures are executed from top to bottom.
             .outerOne, .outerTwo, .outerThree,
             // [2] The outer afterEach closures are executed from top to bottom.

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -3,12 +3,12 @@ import Quick
 import Nimble
 
 private enum AfterEachType {
-    case OuterOne
-    case OuterTwo
-    case OuterThree
-    case InnerOne
-    case InnerTwo
-    case NoExamples
+    case outerOne
+    case outerTwo
+    case outerThree
+    case innerOne
+    case innerTwo
+    case noExamples
 }
 
 private var afterEachOrder = [AfterEachType]()
@@ -16,9 +16,9 @@ private var afterEachOrder = [AfterEachType]()
 class FunctionalTests_AfterEachSpec: QuickSpec {
     override func spec() {
         describe("afterEach ordering") {
-            afterEach { afterEachOrder.append(AfterEachType.OuterOne) }
-            afterEach { afterEachOrder.append(AfterEachType.OuterTwo) }
-            afterEach { afterEachOrder.append(AfterEachType.OuterThree) }
+            afterEach { afterEachOrder.append(.outerOne) }
+            afterEach { afterEachOrder.append(.outerTwo) }
+            afterEach { afterEachOrder.append(.outerThree) }
 
             it("executes the outer afterEach closures once, but not before this closure [1]") {
                 // No examples have been run, so no afterEach will have been run either.
@@ -29,25 +29,25 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
             it("executes the outer afterEach closures a second time, but not before this closure [2]") {
                 // The afterEach for the previous example should have been run.
                 // The list should contain the afterEach for that example, executed from top to bottom.
-                expect(afterEachOrder).to(equal([AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree]))
+                expect(afterEachOrder).to(equal([.outerOne, .outerTwo, .outerThree]))
             }
 
             context("when there are nested afterEach") {
-                afterEach { afterEachOrder.append(AfterEachType.InnerOne) }
-                afterEach { afterEachOrder.append(AfterEachType.InnerTwo) }
+                afterEach { afterEachOrder.append(.innerOne) }
+                afterEach { afterEachOrder.append(.innerTwo) }
 
                 it("executes the outer and inner afterEach closures, but not before this closure [3]") {
                     // The afterEach for the previous two examples should have been run.
                     // The list should contain the afterEach for those example, executed from top to bottom.
                     expect(afterEachOrder).to(equal([
-                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
-                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree
+                        .outerOne, .outerTwo, .outerThree,
+                        .outerOne, .outerTwo, .outerThree
                         ]))
                 }
             }
 
             context("when there are nested afterEach without examples") {
-                afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
+                afterEach { afterEachOrder.append(.noExamples) }
             }
         }
 #if _runtime(_ObjC) && !SWIFT_PACKAGE
@@ -76,15 +76,14 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
         afterEachOrder = []
 
         qck_runSpec(FunctionalTests_AfterEachSpec.self)
-        let expectedOrder = [
+		let expectedOrder: [AfterEachType] = [
             // [1] The outer afterEach closures are executed from top to bottom.
-            AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+            .outerOne, .outerTwo, .outerThree,
             // [2] The outer afterEach closures are executed from top to bottom.
-            AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+            .outerOne, .outerTwo, .outerThree,
             // [3] The inner afterEach closures are executed from top to bottom,
             //     then the outer afterEach closures are executed from top to bottom.
-            AfterEachType.InnerOne, AfterEachType.InnerTwo,
-                AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree
+            .innerOne, .innerTwo, .outerOne, .outerTwo, .outerThree
         ]
         XCTAssertEqual(afterEachOrder, expectedOrder)
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -61,7 +61,7 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
         beforeEachOrder = []
 
         qck_runSpec(FunctionalTests_BeforeEachSpec.self)
-		let expectedOrder: [BeforeEachType] = [
+        let expectedOrder: [BeforeEachType] = [
             // [1] The outer beforeEach closures are executed from top to bottom.
             .outerOne, .outerTwo,
             // [2] The outer beforeEach closures are executed from top to bottom.

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -3,12 +3,12 @@ import Quick
 import Nimble
 
 private enum BeforeEachType {
-    case OuterOne
-    case OuterTwo
-    case InnerOne
-    case InnerTwo
-    case InnerThree
-    case NoExamples
+    case outerOne
+    case outerTwo
+    case innerOne
+    case innerTwo
+    case innerThree
+    case noExamples
 }
 
 private var beforeEachOrder = [BeforeEachType]()
@@ -17,22 +17,22 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
     override func spec() {
 
         describe("beforeEach ordering") {
-            beforeEach { beforeEachOrder.append(BeforeEachType.OuterOne) }
-            beforeEach { beforeEachOrder.append(BeforeEachType.OuterTwo) }
+            beforeEach { beforeEachOrder.append(.outerOne) }
+            beforeEach { beforeEachOrder.append(.outerTwo) }
 
             it("executes the outer beforeEach closures once [1]") {}
             it("executes the outer beforeEach closures a second time [2]") {}
 
             context("when there are nested beforeEach") {
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerOne) }
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerTwo) }
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerThree) }
+                beforeEach { beforeEachOrder.append(.innerOne) }
+                beforeEach { beforeEachOrder.append(.innerTwo) }
+                beforeEach { beforeEachOrder.append(.innerThree) }
 
                 it("executes the outer and inner beforeEach closures [3]") {}
             }
 
             context("when there are nested beforeEach without examples") {
-                beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
+                beforeEach { beforeEachOrder.append(.noExamples) }
             }
         }
 #if _runtime(_ObjC) && !SWIFT_PACKAGE
@@ -61,15 +61,14 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
         beforeEachOrder = []
 
         qck_runSpec(FunctionalTests_BeforeEachSpec.self)
-        let expectedOrder = [
+		let expectedOrder: [BeforeEachType] = [
             // [1] The outer beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
+            .outerOne, .outerTwo,
             // [2] The outer beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
+            .outerOne, .outerTwo,
             // [3] The outer beforeEach closures are executed from top to bottom,
             //     then the inner beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
-                BeforeEachType.InnerOne, BeforeEachType.InnerTwo, BeforeEachType.InnerThree
+            .outerOne, .outerTwo, .innerOne, .innerTwo, .innerThree
         ]
         XCTAssertEqual(beforeEachOrder, expectedOrder)
     }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEach.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEach.swift
@@ -1,7 +1,7 @@
 import Quick
 
 class FunctionalTestsConfigurationAfterEach: QuickConfiguration {
-	static public var wasExecuted = false
+    static var wasExecuted = false
     override class func configure(_ configuration: Configuration) {
         configuration.afterEach {
             wasExecuted = true

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEach.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEach.swift
@@ -1,11 +1,10 @@
 import Quick
 
-public var FunctionalTests_Configuration_AfterEachWasExecuted = false
-
-class FunctionalTests_Configuration_AfterEach: QuickConfiguration {
+class FunctionalTestsConfigurationAfterEach: QuickConfiguration {
+	static public var wasExecuted = false
     override class func configure(_ configuration: Configuration) {
         configuration.afterEach {
-            FunctionalTests_Configuration_AfterEachWasExecuted = true
+            wasExecuted = true
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachTests.swift
@@ -5,10 +5,10 @@ import Nimble
 class Configuration_AfterEachSpec: QuickSpec {
     override func spec() {
         beforeEach {
-            FunctionalTests_Configuration_AfterEachWasExecuted = false
+            FunctionalTestsConfigurationAfterEach.wasExecuted = false
         }
         it("is executed before the configuration afterEach") {
-            expect(FunctionalTests_Configuration_AfterEachWasExecuted).to(beFalsy())
+            expect(FunctionalTestsConfigurationAfterEach.wasExecuted).to(beFalsy())
         }
     }
 }
@@ -21,11 +21,11 @@ final class Configuration_AfterEachTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted() {
-        FunctionalTests_Configuration_AfterEachWasExecuted = false
+        FunctionalTestsConfigurationAfterEach.wasExecuted = false
 
         qck_runSpec(Configuration_BeforeEachSpec.self)
-        XCTAssert(FunctionalTests_Configuration_AfterEachWasExecuted)
+        XCTAssert(FunctionalTestsConfigurationAfterEach.wasExecuted)
 
-        FunctionalTests_Configuration_AfterEachWasExecuted = false
+        FunctionalTestsConfigurationAfterEach.wasExecuted = false
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEach.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEach.swift
@@ -1,7 +1,7 @@
 import Quick
 
 class FunctionalTestsConfigurationBeforeEach: QuickConfiguration {
-	static public var wasExecuted = false
+    static var wasExecuted = false
     override class func configure(_ configuration: Configuration) {
         configuration.beforeEach {
             wasExecuted = true

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEach.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEach.swift
@@ -1,11 +1,10 @@
 import Quick
 
-public var FunctionalTests_Configuration_BeforeEachWasExecuted = false
-
-class FunctionalTests_Configuration_BeforeEach: QuickConfiguration {
+class FunctionalTestsConfigurationBeforeEach: QuickConfiguration {
+	static public var wasExecuted = false
     override class func configure(_ configuration: Configuration) {
         configuration.beforeEach {
-            FunctionalTests_Configuration_BeforeEachWasExecuted = true
+            wasExecuted = true
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachTests.swift
@@ -5,7 +5,7 @@ import Nimble
 class Configuration_BeforeEachSpec: QuickSpec {
     override func spec() {
         it("is executed after the configuration beforeEach") {
-            expect(FunctionalTests_Configuration_BeforeEachWasExecuted).to(beTruthy())
+            expect(FunctionalTestsConfigurationBeforeEach.wasExecuted).to(beTruthy())
         }
     }
 }
@@ -18,11 +18,11 @@ final class Configuration_BeforeEachTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted() {
-        FunctionalTests_Configuration_BeforeEachWasExecuted = false
+        FunctionalTestsConfigurationBeforeEach.wasExecuted = false
 
         qck_runSpec(Configuration_BeforeEachSpec.self)
-        XCTAssert(FunctionalTests_Configuration_BeforeEachWasExecuted)
+        XCTAssert(FunctionalTestsConfigurationBeforeEach.wasExecuted)
 
-        FunctionalTests_Configuration_BeforeEachWasExecuted = false
+        FunctionalTestsConfigurationBeforeEach.wasExecuted = false
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -67,8 +67,8 @@ class FunctionalTests_ItSpec: QuickSpec {
                 var exception: NSException?
 
                 beforeEach {
-                    let capture = NMBExceptionCapture(handler: ({ e in
-                        exception = e
+                    let capture = NMBExceptionCapture(handler: ({ capturedException in
+                        exception = capturedException
                     }), finally: nil)
 
                     capture.tryBlock {
@@ -87,8 +87,8 @@ class FunctionalTests_ItSpec: QuickSpec {
                 var exception: NSException?
 
                 afterEach {
-                    let capture = NMBExceptionCapture(handler: ({ e in
-                        exception = e
+                    let capture = NMBExceptionCapture(handler: ({ capturedException in
+                        exception = capturedException
                         expect(exception).toNot(beNil())
                         expect(exception!.reason).to(equal("'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'. "))
                     }), finally: nil)

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -3,7 +3,7 @@ import Quick
 import Nimble
 
 var oneExampleBeforeEachExecutedCount = 0
-var onlyPendingExamplesBeforeEachExecutedCount = 0
+var pendingExamplesBeforeEachExecutedCount = 0
 
 class FunctionalTests_PendingSpec_Behavior: Behavior<Void> {
     override static func spec(_ aContext: @escaping () -> Void) {
@@ -25,7 +25,7 @@ class FunctionalTests_PendingSpec: QuickSpec {
         }
 
         describe("a describe block containing only pending examples") {
-            beforeEach { onlyPendingExamplesBeforeEachExecutedCount += 1 }
+            beforeEach { pendingExamplesBeforeEachExecutedCount += 1 }
             pending("an example that will not run") {}
         }
     }
@@ -53,9 +53,9 @@ final class PendingTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples() {
-        onlyPendingExamplesBeforeEachExecutedCount = 0
+        pendingExamplesBeforeEachExecutedCount = 0
 
         qck_runSpec(FunctionalTests_PendingSpec.self)
-        XCTAssertEqual(onlyPendingExamplesBeforeEachExecutedCount, 0)
+        XCTAssertEqual(pendingExamplesBeforeEachExecutedCount, 0)
     }
 }


### PR DESCRIPTION
Related to #641.

Remove `variable_name` and `valid_docs` from disabled rules.