### PR TITLE
Add script to run Linux tests in a container using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.build/
+!.build/checkouts/
+!.build/repositories/
+!.build/workspace-state.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [Welcome to Quick!](#welcome-to-quick!)
+- [Welcome to Quick!](#welcome-to-quick)
   - [Reporting Bugs](#reporting-bugs)
   - [Building the Project](#building-the-project)
   - [Pull Requests](#pull-requests)
     - [Style Conventions](#style-conventions)
   - [Core Members](#core-members)
-    - [Code of Conduct](#code-of-conduct)
   - [Creating a Release](#creating-a-release)
+  - [Testing for Linux from MacOS](#testing-for-linux-from-macos)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -109,3 +109,18 @@ The process is relatively straight forward, but here's is a useful checklist for
 - The script will prompt you to create a new [GitHub release](https://github.com/Quick/Quick/releases).
   - Use the same release notes you created for the tag, but tweak up formatting for GitHub.
 - Announce!
+
+## Testing for Linux from MacOS
+
+If you develop on a Mac, it can prove difficult to run Quick tests against Linux. This can result in 
+the temptation to engage in an unpleasant and expensive cycle where you push to CI, watch your stuff fail
+on Linux, try to fix it, then push again and cross your fingers. 
+
+We'd like to make it easier for you to test your PR contents on Linux before pushing, so Quick provides a
+script that uses Docker to create a Linux container and run Quick's tests on it. To run it, simply execute 
+the following command from the root directory:
+
+```
+./script/test-linux-on-macos
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,4 +123,8 @@ the following command from the root directory:
 ```
 ./script/test-linux-on-macos
 ```
+or, if you'd like to run with a specific version of Swift:
 
+```
+./script/test-linux-on-macos 4.0.3
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@
 - [Welcome to Quick!](#welcome-to-quick)
   - [Reporting Bugs](#reporting-bugs)
   - [Building the Project](#building-the-project)
+  - [Testing for Linux from MacOS](#testing-for-linux-from-macos)
   - [Pull Requests](#pull-requests)
     - [Style Conventions](#style-conventions)
   - [Core Members](#core-members)
   - [Creating a Release](#creating-a-release)
-  - [Testing for Linux from MacOS](#testing-for-linux-from-macos)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -46,6 +46,25 @@ Be sure to include in your issue:
 - After cloning the repository, run `git submodule update --init` to pull the Nimble submodule.
 - Use `Quick.xcworkspace` to work on Quick. The workspace includes
   Nimble, which is used in Quick's tests.
+  
+  ## Testing for Linux from MacOS
+
+  If you develop on a Mac, it can prove difficult to run Quick tests against Linux. This can result in 
+  the temptation to engage in an unpleasant and expensive cycle where you push to CI, watch your stuff fail
+  on Linux, try to fix it, then push again and cross your fingers. 
+
+  We'd like to make it easier for you to test your PR contents on Linux before pushing, so Quick provides a
+  script that uses Docker to create a Linux container and run Quick's tests on it. To run it, simply execute 
+  the following command from the root directory:
+
+  ```
+  ./script/test-linux-on-macos
+  ```
+  or, if you'd like to run with a specific version of Swift:
+
+  ```
+  ./script/test-linux-on-macos 4.0.3
+  ```
 
 ## Pull Requests
 
@@ -109,22 +128,3 @@ The process is relatively straight forward, but here's is a useful checklist for
 - The script will prompt you to create a new [GitHub release](https://github.com/Quick/Quick/releases).
   - Use the same release notes you created for the tag, but tweak up formatting for GitHub.
 - Announce!
-
-## Testing for Linux from MacOS
-
-If you develop on a Mac, it can prove difficult to run Quick tests against Linux. This can result in 
-the temptation to engage in an unpleasant and expensive cycle where you push to CI, watch your stuff fail
-on Linux, try to fix it, then push again and cross your fingers. 
-
-We'd like to make it easier for you to test your PR contents on Linux before pushing, so Quick provides a
-script that uses Docker to create a Linux container and run Quick's tests on it. To run it, simply execute 
-the following command from the root directory:
-
-```
-./script/test-linux-on-macos
-```
-or, if you'd like to run with a specific version of Swift:
-
-```
-./script/test-linux-on-macos 4.0.3
-```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM swift:4.0.3
+
+WORKDIR /package
+
+ENV SWIFT_VERSION=4.0.3
+
+COPY . ./
+
+RUN apt-get -q update && \
+    apt-get -q install -y \
+    lsb-release \
+    rake
+
+RUN ./script/travis-install-linux
+
+ENTRYPOINT ./script/travis-script-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,4 @@ RUN apt-get -q update && \
     lsb-release \
     rake
 
-RUN ./script/travis-install-linux
-
 ENTRYPOINT ./script/travis-script-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM swift:4.0.3
+ARG swift_version
+FROM swift:${swift_version}
+
+ENV SWIFT_VERSION=$swift_version
 
 WORKDIR /package
-
-ENV SWIFT_VERSION=4.0.3
 
 COPY . ./
 

--- a/script/test-linux-on-macos
+++ b/script/test-linux-on-macos
@@ -1,0 +1,8 @@
+printerror () {
+  RED='\033[0;31m'
+  echo -e "${RED}$1"
+}
+
+command -v docker >/dev/null 2>&1 || { printerror "Error: Docker For Mac is required to run tests in a Linux container" ; exit 1; }
+docker build --tag test-quick-linux .
+docker run --rm test-quick-linux

--- a/script/test-linux-on-macos
+++ b/script/test-linux-on-macos
@@ -3,6 +3,8 @@ printerror () {
   echo -e "${RED}$1"
 }
 
+SWIFT_VERSION=${1:-4.2}
+
 command -v docker >/dev/null 2>&1 || { printerror "Error: Docker For Mac is required to run tests in a Linux container" ; exit 1; }
-docker build --tag test-quick-linux .
+docker build --tag test-quick-linux --build-arg swift_version=${SWIFT_VERSION} .
 docker run --rm test-quick-linux

--- a/script/travis-install-linux
+++ b/script/travis-install-linux
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-# See: https://github.com/kylef/swiftenv/wiki/Travis-CI
-curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash

--- a/script/travis-install-linux
+++ b/script/travis-install-linux
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# See: https://github.com/kylef/swiftenv/wiki/Travis-CI
+curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash

--- a/script/travis-script-linux
+++ b/script/travis-script-linux
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
 
-. ~/.swiftenv/init
 rake test:swiftpm


### PR DESCRIPTION
I develop on a Mac. Yesterday, I broke the Linux build working on a [PR to address the concerns raised by another issue](https://github.com/Quick/Quick/pull/766), and found myself wishing I had an easy way to run the Linux test suite locally before pushing, lest I drive the community and myself crazy with the churn. 

I ended up doing some stuff with Docker to see how easy that process could be, and that's where this PR comes from. It creates a new script that builds an image and uses it to run Quick's Linux tests. I smoke tested it with both a compilation error and an actual test failure and it works great!

This commit includes an update to the contributors' documentation explaining the test script and how to use it. 

I understand that this is purely a quality-of-life change for the codebase's developers, and that we should be wary of those types of changes. I'd love feedback on this though, especially feedback on whether the community even believes this is a valuable addition to the repository. 

Thanks, y'all 😃 
