### PR TITLE
Fix: Compile with Xcode 9 and Swift 4

### DIFF
--- a/Sources/Quick/Callsite.swift
+++ b/Sources/Quick/Callsite.swift
@@ -8,12 +8,12 @@ final public class Callsite: NSObject {
     /**
         The absolute path of the file in which an example is defined.
     */
-    public let file: String
+    @objc public let file: String
 
     /**
         The line number on which an example is defined.
     */
-    public let line: UInt
+    @objc public let line: UInt
 
     internal init(file: String, line: UInt) {
         self.file = file

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -12,14 +12,14 @@ final public class Example: NSObject {
         A boolean indicating whether the example is a shared example;
         i.e.: whether it is an example defined with `itBehavesLike`.
     */
-    public var isSharedExample = false
+    @objc public var isSharedExample = false
 
     /**
         The site at which the example is defined.
         This must be set correctly in order for Xcode to highlight
         the correct line in red when reporting a failure.
     */
-    public var callsite: Callsite
+    @objc public var callsite: Callsite
 
     weak internal var group: ExampleGroup?
 
@@ -46,7 +46,7 @@ final public class Example: NSObject {
         The example name is used to generate a test method selector
         to be displayed in Xcode's test navigator.
     */
-    public var name: String {
+    @objc public var name: String {
         guard let groupName = group?.name else { return description }
         return "\(groupName), \(description)"
     }
@@ -55,7 +55,7 @@ final public class Example: NSObject {
         Executes the example closure, as well as all before and after
         closures defined in the its surrounding example groups.
     */
-    public func run() {
+    @objc public func run() {
         let world = World.sharedWorld
 
         if numberOfIncludedExamples == 0 {

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -36,7 +36,7 @@ public class QuickTestSuite: XCTestSuite {
      It is expected that the first call should return a valid test suite, and
      all subsequent calls should return `nil`.
      */
-    public static func selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
+    @objc public static func selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
         guard let builder = QuickSelectedTestSuiteBuilder(forTestCaseWithName: name) else { return nil }
 
         let (inserted, _) = builtTestSuites.insert(builder.testSuiteClassName)


### PR DESCRIPTION
This PR allows Quick to be build with Xcode 9 and Swift 4

When using `pod 'Quick'` I end up with a number of compile errors under Xcode 9 with Swift 4 enabled and without the Swift 3 inference of `@objc`.

Using
```
pod 'Quick', :git => 'https://github.com/hashier/Quick.git', :branch => 'swift-4'
```
works well for me (it compiles, there are still lots of @objc missing to actually make it work)