### PR TITLE
Allow example groups to order tests either randomly OR as they are defined

### DIFF
--- a/Documentation/en-us/TestOrdering.md
+++ b/Documentation/en-us/TestOrdering.md
@@ -1,0 +1,103 @@
+# Test Ordering
+
+Quick provides a way to enforce ordering on your project's tests. The API for
+this acts on the level of `describe` and `context` blocks, and provides
+two options:
+- `.defined` - Guarantees that your tests will run in the order that they appear
+in the test itself with every test run. This is the default value.
+- `.random` - Randomizes the order that tests run within that block.
+
+For more details about each of these settings, including examples, read on.
+
+## `.defined` Test Order
+
+_Example_
+```swift
+describe("A describe block of ordered tests", order: Order.defined) {
+    it("runs this test first every time") {}
+    it("runs this test second every time") {}
+}
+
+context("A context block of ordered tests", order: Order.defined) {
+    it("runs this test first every time") {}
+    it("runs this test second every time") {}
+}
+```
+
+Using the `.defined` switch on the `order` parameter of a `describe` or
+`context` block will ensure Quick runs the tests within this block in the
+order they are defined.
+
+## `.random` Test Order
+
+_Example_
+```swift
+describe("A describe block of ordered tests", order: Order.random) {
+    it("could run first or second") {}
+    it("could run first or second") {}
+}
+
+context("A context block of ordered tests", order: Order.random) {
+    it("could run first or second") {}
+    it("could run first or second") {}
+}
+```
+
+Using the `.random` switch on the `order` parameter of a `describe` or
+`context` block will cause Quick to randomize the order in which these tests
+are run.
+
+We recommend that you use this option. Good, robust unit testing suites avoid
+imposing ordering on tests as much as possible.
+
+## Nested `describe` and `context` blocks
+
+How does this all work for deeply nested tests with many layers of `describe`
+and `context` blocks? Let's look at some examples:
+
+```swift
+// 1
+describe("Top level is defined", order: Order.defined) {
+    it("runs this test first every time") {}
+
+    // 2
+    context("Nested context with defined order", order: Order.defined) {
+        it("runs this test second every time") {}
+        it("runs this test third every time") {}
+    }
+
+    it("runs this test fourth every time") {}
+
+    // 3
+    describe("Nested describe with random order", order: Order.random) {
+        it("runs this test fifth or sixth every time") {}
+        it("runs this test fifth or sixth every time (whichever first isn't)") {}
+    }
+}
+```
+
+- At `1`, we have defined a `describe` block with `.defined`. It will thus order
+all Quick "elements" inside (`it`s, `describe`s, and `context`s) in the
+sequence they appear within the block.
+- At `2`, we've defined a `context` block with `.defined`. It will runs its
+Quick elements in the order they appear in the block, just as is happening with
+the `describe` block defined at `1`. Note that when this `context` gets "its
+ turn" in the order, it will run through all the elements it has inside.
+
+ All the above would apply if the block were a `describe` instead.
+- At `3`, we've defined a `describe` block with `.random`. It will run its
+Quick elements in a random order. However, because this `describe` falls within
+a `describe` block with `.defined` order, the randomness is limited within the
+grand scheme of the test suite. In other words, the `.random` switch only
+randomizes the tests within the nested `describe`, and because that `describe`
+appears at "slot" 5 within the top-level `describe`, that means that the
+shuffling of the inner `it` blocks only shuffles the tests within slot 5 and
+slot 6.
+
+ All the above would apply if the block were a `context` instead.
+
+## Why default to `.defined` if `.random` is recommended?
+
+This is done primarily to avoid breaking existing Quick test suites, as the
+behavior of `.defined` most closely matches the way that it worked before the
+addition of this feature.

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -128,6 +128,12 @@
 		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		7B82D57920190AD9000C4EB6 /* ExplicitOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57820190AD2000C4EB6 /* ExplicitOrderingTests.swift */; };
+		7B82D57A20190ADB000C4EB6 /* ExplicitOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57820190AD2000C4EB6 /* ExplicitOrderingTests.swift */; };
+		7B82D57B20190ADC000C4EB6 /* ExplicitOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57820190AD2000C4EB6 /* ExplicitOrderingTests.swift */; };
+		7B82D57D20191253000C4EB6 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57C20191253000C4EB6 /* Ordering.swift */; };
+		7B82D57E20191288000C4EB6 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57C20191253000C4EB6 /* Ordering.swift */; };
+		7B82D57F20191289000C4EB6 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B82D57C20191253000C4EB6 /* Ordering.swift */; };
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
@@ -511,6 +517,8 @@
 		79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpec_SelectedTests.swift; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
+		7B82D57820190AD2000C4EB6 /* ExplicitOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitOrderingTests.swift; sourceTree = "<group>"; };
+		7B82D57C20191253000C4EB6 /* Ordering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ordering.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrossReferencingSpecs.swift; sourceTree = "<group>"; };
 		CD1F6502226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestObservationCenter+QCKSuspendObservation.swift"; sourceTree = "<group>"; };
@@ -762,6 +770,7 @@
 			children = (
 				DA3124E519FCAEE8002858A7 /* World+DSL.swift */,
 				DA3124E219FCAEE8002858A7 /* DSL.swift */,
+				7B82D57C20191253000C4EB6 /* Ordering.swift */,
 			);
 			path = DSL;
 			sourceTree = "<group>";
@@ -809,6 +818,7 @@
 				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
+				7B82D57820190AD2000C4EB6 /* ExplicitOrderingTests.swift */,
 				CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */,
 				79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */,
 			);
@@ -1459,6 +1469,7 @@
 				1F118D001BDCA536005013A2 /* Closures.swift in Sources */,
 				1F118D051BDCA536005013A2 /* ExampleMetadata.swift in Sources */,
 				1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */,
+				7B82D57F20191289000C4EB6 /* Ordering.swift in Sources */,
 				CE175D501E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				CE590E1F1C431FE400253D19 /* QuickTestSuite.swift in Sources */,
 				1F118D091BDCA536005013A2 /* QuickSpec.m in Sources */,
@@ -1489,6 +1500,7 @@
 				1F118D171BDCA556005013A2 /* BeforeEachTests+ObjC.m in Sources */,
 				1F118D231BDCA556005013A2 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				1F118D151BDCA556005013A2 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
+				7B82D57B20190ADC000C4EB6 /* ExplicitOrderingTests.swift in Sources */,
 				1F118D131BDCA556005013A2 /* ItTests+ObjC.m in Sources */,
 				1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */,
 				1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */,
@@ -1547,6 +1559,7 @@
 				DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				34F375AC19515CA700CE1B99 /* Example.swift in Sources */,
+				7B82D57E20191288000C4EB6 /* Ordering.swift in Sources */,
 				CE175D4F1E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				CE590E1A1C431FE300253D19 /* QuickTestSuite.swift in Sources */,
 				DA3124E719FCAEE8002858A7 /* DSL.swift in Sources */,
@@ -1577,6 +1590,7 @@
 				DAA63EA419F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AC19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
 				DA7AE6F219FC493F000AFDCE /* ItTests.swift in Sources */,
+				7B82D57A20190ADB000C4EB6 /* ExplicitOrderingTests.swift in Sources */,
 				4748E8951A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				CE4A578E1EA7251C0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
@@ -1675,6 +1689,7 @@
 				7B44ADBE1C5444940007AF2E /* HooksPhase.swift in Sources */,
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				DA408BE419FF5599005DF92A /* ExampleHooks.swift in Sources */,
+				7B82D57D20191253000C4EB6 /* Ordering.swift in Sources */,
 				CE175D4E1E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				34F375AB19515CA700CE1B99 /* Example.swift in Sources */,
 				DA3124E619FCAEE8002858A7 /* DSL.swift in Sources */,
@@ -1705,6 +1720,7 @@
 				DA8C00211A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
 				DAA63EA319F7637300CD0A3B /* PendingTests.swift in Sources */,
 				DA8F91AB19F3299E006F6675 /* SharedExamplesTests.swift in Sources */,
+				7B82D57920190AD9000C4EB6 /* ExplicitOrderingTests.swift in Sources */,
 				DA7AE6F119FC493F000AFDCE /* ItTests.swift in Sources */,
 				4748E8941A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -65,15 +65,15 @@ public func sharedExamples(_ name: String, closure: @escaping SharedExampleClosu
     - parameter closure: A closure that can contain other examples.
     - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
 */
-public func describe(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-    World.sharedWorld.describe(description, flags: flags, closure: closure)
+public func describe(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+    World.sharedWorld.describe(description, order: order, flags: flags, closure: closure)
 }
 
 /**
     Defines an example group. Equivalent to `describe`.
 */
-public func context(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-    World.sharedWorld.context(description, flags: flags, closure: closure)
+public func context(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+    World.sharedWorld.context(description, order: order, flags: flags, closure: closure)
 }
 
 /**
@@ -198,8 +198,8 @@ public func pending(_ description: String, closure: () -> Void) {
     Use this to quickly mark a `describe` closure as pending.
     This disables all examples within the closure.
 */
-public func xdescribe(_ description: String, flags: FilterFlags, closure: () -> Void) {
-    World.sharedWorld.xdescribe(description, flags: flags, closure: closure)
+public func xdescribe(_ description: String, order: Order = Order.defined, flags: FilterFlags, closure: () -> Void) {
+    World.sharedWorld.xdescribe(description, order: order, flags: flags, closure: closure)
 }
 
 /**
@@ -230,15 +230,15 @@ public func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags =
     If any examples in the test suite are focused, only those examples are executed.
     This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
 */
-public func fdescribe(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-    World.sharedWorld.fdescribe(description, flags: flags, closure: closure)
+public func fdescribe(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+    World.sharedWorld.fdescribe(description, order: order, flags: flags, closure: closure)
 }
 
 /**
     Use this to quickly focus a `context` closure. Equivalent to `fdescribe`.
 */
-public func fcontext(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-    fdescribe(description, flags: flags, closure: closure)
+public func fcontext(_ description: String, order: Order, flags: FilterFlags = [:], closure: () -> Void) {
+    fdescribe(description, order: order, flags: flags, closure: closure)
 }
 
 /**

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -65,14 +65,14 @@ public func sharedExamples(_ name: String, closure: @escaping SharedExampleClosu
     - parameter closure: A closure that can contain other examples.
     - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
 */
-public func describe(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+public func describe(_ description: String, order: Order = .defined, flags: FilterFlags = [:], closure: () -> Void) {
     World.sharedWorld.describe(description, order: order, flags: flags, closure: closure)
 }
 
 /**
     Defines an example group. Equivalent to `describe`.
 */
-public func context(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+public func context(_ description: String, order: Order = .defined, flags: FilterFlags = [:], closure: () -> Void) {
     World.sharedWorld.context(description, order: order, flags: flags, closure: closure)
 }
 
@@ -198,7 +198,7 @@ public func pending(_ description: String, closure: () -> Void) {
     Use this to quickly mark a `describe` closure as pending.
     This disables all examples within the closure.
 */
-public func xdescribe(_ description: String, order: Order = Order.defined, flags: FilterFlags, closure: () -> Void) {
+public func xdescribe(_ description: String, order: Order = .defined, flags: FilterFlags, closure: () -> Void) {
     World.sharedWorld.xdescribe(description, order: order, flags: flags, closure: closure)
 }
 
@@ -230,7 +230,7 @@ public func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags =
     If any examples in the test suite are focused, only those examples are executed.
     This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
 */
-public func fdescribe(_ description: String, order: Order = Order.defined, flags: FilterFlags = [:], closure: () -> Void) {
+public func fdescribe(_ description: String, order: Order = .defined, flags: FilterFlags = [:], closure: () -> Void) {
     World.sharedWorld.fdescribe(description, order: order, flags: flags, closure: closure)
 }
 

--- a/Sources/Quick/DSL/Ordering.swift
+++ b/Sources/Quick/DSL/Ordering.swift
@@ -1,4 +1,13 @@
+import Foundation
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 @objc public enum Order: Int {
     case random
     case defined
 }
+#else
+public enum Order: Int {
+    case random
+    case defined
+}
+#endif

--- a/Sources/Quick/DSL/Ordering.swift
+++ b/Sources/Quick/DSL/Ordering.swift
@@ -1,0 +1,4 @@
+@objc public enum Order: Int {
+    case random
+    case defined
+}

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -18,35 +18,35 @@ extension World {
         registerSharedExample(name, closure: closure)
     }
 
-    internal func describe(_ description: String, flags: FilterFlags, closure: () -> Void) {
+    internal func describe(_ description: String, order: Order, flags: FilterFlags, closure: () -> Void) {
         guard currentExampleMetadata == nil else {
             raiseError("'describe' cannot be used inside '\(currentPhase)', 'describe' may only be used inside 'context' or 'describe'. ")
         }
         guard currentExampleGroup != nil else {
             raiseError("Error: example group was not created by its parent QuickSpec spec. Check that describe() or context() was used in QuickSpec.spec() and not a more general context (i.e. an XCTestCase test)")
         }
-        let group = ExampleGroup(description: description, flags: flags)
+        let group = ExampleGroup(description: description, order: order, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         performWithCurrentExampleGroup(group, closure: closure)
     }
 
-    internal func context(_ description: String, flags: FilterFlags, closure: () -> Void) {
+    internal func context(_ description: String, order: Order, flags: FilterFlags, closure: () -> Void) {
         guard currentExampleMetadata == nil else {
             raiseError("'context' cannot be used inside '\(currentPhase)', 'context' may only be used inside 'context' or 'describe'. ")
         }
-        self.describe(description, flags: flags, closure: closure)
+        self.describe(description, order: order, flags: flags, closure: closure)
     }
 
-    internal func fdescribe(_ description: String, flags: FilterFlags, closure: () -> Void) {
+    internal func fdescribe(_ description: String, order: Order, flags: FilterFlags, closure: () -> Void) {
         var focusedFlags = flags
         focusedFlags[Filter.focused] = true
-        self.describe(description, flags: focusedFlags, closure: closure)
+        self.describe(description, order: order, flags: focusedFlags, closure: closure)
     }
 
-    internal func xdescribe(_ description: String, flags: FilterFlags, closure: () -> Void) {
+    internal func xdescribe(_ description: String, order: Order, flags: FilterFlags, closure: () -> Void) {
         var pendingFlags = flags
         pendingFlags[Filter.pending] = true
-        self.describe(description, flags: pendingFlags, closure: closure)
+        self.describe(description, order: order, flags: pendingFlags, closure: closure)
     }
 
     internal func beforeEach(_ closure: @escaping BeforeExampleClosure) {
@@ -123,7 +123,7 @@ extension World {
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld.sharedExample(name)
 
-        let group = ExampleGroup(description: name, flags: flags)
+        let group = ExampleGroup(description: name, order: Order.defined, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         performWithCurrentExampleGroup(group) {
             closure(sharedExampleContext)
@@ -148,7 +148,7 @@ extension World {
         }
         let callsite = Callsite(file: file, line: line)
         let closure = behavior.spec
-        let group = ExampleGroup(description: behavior.name, flags: flags)
+        let group = ExampleGroup(description: behavior.name, order: Order.defined, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         performWithCurrentExampleGroup(group) {
             closure(context)

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -123,7 +123,7 @@ extension World {
         let callsite = Callsite(file: file, line: line)
         let closure = World.sharedWorld.sharedExample(name)
 
-        let group = ExampleGroup(description: name, order: Order.defined, flags: flags)
+        let group = ExampleGroup(description: name, order: .defined, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         performWithCurrentExampleGroup(group) {
             closure(sharedExampleContext)
@@ -148,7 +148,7 @@ extension World {
         }
         let callsite = Callsite(file: file, line: line)
         let closure = behavior.spec
-        let group = ExampleGroup(description: behavior.name, order: Order.defined, flags: flags)
+        let group = ExampleGroup(description: behavior.name, order: .defined, flags: flags)
         currentExampleGroup.appendExampleGroup(group)
         performWithCurrentExampleGroup(group) {
             closure(context)

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -76,14 +76,14 @@ final public class ExampleGroup: NSObject {
         for (firstUnshuffled, unshuffledCount) in zip(randomized.indices, stride(from: randomized.count, to: 1, by: -1)) {
             #if os(Linux)
                 srandom(UInt32(time(nil)))
-                let d: Int = Int(random() % (unshuffledCount + 1))
+                let offset: Int = Int(random() % (unshuffledCount + 1))
             #else
-                let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+                let offset: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
             #endif
-            let i = randomized.index(firstUnshuffled, offsetBy: d)
+            let item = randomized.index(firstUnshuffled, offsetBy: offset)
 
             #if swift(>=4.0)
-                randomized.swapAt(firstUnshuffled, i)
+                randomized.swapAt(firstUnshuffled, item)
             #else
                 swap(&randomized[firstUnshuffled], &randomized[i])
             #endif

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -100,7 +100,6 @@ final public class ExampleGroup: NSObject {
 
         return result
     }
-    #endif
 
     internal var name: String? {
         guard let parent = parent else {

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -74,7 +74,12 @@ final public class ExampleGroup: NSObject {
     private var randomizedExamples: [Example] {
         var randomized = Array(groupUnits)
         for (firstUnshuffled, unshuffledCount) in zip(randomized.indices, stride(from: randomized.count, to: 1, by: -1)) {
-            let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+            #if os(Linux)
+                srandom(UInt32(time(nil)))
+                let d: Int = Int(random() % (unshuffledCount + 1))
+            #else
+                let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+            #endif
             let i = randomized.index(firstUnshuffled, offsetBy: d)
             randomized.swapAt(firstUnshuffled, i)
         }

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -81,7 +81,12 @@ final public class ExampleGroup: NSObject {
                 let d: Int = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
             #endif
             let i = randomized.index(firstUnshuffled, offsetBy: d)
-            randomized.swapAt(firstUnshuffled, i)
+
+            #if swift(>=4.0)
+                randomized.swapAt(firstUnshuffled, i)
+            #else
+                swap(&randomized[firstUnshuffled], &randomized[i])
+            #endif
         }
 
         var result = [Example]()

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -146,6 +146,7 @@ final internal class World: _WorldBase {
         } else {
             let group = ExampleGroup(
                 description: "root example group",
+                order: Order.defined,
                 flags: [:],
                 isInternalRootExampleGroup: true
             )

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -146,7 +146,7 @@ final internal class World: _WorldBase {
         } else {
             let group = ExampleGroup(
                 description: "root example group",
-                order: Order.defined,
+                order: .defined,
                 flags: [:],
                 isInternalRootExampleGroup: true
             )

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -19,7 +19,8 @@ void qck_sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure) {
 }
 
 void qck_describe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] describe:description order: OrderDefined flags:@{} closure:closure];
+    int orderDefined = 1;
+    [[World sharedWorld] describe:description order: orderDefined flags:@{} closure:closure];
 }
 
 void qck_context(NSString *description, QCKDSLEmptyBlock closure) {
@@ -67,7 +68,8 @@ void qck_pending(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] xdescribe:description order: OrderDefined flags:@{} closure:closure];
+    int orderDefined = 1;
+    [[World sharedWorld] xdescribe:description order: orderDefined flags:@{} closure:closure];
 }
 
 void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
@@ -75,7 +77,8 @@ void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] fdescribe:description order: OrderDefined flags:@{} closure:closure];
+    int orderDefined = 1;
+    [[World sharedWorld] fdescribe:description order: orderDefined flags:@{} closure:closure];
 }
 
 void qck_fcontext(NSString *description, QCKDSLEmptyBlock closure) {

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -19,7 +19,7 @@ void qck_sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure) {
 }
 
 void qck_describe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] describe:description flags:@{} closure:closure];
+    [[World sharedWorld] describe:description order: OrderDefined flags:@{} closure:closure];
 }
 
 void qck_context(NSString *description, QCKDSLEmptyBlock closure) {
@@ -67,7 +67,7 @@ void qck_pending(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] xdescribe:description flags:@{} closure:closure];
+    [[World sharedWorld] xdescribe:description order: OrderDefined flags:@{} closure:closure];
 }
 
 void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
@@ -75,7 +75,7 @@ void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
 }
 
 void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] fdescribe:description flags:@{} closure:closure];
+    [[World sharedWorld] fdescribe:description order: OrderDefined flags:@{} closure:closure];
 }
 
 void qck_fcontext(NSString *description, QCKDSLEmptyBlock closure) {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
@@ -1,0 +1,59 @@
+import Quick
+import Nimble
+
+class ExplicitOrderingTests: QuickSpec {
+    override func spec() {
+        describe("Running a set of tests exactly in the order that they're written", order: Order.defined) {
+            var testRunCount = 0
+
+            it("b should run this one first") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(1))
+            }
+
+            it("z should run this one second") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(2))
+            }
+
+            it("e should run this one third") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(3))
+            }
+
+            it("a should run this one fourth") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(4))
+            }
+
+            describe("h even handles describes", order: Order.defined) {
+                it("c should run this one fifth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(5))
+                }
+
+                it("j should run this one sixth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(6))
+                }
+            }
+
+            it("d should run this one seventh") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(7))
+            }
+
+            describe("k more describes don't break it", order: Order.defined) {
+                it("c should run this one eighth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(8))
+                }
+
+                it("j should run this one ninth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(9))
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
@@ -54,6 +54,18 @@ class ExplicitOrderingTests: QuickSpec {
                     expect(testRunCount).to(equal(9))
                 }
             }
+
+            context("n works for contexts too", order: Order.defined) {
+                it("c should run this one tenth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(10))
+                }
+
+                it("j should run this one eleventh") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(11))
+                }
+            }
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ExplicitOrderingTests.swift
@@ -3,7 +3,7 @@ import Nimble
 
 class ExplicitOrderingTests: QuickSpec {
     override func spec() {
-        describe("Running a set of tests exactly in the order that they're written", order: Order.defined) {
+        describe("Running a set of tests exactly in the order that they're written", order: .defined) {
             var testRunCount = 0
 
             it("b should run this one first") {
@@ -26,7 +26,7 @@ class ExplicitOrderingTests: QuickSpec {
                 expect(testRunCount).to(equal(4))
             }
 
-            describe("h even handles describes", order: Order.defined) {
+            describe("h even handles describes", order: .defined) {
                 it("c should run this one fifth") {
                     testRunCount += 1
                     expect(testRunCount).to(equal(5))
@@ -43,7 +43,7 @@ class ExplicitOrderingTests: QuickSpec {
                 expect(testRunCount).to(equal(7))
             }
 
-            describe("k more describes don't break it", order: Order.defined) {
+            describe("k more describes don't break it", order: .defined) {
                 it("c should run this one eighth") {
                     testRunCount += 1
                     expect(testRunCount).to(equal(8))
@@ -55,7 +55,7 @@ class ExplicitOrderingTests: QuickSpec {
                 }
             }
 
-            context("n works for contexts too", order: Order.defined) {
+            context("n works for contexts too", order: .defined) {
                 it("c should run this one tenth") {
                     testRunCount += 1
                     expect(testRunCount).to(equal(10))


### PR DESCRIPTION
This PR attempts to add the ordering functionality requested in #759 . 

As written, this PR adds a new argument to `describe`-type and `context`-type DSL methods -- an `order` enum value, which can be one of `.defined` or `.random`.

`.defined` will ensure that the examples are run in the order they are defined within the `describe` or `context` blocks. This includes respecting nested `describe` and `context` blocks in turn. The new test file (`ExplicitOrderingTests.swift`) shows you exactly how you can expect it to handle nested describes. 

`.random` will randomize the examples within the describe, although it takes care to respect the `order` values defined by nested `describe` and `context` blocks. 

Now, there exist some caveats to note here. The most significant of these is the fact that XCode 9 appears to revert to using alphabetical-by-name ordering of tests _only when you use the side tray candies to run the tests_. In other words, XCTest does not appear to respect the ordering we set as the return value of `testInvocations` from `QuickSpec`. I suspect this is related to #744 and #745, but I'm not sure. 

I argue that this PR is still worth adding, because it's still giving many users (anyone using Cmd+U or the command line to run their tests) new goodness. Please let me know if you disagree!

Also, I chose to default the Order to `.defined` because of the [principle of least surprise](https://softwareengineering.stackexchange.com/questions/187457/what-is-the-principle-of-least-astonishment) -- that's closest to how things work now. 

Technically, we should probably default to `.random` since having an explicit ordering to tests is not the best practice. 

Here's some stuff I still want to do with this PR once I get some feedback of the high-level design: 
- ~~complete documentation of how to use the feature~~ ✅ 
- ~~it's probably unnecessary to maintain `childGroups` and `childExamples` as separate collections now within the `ExampleGroup` class~~ True, but not an optimization that I feel is worth it for now.
- ~~add some `context` blocks to the test~~✅ 
- super bonus: allow user to define a sorting function (I actually think this should be done separately though) 