### PR TITLE
Enum cases should be lower camel case

### DIFF
--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -3,12 +3,12 @@ import Quick
 import Nimble
 
 private enum AfterEachType {
-    case OuterOne
-    case OuterTwo
-    case OuterThree
-    case InnerOne
-    case InnerTwo
-    case NoExamples
+    case outerOne
+    case outerTwo
+    case outerThree
+    case innerOne
+    case innerTwo
+    case noExamples
 }
 
 private var afterEachOrder = [AfterEachType]()
@@ -16,9 +16,9 @@ private var afterEachOrder = [AfterEachType]()
 class FunctionalTests_AfterEachSpec: QuickSpec {
     override func spec() {
         describe("afterEach ordering") {
-            afterEach { afterEachOrder.append(AfterEachType.OuterOne) }
-            afterEach { afterEachOrder.append(AfterEachType.OuterTwo) }
-            afterEach { afterEachOrder.append(AfterEachType.OuterThree) }
+            afterEach { afterEachOrder.append(.outerOne) }
+            afterEach { afterEachOrder.append(.outerTwo) }
+            afterEach { afterEachOrder.append(.outerThree) }
 
             it("executes the outer afterEach closures once, but not before this closure [1]") {
                 // No examples have been run, so no afterEach will have been run either.
@@ -29,25 +29,25 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
             it("executes the outer afterEach closures a second time, but not before this closure [2]") {
                 // The afterEach for the previous example should have been run.
                 // The list should contain the afterEach for that example, executed from top to bottom.
-                expect(afterEachOrder).to(equal([AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree]))
+                expect(afterEachOrder).to(equal([.outerOne, .outerTwo, .outerThree]))
             }
 
             context("when there are nested afterEach") {
-                afterEach { afterEachOrder.append(AfterEachType.InnerOne) }
-                afterEach { afterEachOrder.append(AfterEachType.InnerTwo) }
+                afterEach { afterEachOrder.append(.innerOne) }
+                afterEach { afterEachOrder.append(.innerTwo) }
 
                 it("executes the outer and inner afterEach closures, but not before this closure [3]") {
                     // The afterEach for the previous two examples should have been run.
                     // The list should contain the afterEach for those example, executed from top to bottom.
                     expect(afterEachOrder).to(equal([
-                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
-                        AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree
+                        .outerOne, .outerTwo, .outerThree,
+                        .outerOne, .outerTwo, .outerThree
                         ]))
                 }
             }
 
             context("when there are nested afterEach without examples") {
-                afterEach { afterEachOrder.append(AfterEachType.NoExamples) }
+                afterEach { afterEachOrder.append(.noExamples) }
             }
         }
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
@@ -76,15 +76,14 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
         afterEachOrder = []
 
         qck_runSpec(FunctionalTests_AfterEachSpec.self)
-        let expectedOrder = [
+		let expectedOrder: [AfterEachType] = [
             // [1] The outer afterEach closures are executed from top to bottom.
-            AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+            .outerOne, .outerTwo, .outerThree,
             // [2] The outer afterEach closures are executed from top to bottom.
-            AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree,
+            .outerOne, .outerTwo, .outerThree,
             // [3] The inner afterEach closures are executed from top to bottom,
             //     then the outer afterEach closures are executed from top to bottom.
-            AfterEachType.InnerOne, AfterEachType.InnerTwo,
-                AfterEachType.OuterOne, AfterEachType.OuterTwo, AfterEachType.OuterThree
+            .innerOne, .innerTwo, .outerOne, .outerTwo, .outerThree
         ]
         XCTAssertEqual(afterEachOrder, expectedOrder)
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -76,7 +76,7 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
         afterEachOrder = []
 
         qck_runSpec(FunctionalTests_AfterEachSpec.self)
-		let expectedOrder: [AfterEachType] = [
+        let expectedOrder: [AfterEachType] = [
             // [1] The outer afterEach closures are executed from top to bottom.
             .outerOne, .outerTwo, .outerThree,
             // [2] The outer afterEach closures are executed from top to bottom.

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -61,7 +61,7 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
         beforeEachOrder = []
 
         qck_runSpec(FunctionalTests_BeforeEachSpec.self)
-		let expectedOrder: [BeforeEachType] = [
+        let expectedOrder: [BeforeEachType] = [
             // [1] The outer beforeEach closures are executed from top to bottom.
             .outerOne, .outerTwo,
             // [2] The outer beforeEach closures are executed from top to bottom.

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -3,12 +3,12 @@ import Quick
 import Nimble
 
 private enum BeforeEachType {
-    case OuterOne
-    case OuterTwo
-    case InnerOne
-    case InnerTwo
-    case InnerThree
-    case NoExamples
+    case outerOne
+    case outerTwo
+    case innerOne
+    case innerTwo
+    case innerThree
+    case noExamples
 }
 
 private var beforeEachOrder = [BeforeEachType]()
@@ -17,22 +17,22 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
     override func spec() {
 
         describe("beforeEach ordering") {
-            beforeEach { beforeEachOrder.append(BeforeEachType.OuterOne) }
-            beforeEach { beforeEachOrder.append(BeforeEachType.OuterTwo) }
+            beforeEach { beforeEachOrder.append(.outerOne) }
+            beforeEach { beforeEachOrder.append(.outerTwo) }
 
             it("executes the outer beforeEach closures once [1]") {}
             it("executes the outer beforeEach closures a second time [2]") {}
 
             context("when there are nested beforeEach") {
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerOne) }
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerTwo) }
-                beforeEach { beforeEachOrder.append(BeforeEachType.InnerThree) }
+                beforeEach { beforeEachOrder.append(.innerOne) }
+                beforeEach { beforeEachOrder.append(.innerTwo) }
+                beforeEach { beforeEachOrder.append(.innerThree) }
 
                 it("executes the outer and inner beforeEach closures [3]") {}
             }
 
             context("when there are nested beforeEach without examples") {
-                beforeEach { beforeEachOrder.append(BeforeEachType.NoExamples) }
+                beforeEach { beforeEachOrder.append(.noExamples) }
             }
         }
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
@@ -61,15 +61,14 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
         beforeEachOrder = []
 
         qck_runSpec(FunctionalTests_BeforeEachSpec.self)
-        let expectedOrder = [
+		let expectedOrder: [BeforeEachType] = [
             // [1] The outer beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
+            .outerOne, .outerTwo,
             // [2] The outer beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
+            .outerOne, .outerTwo,
             // [3] The outer beforeEach closures are executed from top to bottom,
             //     then the inner beforeEach closures are executed from top to bottom.
-            BeforeEachType.OuterOne, BeforeEachType.OuterTwo,
-                BeforeEachType.InnerOne, BeforeEachType.InnerTwo, BeforeEachType.InnerThree
+            .outerOne, .outerTwo, .innerOne, .innerTwo, .innerThree
         ]
         XCTAssertEqual(beforeEachOrder, expectedOrder)
     }


### PR DESCRIPTION
Cherry-picked some commits from #724. Related to #641.

Thanks to @ecylo for the original efforts!