### PR TITLE
Fix running tests with Swift 4 / Xcode 9 beta 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       sudo: required
       dist: trusty
       env:
-        - SWIFT_VERSION=4.0-DEVELOPMENT-SNAPSHOT-2017-07-25-a
+        - SWIFT_VERSION=4.0-DEVELOPMENT-SNAPSHOT-2017-08-21-a
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then ./script/travis-install-macos; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./script/travis-install-linux; fi

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -2403,6 +2403,7 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2447,6 +2448,7 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Sources/Quick/Callsite.swift
+++ b/Sources/Quick/Callsite.swift
@@ -8,12 +8,22 @@ final public class Callsite: NSObject {
     /**
         The absolute path of the file in which an example is defined.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public let file: String
+    #else
+    public let file: String
+    #endif
 
     /**
         The line number on which an example is defined.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public let line: UInt
+    #else
+    public let line: UInt
+    #endif
 
     internal init(file: String, line: UInt) {
         self.file = file

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -12,14 +12,24 @@ final public class Example: NSObject {
         A boolean indicating whether the example is a shared example;
         i.e.: whether it is an example defined with `itBehavesLike`.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public var isSharedExample = false
+    #else
+    public var isSharedExample = false
+    #endif
 
     /**
         The site at which the example is defined.
         This must be set correctly in order for Xcode to highlight
         the correct line in red when reporting a failure.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public var callsite: Callsite
+    #else
+    public var callsite: Callsite
+    #endif
 
     weak internal var group: ExampleGroup?
 
@@ -46,7 +56,14 @@ final public class Example: NSObject {
         The example name is used to generate a test method selector
         to be displayed in Xcode's test navigator.
     */
-    public var name: String {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
+    public var name: String { return _name }
+    #else
+    public var name: String { return _name }
+    #endif
+
+    private var _name: String {
         guard let groupName = group?.name else { return description }
         return "\(groupName), \(description)"
     }
@@ -55,7 +72,14 @@ final public class Example: NSObject {
         Executes the example closure, as well as all before and after
         closures defined in the its surrounding example groups.
     */
-    public func run() {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
+    public func run() { _run() }
+    #else
+    public func run() { _run() }
+    #endif
+
+    private func _run() {
         let world = World.sharedWorld
 
         if numberOfIncludedExamples == 0 {

--- a/Sources/Quick/ExampleMetadata.swift
+++ b/Sources/Quick/ExampleMetadata.swift
@@ -9,13 +9,23 @@ final public class ExampleMetadata: NSObject {
     /**
         The example for which this metadata was collected.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public let example: Example
+    #else
+    public let example: Example
+    #endif
 
     /**
         The index at which this example was executed in the
         test suite.
     */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public let exampleIndex: Int
+    #else
+    public let exampleIndex: Int
+    #endif
 
     internal init(example: Example, exampleIndex: Int) {
         self.example = example

--- a/Sources/Quick/Filter.swift
+++ b/Sources/Quick/Filter.swift
@@ -17,15 +17,21 @@ final public class Filter: NSObject {
         excluding all other examples without this flag. Use this to only run one or
         two tests that you're currently focusing on.
     */
-    public class var focused: String {
-        return "focused"
-    }
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
+    public class var focused: String { return "focused" }
+    #else
+    public class var focused: String { return "focused" }
+    #endif
 
     /**
         Example and example groups with [Pending: true] are excluded from test runs.
         Use this to temporarily suspend examples that you know do not pass yet.
     */
-    public class var pending: String {
-        return "pending"
-    }
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
+    public class var pending: String { return "pending" }
+    #else
+    public class var pending: String { return "pending" }
+    #endif
 }

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -36,7 +36,18 @@ public class QuickTestSuite: XCTestSuite {
      It is expected that the first call should return a valid test suite, and
      all subsequent calls should return `nil`.
      */
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @objc
     public static func selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
+        return _selectedTestSuite(forTestCaseWithName: name)
+    }
+    #else
+    public static func selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
+        return _selectedTestSuite(forTestCaseWithName: name)
+    }
+    #endif
+
+    private static func _selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
         guard let builder = QuickSelectedTestSuiteBuilder(forTestCaseWithName: name) else { return nil }
 
         let (inserted, _) = builtTestSuites.insert(builder.testSuiteClassName)
@@ -46,7 +57,6 @@ public class QuickTestSuite: XCTestSuite {
             return nil
         }
     }
-
 }
 
 #endif

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -64,6 +64,7 @@ final internal class World: NSObject {
     // MARK: Singleton Constructor
 
     private override init() {}
+	@objc(sharedWorld)
     static let sharedWorld = World()
 
     // MARK: Public Interface
@@ -86,6 +87,7 @@ final internal class World: NSObject {
         Finalizes the World's configuration.
         Any subsequent calls to World.configure() will raise.
     */
+	@objc(finalizeConfiguration)
     internal func finalizeConfiguration() {
         isConfigurationFinalized = true
     }
@@ -108,6 +110,7 @@ final internal class World: NSObject {
         - parameter cls: The QuickSpec class for which to retrieve the root example group.
         - returns: The root example group for the class.
     */
+	@objc(rootExampleGroupForSpecClass:)
     internal func rootExampleGroupForSpecClass(_ cls: AnyClass) -> ExampleGroup {
         let name = String(describing: cls)
 
@@ -189,6 +192,7 @@ final internal class World: NSObject {
         return suiteAftersExecuting || exampleAftersExecuting || groupAftersExecuting
     }
 
+	@objc(performWithCurrentExampleGroup:closure:)
     internal func performWithCurrentExampleGroup(_ group: ExampleGroup, closure: () -> Void) {
         let previousExampleGroup = currentExampleGroup
         currentExampleGroup = group

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -36,7 +36,7 @@ class _FunctionalTests_FocusedSpec_Focused: QuickSpec {
         }
 
         fitBehavesLike("two passing shared examples")
-        fitBehavesLike(FunctionalTests_FocusedSpec_Behavior.self) {_ in ()}
+        fitBehavesLike(FunctionalTests_FocusedSpec_Behavior.self) { () -> Void in }
     }
 }
 
@@ -63,6 +63,6 @@ final class FocusedTests: XCTestCase, XCTestCaseProvider {
             _FunctionalTests_FocusedSpec_Focused.self,
             _FunctionalTests_FocusedSpec_Unfocused.self
         ])
-        XCTAssertEqual(result?.executionCount, 8 as UInt)
+        XCTAssertEqual(result?.executionCount, 8)
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class FunctionalTests_BehaviorTests_Spec: QuickSpec {
     override func spec() {
-        itBehavesLike(FunctionalTests_BehaviorTests_Behavior2.self) {_ in ()}
+        itBehavesLike(FunctionalTests_BehaviorTests_Behavior2.self) { () -> Void in }
     }
 }
 
@@ -49,7 +49,7 @@ final class BehaviorTests: XCTestCase, XCTestCaseProvider {
     func testBehaviorExecutesThreeExamples() {
         let result = qck_runSpec(FunctionalTests_BehaviorTests_Spec.self)
         XCTAssert(result!.hasSucceeded)
-        XCTAssertEqual(result!.executionCount, 3 as UInt)
+        XCTAssertEqual(result!.executionCount, 3)
     }
 
     func testBehaviorPassContextToExamples() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -116,12 +116,12 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result?.executionCount, 10 as UInt)
+        XCTAssertEqual(result?.executionCount, 10)
     }
 #else
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
-        XCTAssertEqual(result?.executionCount, 2 as UInt)
+        XCTAssertEqual(result?.executionCount, 2)
     }
 #endif
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -17,7 +17,7 @@ class FunctionalTests_PendingSpec: QuickSpec {
         xit("an example that will not run") {
             expect(true).to(beFalsy())
         }
-        xitBehavesLike(FunctionalTests_PendingSpec_Behavior.self) {_ in }
+        xitBehavesLike(FunctionalTests_PendingSpec_Behavior.self) { () -> Void in }
         describe("a describe block containing only one enabled example") {
             beforeEach { oneExampleBeforeEachExecutedCount += 1 }
             it("an example that will run") {}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -44,7 +44,7 @@ final class SharedExamplesTests: XCTestCase, XCTestCaseProvider {
     func testAGroupOfThreeSharedExamplesExecutesThreeExamples() {
         let result = qck_runSpec(FunctionalTests_SharedExamples_Spec.self)
         XCTAssert(result!.hasSucceeded)
-        XCTAssertEqual(result!.executionCount, 3 as UInt)
+        XCTAssertEqual(result!.executionCount, 3)
     }
 
     func testSharedExamplesWithContextPassContextToExamples() {


### PR DESCRIPTION
Added `@objc` exports to make sure selectors and properties are visible from Objective-C with Swift 4

