### PR TITLE
Fix SPM integration.

### DIFF
--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -25,10 +25,11 @@ internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.T
     var subclass, superclass: AnyClass!
     for i in 0..<classesCount {
         subclass = classes[Int(i)]
-        superclass = class_getSuperclass(subclass)
-        if superclass === klass {
-            block(subclass as! T.Type) // swiftlint:disable:this force_cast
-        }
+
+        guard let superclass = class_getSuperclass(subclass),
+            superclass === klass else { return }
+
+        block(subclass as! T.Type) // swiftlint:disable:this force_cast
     }
 
     free(classes)

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -26,10 +26,9 @@ internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.T
     for i in 0..<classesCount {
         subclass = classes[Int(i)]
 
-        guard let superclass = class_getSuperclass(subclass),
-            superclass === klass else { return }
-
-        block(subclass as! T.Type) // swiftlint:disable:this force_cast
+        if let superclass = class_getSuperclass(subclass), superclass === klass {
+            block(subclass as! T.Type) // swiftlint:disable:this force_cast
+        }
     }
 
     free(classes)

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -22,7 +22,7 @@ internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.T
     let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
     classesCount = objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
 
-    var subclass, superclass: AnyClass!
+    var subclass: AnyClass!
     for i in 0..<classesCount {
         subclass = classes[Int(i)]
 


### PR DESCRIPTION
Hey guys! First of all thank you so much for your constant work on Quick/Nimble, really appreciate that. Recently I was working extensively with SPM and wanted to try both Quick/Nimble with SPM. I encountered a runtime crash (bad access) on [this line](https://github.com/sunshinejr/Quick/blob/master/Sources/Quick/Configuration/QuickConfiguration.swift#L29).

My environment:
- SPM/Swift 4.0
- PackageDescriptionV4
- Quick version 1.1.0

Seems like the forcecast on the `superclass` type was creating a crash whenever there was no superclass. I've changed it to be safer so whenever there is no superclass, it will just skip it. If the code style is different from what you have right now, feel free to correct me/change it.

Cheers!
