### PR TITLE
Minor documentation fixes

### DIFF
--- a/Documentation/en-us/NimbleAssertions.md
+++ b/Documentation/en-us/NimbleAssertions.md
@@ -8,7 +8,7 @@ the silly monkeys in the bunch:
 
 ```swift
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
-  return monkeys.filter { $0.silliness == .VerySilly }
+  return monkeys.filter { $0.silliness == .verySilly }
 }
 ```
 
@@ -16,9 +16,9 @@ Now let's say we have a unit test for this function:
 
 ```swift
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
   XCTAssertTrue(contains(sillyMonkeys, kiki))
 }
@@ -42,9 +42,9 @@ That confusion slows us down, since we now have to spend time deciphering test c
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki))
 +  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
@@ -59,9 +59,9 @@ Nimble makes your test assertions, and their failure messages, easier to read:
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
 +  expect(sillyMonkeys).to(contain(kiki))
@@ -72,8 +72,8 @@ We don't have to write our own failure message--the one provided by Nimble
 is already very readable:
 
 ```
-expected to contain <Monkey(name: Kiki, sillines: ExtremelySilly)>,
-                got <[Monkey(name: Jane, silliness: VerySilly)]>
+expected to contain <Monkey(name: Kiki, sillines: extremelySilly)>,
+                got <[Monkey(name: Jane, silliness: verySilly)]>
 ```
 
 ![](http://f.cl.ly/items/3N2e3g2K3W123b1L1J0G/Screen%20Shot%202015-02-26%20at%2011.27.02%20AM.png)
@@ -84,8 +84,8 @@ exactly what's wrong, it's easy to fix the issue:
 
 ```diff
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
--  return monkeys.filter { $0.silliness == .VerySilly }
-+  return monkeys.filter { $0.silliness == .VerySilly || $0.silliness == .ExtremelySilly }
+-  return monkeys.filter { $0.silliness == .verySilly }
++  return monkeys.filter { $0.silliness == .verySilly || $0.silliness == .extremelySilly }
 }
 ```
 

--- a/Documentation/en-us/QuickExamplesAndGroups.md
+++ b/Documentation/en-us/QuickExamplesAndGroups.md
@@ -243,7 +243,7 @@ class DolphinSpec: QuickSpec {
       describe("its click") {
         context("when the dolphin is not near anything interesting") {
           it("is only emitted once") {
-            expect(dolphin!.click().count).to(equal(1))
+            expect(dolphin.click().count).to(equal(1))
           }
         }
 

--- a/Documentation/ja/NimbleAssertions.md
+++ b/Documentation/ja/NimbleAssertions.md
@@ -6,7 +6,7 @@
 
 ```swift
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
-  return monkeys.filter { $0.silliness == .VerySilly }
+  return monkeys.filter { $0.silliness == .verySilly }
 }
 ```
 
@@ -14,9 +14,9 @@ public func silliest(monkeys: [Monkey]) -> [Monkey] {
 
 ```swift
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
   XCTAssertTrue(contains(sillyMonkeys, kiki))
 }
@@ -39,9 +39,9 @@ true や false だけではそれがなにか分かりません。このまま�
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki))
 +  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
@@ -56,9 +56,9 @@ Nimble は Assert, 失敗時のメッセージを読みやすくしてくれま�
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
 +  expect(sillyMonkeys).to(contain(kiki))
@@ -68,8 +68,8 @@ func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
 Nimble では自分でメッセージを指定しなくても Nimble がとても読みやすいメッセージを返してくれます。
 
 ```
-expected to contain <Monkey(name: Kiki, sillines: ExtremelySilly)>,
-                got <[Monkey(name: Jane, silliness: VerySilly)]>
+expected to contain <Monkey(name: Kiki, sillines: extremelySilly)>,
+                got <[Monkey(name: Jane, silliness: verySilly)]>
 ```
 
 ![](http://f.cl.ly/items/3N2e3g2K3W123b1L1J0G/Screen%20Shot%202015-02-26%20at%2011.27.02%20AM.png)
@@ -79,8 +79,8 @@ expected to contain <Monkey(name: Kiki, sillines: ExtremelySilly)>,
 
 ```diff
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
--  return monkeys.filter { $0.silliness == .VerySilly }
-+  return monkeys.filter { $0.silliness == .VerySilly || $0.silliness == .ExtremelySilly }
+-  return monkeys.filter { $0.silliness == .verySilly }
++  return monkeys.filter { $0.silliness == .verySilly || $0.silliness == .extremelySilly }
 }
 ```
 

--- a/Documentation/ja/QuickExamplesAndGroups.md
+++ b/Documentation/ja/QuickExamplesAndGroups.md
@@ -235,7 +235,7 @@ class DolphinSpec: QuickSpec {
       describe("its click") {
         context("when the dolphin is not near anything interesting") {
           it("is only emitted once") {
-            expect(dolphin!.click().count).to(equal(1))
+            expect(dolphin.click().count).to(equal(1))
           }
         }
 

--- a/Documentation/ko-kr/NimbleAssertions.md
+++ b/Documentation/ko-kr/NimbleAssertions.md
@@ -6,7 +6,7 @@
 
 ```swift
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
-  return monkeys.filter { $0.silliness == .VerySilly }
+  return monkeys.filter { $0.silliness == .verySilly }
 }
 ```
 
@@ -14,9 +14,9 @@ public func silliest(monkeys: [Monkey]) -> [Monkey] {
 
 ```swift
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
   XCTAssertTrue(contains(sillyMonkeys, kiki))
 }
@@ -38,9 +38,9 @@ XCTAssertTrue failed
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki))
 +  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
@@ -55,9 +55,9 @@ Nimble은 테스트 assertions를 만들고, 실패 메시지를 읽기 쉽게 �
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
 +  expect(sillyMonkeys).to(contain(kiki))
@@ -77,8 +77,8 @@ expected to contain <Monkey(name: Kiki, sillines: ExtremelySilly)>,
 
 ```diff
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
--  return monkeys.filter { $0.silliness == .VerySilly }
-+  return monkeys.filter { $0.silliness == .VerySilly || $0.silliness == .ExtremelySilly }
+-  return monkeys.filter { $0.silliness == .verySilly }
++  return monkeys.filter { $0.silliness == .verySilly || $0.silliness == .extremelySilly }
 }
 ```
 

--- a/Documentation/ko-kr/QuickExamplesAndGroups.md
+++ b/Documentation/ko-kr/QuickExamplesAndGroups.md
@@ -225,7 +225,7 @@ class DolphinSpec: QuickSpec {
       describe("its click") {
         context("when the dolphin is not near anything interesting") {
           it("is only emitted once") {
-            expect(dolphin!.click().count).to(equal(1))
+            expect(dolphin.click().count).to(equal(1))
           }
         }
 

--- a/Documentation/zh-cn/NimbleAssertions.md
+++ b/Documentation/zh-cn/NimbleAssertions.md
@@ -6,7 +6,7 @@
 
 ```swift
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
-  return monkeys.filter { $0.silliness == .VerySilly }
+  return monkeys.filter { $0.silliness == .verySilly }
 }
 ```
 
@@ -14,9 +14,9 @@ public func silliest(monkeys: [Monkey]) -> [Monkey] {
 
 ```swift
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
   XCTAssertTrue(contains(sillyMonkeys, kiki))
 }
@@ -39,9 +39,9 @@ XCTAssertTrue failed
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki))
 +  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
@@ -56,9 +56,9 @@ Nimble 能让你的测试断言及其返回信息更便于阅读：
 
 ```diff
 func testSilliest_whenMonkeysContainSillyMonkeys_theyreIncludedInTheResult() {
-  let kiki = Monkey(name: "Kiki", silliness: .ExtremelySilly)
-  let carl = Monkey(name: "Carl", silliness: .NotSilly)
-  let jane = Monkey(name: "Jane", silliness: .VerySilly)
+  let kiki = Monkey(name: "Kiki", silliness: .extremelySilly)
+  let carl = Monkey(name: "Carl", silliness: .notSilly)
+  let jane = Monkey(name: "Jane", silliness: .verySilly)
   let sillyMonkeys = silliest([kiki, carl, jane])
 -  XCTAssertTrue(contains(sillyMonkeys, kiki), "Expected sillyMonkeys to contain 'Kiki'")
 +  expect(sillyMonkeys).to(contain(kiki))
@@ -78,8 +78,8 @@ expected to contain <Monkey(name: Kiki, sillines: ExtremelySilly)>,
 
 ```diff
 public func silliest(monkeys: [Monkey]) -> [Monkey] {
--  return monkeys.filter { $0.silliness == .VerySilly }
-+  return monkeys.filter { $0.silliness == .VerySilly || $0.silliness == .ExtremelySilly }
+-  return monkeys.filter { $0.silliness == .verySilly }
++  return monkeys.filter { $0.silliness == .verySilly || $0.silliness == .extremelySilly }
 }
 ```
 

--- a/Documentation/zh-cn/QuickExamplesAndGroups.md
+++ b/Documentation/zh-cn/QuickExamplesAndGroups.md
@@ -223,7 +223,7 @@ class DolphinSpec: QuickSpec {
       describe("its click") {
         context("when the dolphin is not near anything interesting") {
           it("is only emitted once") {
-            expect(dolphin!.click().count).to(equal(1))
+            expect(dolphin.click().count).to(equal(1))
           }
         }
 


### PR DESCRIPTION
This PR fixes two minor issues in the docs:

- Use modern Swift-styled enum case names
- Remove a force-unwrapping where the definition itself is already implicitly unwrapped