### PR TITLE
Fix XCTest override error on SPM/Swift4

### DIFF
--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -26,9 +26,9 @@ internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.T
     for i in 0..<classesCount {
         subclass = classes[Int(i)]
 
-        if let superclass = class_getSuperclass(subclass), superclass === klass {
-            block(subclass as! T.Type) // swiftlint:disable:this force_cast
-        }
+        guard let superclass = class_getSuperclass(subclass), superclass == klass else { continue }
+
+        block(subclass as! T.Type) // swiftlint:disable:this force_cast
     }
 
     free(classes)

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -38,7 +38,7 @@ open class QuickSpec: QuickSpecBase {
     /// discovered powered by Objective-C runtime), so we needed the alternative
     /// way.
     #if swift(>=4)
-    override open static var defaultTestSuite: XCTestSuite {
+    override open class var defaultTestSuite: XCTestSuite {
         configureDefaultTestSuite()
 
         return super.defaultTestSuite

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -37,7 +37,21 @@ open class QuickSpec: QuickSpecBase {
     /// SwiftPM on macOS does not have the mechanism (test cases are automatically
     /// discovered powered by Objective-C runtime), so we needed the alternative
     /// way.
+    #if swift(>=4)
+    override open static var defaultTestSuite: XCTestSuite {
+        configureDefaultTestSuite()
+
+        return super.defaultTestSuite
+    }
+    #else
     override open class func defaultTestSuite() -> XCTestSuite {
+        configureDefaultTestSuite()
+
+        return super.defaultTestSuite()
+    }
+    #endif
+
+    private static func configureDefaultTestSuite() {
         let world = World.sharedWorld
 
         if !world.isConfigurationFinalized {
@@ -53,8 +67,6 @@ open class QuickSpec: QuickSpecBase {
         // Let's gather examples for each spec classes. This has the same effect
         // as listing spec classes in `LinuxMain.swift` on Linux.
         _ = allTests
-
-        return super.defaultTestSuite()
     }
 
     override open class func _qck_testMethodSelectors() -> [_QuickSelectorWrapper] {


### PR DESCRIPTION
Hey guys! 

Here with another SPM fix. This time for Swift 4 specifically. Seems like [last time](https://github.com/Quick/Quick/pull/746) I was using Swift 3.2 for Quick, even though I've built it in with SPM/Swift4. This time, when switching to Swift 4.0 on Quick, I've seen an error due to `XCTest.defaultTestSuite()` change. Basically in Swift 3.* `XCTest.defaultTestSuite()` is a method and in Swift 4.* it is a [variable](https://developer.apple.com/documentation/xctest/xctestcase/1496289-defaulttestsuite), making the build fail. 

I've fixed this one using `if swift(>=4)`, but I'm all ears if you have another fix in mind.

Also, this could appear everywhere with Swift 4, not only SPM, but SPM was the only one I’ve tested.

Cheers!