### PR TITLE
[gardening] Remove redundant OS checks

### DIFF
--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -50,7 +50,7 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
                 afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
             }
         }
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including afterEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -35,7 +35,7 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
                 beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
             }
         }
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including beforeEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -17,7 +17,7 @@ class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
     }
 }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 class FunctionalTests_BehaviorTests_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Quick
 import Nimble
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 class QuickContextTests: QuickSpec {
     override func spec() {
         describe("Context") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 import Quick
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 
 final class DescribeTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (DescribeTests) -> () throws -> Void)] {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -16,8 +16,7 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(name))
         }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
-
+#if !SWIFT_PACKAGE
         describe("when an example has a unique name") {
             it("has a unique name") {}
 
@@ -113,7 +112,7 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
         XCTAssertEqual(result?.executionCount, 10 as UInt)

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -15,7 +15,7 @@ class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
     }
 }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {


### PR DESCRIPTION
`#if !SWIFT_PACKAGE` should be sufficient for those cases.

Just a minor refactoring.