### PR TITLE
Unique identifiers for all test examples

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		7BB41F3C202A87E20064470A /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB41F3B202A87E20064470A /* ExampleTests.swift */; };
+		7BB41F3D202A87E20064470A /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB41F3B202A87E20064470A /* ExampleTests.swift */; };
+		7BB41F3E202A87E20064470A /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB41F3B202A87E20064470A /* ExampleTests.swift */; };
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
@@ -495,6 +498,7 @@
 		64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AfterSuiteTests+ObjC.m"; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
+		7BB41F3B202A87E20064470A /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		96327C611C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QuickSpec+QuickSpec_MethodList.h"; sourceTree = "<group>"; };
 		96327C621C56E90C00405AB3 /* QuickSpec+QuickSpec_MethodList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "QuickSpec+QuickSpec_MethodList.m"; sourceTree = "<group>"; };
@@ -793,6 +797,7 @@
 				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
+				7BB41F3B202A87E20064470A /* ExampleTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1452,6 +1457,7 @@
 			files = (
 				1F118D381BDCA6E1005013A2 /* Configuration+BeforeEachTests.swift in Sources */,
 				1F118D121BDCA556005013A2 /* ItTests.swift in Sources */,
+				7BB41F3E202A87E20064470A /* ExampleTests.swift in Sources */,
 				1F118D1C1BDCA556005013A2 /* BeforeSuiteTests.swift in Sources */,
 				1F118D1D1BDCA556005013A2 /* BeforeSuiteTests+ObjC.m in Sources */,
 				1F118D0E1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
@@ -1535,6 +1541,7 @@
 			files = (
 				DAE714F819FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAA7C0D719F777EB0093D1D9 /* BeforeEachTests.swift in Sources */,
+				7BB41F3D202A87E20064470A /* ExampleTests.swift in Sources */,
 				DA8F919A19F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F11B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253C1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
@@ -1657,6 +1664,7 @@
 			files = (
 				DAE714F719FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAB067E919F7801C00F970AC /* BeforeEachTests.swift in Sources */,
+				7BB41F3C202A87E20064470A /* ExampleTests.swift in Sources */,
 				DA8F919919F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F01B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253B1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -240,9 +240,9 @@
 		DAEB6B9A1943873100289F44 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAEB6B8E1943873100289F44 /* Quick.framework */; };
 		DAF28BC31A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */; };
 		DAF28BC41A4DB8EC00A5D9BF /* FocusedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */; };
-		DED3036B1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift */; };
-		DED3036C1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift */; };
-		DED3036D1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift */; };
+		DED3036B1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */; };
+		DED3036C1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */; };
+		DED3036D1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */; };
 		DED3037D1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
 		DED3037E1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
 		DED3037F1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
@@ -557,7 +557,7 @@
 		DAEB6B991943873100289F44 /* Quick - macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick - macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAEB6B9F1943873100289F44 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FocusedTests+ObjC.m"; sourceTree = "<group>"; };
-		DED3036A1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleModuleNameTests.swift; sourceTree = "<group>"; };
 		F8100E901A1E4447007595ED /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -899,7 +899,7 @@
 				CE57CEDA1C430BD200D63004 /* QuickTestSuite.swift */,
 				CE57CED91C430BD200D63004 /* QuickSelectedTestSuiteBuilder.swift */,
 				CE57CED81C430BD200D63004 /* NSBundle+CurrentTestBundle.swift */,
-				DED3036A1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift */,
+				DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */,
 				CE57CEDB1C430BD200D63004 /* URL+FileName.swift */,
 				34C586071C4AC5E500D4F057 /* ErrorUtility.swift */,
 				DAEB6B911943873100289F44 /* Supporting Files */,
@@ -1432,7 +1432,7 @@
 				34C5860A1C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				1F118D041BDCA536005013A2 /* Example.swift in Sources */,
 				1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */,
-				DED3036D1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				DED3036D1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				CE590E211C431FE400253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				1F118D071BDCA536005013A2 /* Callsite.swift in Sources */,
 				CE590E231C431FE400253D19 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1515,7 +1515,7 @@
 				34C586091C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				DA408BE719FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				34F375BA19515CA700CE1B99 /* QuickSpec.m in Sources */,
-				DED3036C1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				DED3036C1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				CE590E1C1C431FE300253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				DAE7150119FF6A62005905B8 /* QuickConfiguration.m in Sources */,
 				CE590E1E1C431FE300253D19 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1638,7 +1638,7 @@
 				DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */,
 				CE57CEDF1C430BD200D63004 /* QuickTestSuite.swift in Sources */,
 				34C586081C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
-				DED3036B1DF6C66B0041394E /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				DED3036B1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				34F375B919515CA700CE1B99 /* QuickSpec.m in Sources */,
 				CE57CEE11C430BD200D63004 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,

--- a/Sources/Quick/Configuration/Configuration.swift
+++ b/Sources/Quick/Configuration/Configuration.swift
@@ -20,8 +20,8 @@ final public class Configuration: NSObject {
     internal let exampleHooks = ExampleHooks()
     internal let suiteHooks = SuiteHooks()
     internal var exclusionFilters: [ExampleFilter] = [ { example in
-        if let pending = example.filterFlags[Filter.pending] {
-            return pending
+        if let excluded = example.filterFlags[Filter.excluded] {
+            return excluded
         } else {
             return false
         }

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -190,8 +190,9 @@ public func itBehavesLike<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags = 
     - parameter description: An arbitrary string describing the example or example group.
     - parameter closure: A closure that will not be evaluated.
 */
-public func pending(_ description: String, closure: () -> Void) {
-    World.sharedWorld.pending(description, closure: closure)
+public func pending(_ description: String, file: String = #file, line: UInt = #line,
+                    closure: @escaping () -> Void) {
+    World.sharedWorld.pending(description, file: file, line: line, closure: closure)
 }
 
 /**

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -217,7 +217,7 @@ extension World {
     }
 
     @objc(pendingWithDescription:file:line:closure:)
-    private func objc_pending(_ description: String, file: String, line: UInt, closure: @escaping () -> Void) {
+    internal func objc_pending(_ description: String, file: String, line: UInt, closure: @escaping () -> Void) {
         pending(description, file: file, line: line, closure: closure)
     }
 #endif

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -125,7 +125,7 @@ final public class Example: _ExampleBase {
 
     internal var uniqueIdentifier: String {
         guard let uniqueIdentifier = group?.uniqueIdentifier(forExample: self) else {
-            return (description as NSString).c99ExtendedIdentifier
+            return description.c99ExtendedIdentifier
         }
 
         return uniqueIdentifier

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -34,6 +34,8 @@ final public class Example: _ExampleBase {
     private let closure: () -> Void
     private let flags: FilterFlags
 
+    internal var isPending = false
+
     internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () -> Void) {
         self.internalDescription = description
         self.closure = closure
@@ -63,6 +65,11 @@ final public class Example: _ExampleBase {
         closures defined in the its surrounding example groups.
     */
     public func run() {
+        if isPending {
+            print("Pending: \(uniqueIdentifier)")
+            return
+        }
+
         let world = World.sharedWorld
 
         if numberOfIncludedExamples == 0 {
@@ -114,6 +121,14 @@ final public class Example: _ExampleBase {
             aggregateFlags[key] = value
         }
         return aggregateFlags
+    }
+
+    internal var uniqueIdentifier: String {
+        guard let uniqueIdentifier = group?.uniqueIdentifier(forExample: self) else {
+            return (description as NSString).c99ExtendedIdentifier
+        }
+
+        return uniqueIdentifier
     }
 }
 

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -141,7 +141,7 @@ final public class ExampleGroup: NSObject {
     }
 
     private func deduplicateIdentifier(_ identifier: String) -> String {
-        var uniqueIdentifier = (identifier as NSString).c99ExtendedIdentifier
+        var uniqueIdentifier = identifier.c99ExtendedIdentifier
         let baseUniqueIdentifier = uniqueIdentifier
         var identifyingTag = 2
         while allExampleUniqueIdentifiers.contains(uniqueIdentifier) {

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -127,15 +127,7 @@ final public class ExampleGroup: NSObject {
 
     private func generateUniqueIdentifier(givenIdentifierSuffix suffix: String) -> String {
         if isInternalRootExampleGroup {
-            var uniqueIdentifier = (suffix as NSString).c99ExtendedIdentifier
-            let baseUniqueIdentifier = uniqueIdentifier
-            var identifyingTag = 2
-            while allExampleUniqueIdentifiers.contains(uniqueIdentifier) {
-                uniqueIdentifier = baseUniqueIdentifier + "_\(identifyingTag)"
-                identifyingTag += 1
-            }
-
-            return uniqueIdentifier
+            return deduplicateIdentifier(suffix)
         }
 
         if let parent = parent {
@@ -145,7 +137,11 @@ final public class ExampleGroup: NSObject {
         }
 
         let unformatted = self.description + " " + suffix
-        var uniqueIdentifier = (unformatted as NSString).c99ExtendedIdentifier
+        return deduplicateIdentifier(unformatted)
+    }
+
+    private func deduplicateIdentifier(_ identifier: String) -> String {
+        var uniqueIdentifier = (identifier as NSString).c99ExtendedIdentifier
         let baseUniqueIdentifier = uniqueIdentifier
         var identifyingTag = 2
         while allExampleUniqueIdentifiers.contains(uniqueIdentifier) {

--- a/Sources/Quick/Filter.swift
+++ b/Sources/Quick/Filter.swift
@@ -20,7 +20,7 @@ public typealias FilterFlags = [String: Bool]
 */
 final public class Filter: _FilterBase {
     /**
-        Example and example groups with [Focused: true] are included in test runs,
+        Example and example groups with [focused: true] are included in test runs,
         excluding all other examples without this flag. Use this to only run one or
         two tests that you're currently focusing on.
     */
@@ -29,10 +29,10 @@ final public class Filter: _FilterBase {
     }
 
     /**
-        Example and example groups with [Pending: true] are excluded from test runs.
-        Use this to temporarily suspend examples that you know do not pass yet.
-    */
-    public class var pending: String {
-        return "pending"
+     Example and example groups with [excluded: true] are excluded from test runs.
+     Use this to temporarily suspend examples that you know do not pass yet.
+     */
+    public class var excluded: String {
+        return "excluded"
     }
 }

--- a/Sources/Quick/String+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/String+C99ExtendedIdentifier.swift
@@ -1,7 +1,6 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 
-extension NSString {
+extension String {
     private static var invalidCharacters: CharacterSet = {
         var invalidCharacters = CharacterSet()
 
@@ -21,14 +20,19 @@ extension NSString {
         return invalidCharacters
     }()
 
-    /// This API is not meant to be used outside Quick, so will be unavailable in
-    /// a next major version.
-    @objc(qck_c99ExtendedIdentifier)
-    public var c99ExtendedIdentifier: String {
-        let validComponents = components(separatedBy: NSString.invalidCharacters)
+    var c99ExtendedIdentifier: String {
+        let validComponents = components(separatedBy: String.invalidCharacters)
         let result = validComponents.joined(separator: "_")
 
         return result.isEmpty ? "_" : result
+    }
+}
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+public extension NSString {
+    @objc(qck_c99ExtendedIdentifier)
+    public var c99ExtendedIdentifier: String {
+        return (self as String).c99ExtendedIdentifier
     }
 }
 

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -144,9 +144,13 @@ final internal class World: _WorldBase {
     internal func examples(_ specClass: AnyClass) -> [Example] {
         // 1. Grab all included examples.
         let included = includedExamples
+
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.
-        let spec = rootExampleGroupForSpecClass(specClass).examples.filter { included.contains($0) }
-        // 3. Remove all excluded examples.
+        let rootExampleGroup = rootExampleGroupForSpecClass(specClass)
+        rootExampleGroup.assignUniqueIdentifiersToExamples()
+        let spec = rootExampleGroup.examples.filter { included.contains($0) }
+
+        // 3. Remove excluded examples.
         return spec.filter { example in
             !self.configuration.exclusionFilters.reduce(false) { $0 || $1(example) }
         }

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -61,7 +61,6 @@ QUICK_EXPORT void qck_beforeEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure);
 QUICK_EXPORT void qck_afterEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure);
-QUICK_EXPORT void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure);
@@ -170,17 +169,6 @@ static inline void afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
 }
 
 /**
-    Defines an example or example group that should not be executed. Use `pending` to temporarily disable
-    examples or groups that should not be run yet.
- 
-    @param description An arbitrary string describing the example or example group.
-    @param closure A closure that will not be evaluated.
- */
-static inline void pending(NSString *description, QCKDSLEmptyBlock closure) {
-    qck_pending(description, closure);
-}
-
-/**
     Use this to quickly mark a `describe` block as pending.
     This disables all examples within the block.
  */
@@ -215,20 +203,24 @@ static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
 #define it qck_it
 #define xit qck_xit
 #define fit qck_fit
+#define pending qck_pending
 #define itBehavesLike qck_itBehavesLike
 #define xitBehavesLike qck_xitBehavesLike
 #define fitBehavesLike qck_fitBehavesLike
 #endif
 
 #define qck_it qck_it_builder(@{}, @(__FILE__), __LINE__)
-#define qck_xit qck_it_builder(@{Filter.pending: @YES}, @(__FILE__), __LINE__)
+#define qck_xit qck_it_builder(@{Filter.excluded: @YES}, @(__FILE__), __LINE__)
 #define qck_fit qck_it_builder(@{Filter.focused: @YES}, @(__FILE__), __LINE__)
+#define qck_pending qck_pending_builder(@(__FILE__), __LINE__)
 #define qck_itBehavesLike qck_itBehavesLike_builder(@{}, @(__FILE__), __LINE__)
-#define qck_xitBehavesLike qck_itBehavesLike_builder(@{Filter.pending: @YES}, @(__FILE__), __LINE__)
+#define qck_xitBehavesLike qck_itBehavesLike_builder(@{Filter.excluded: @YES}, @(__FILE__), __LINE__)
 #define qck_fitBehavesLike qck_itBehavesLike_builder(@{Filter.focused: @YES}, @(__FILE__), __LINE__)
 
 typedef void (^QCKItBlock)(NSString *description, QCKDSLEmptyBlock closure);
+typedef void (^QCKPendingBlock)(NSString *description, QCKDSLEmptyBlock closure);
 typedef void (^QCKItBehavesLikeBlock)(NSString *description, QCKDSLSharedExampleContext context);
 
 QUICK_EXPORT QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line);
+QUICK_EXPORT QCKPendingBlock qck_pending_builder(NSString *file, NSUInteger line);
 QUICK_EXPORT QCKItBehavesLikeBlock qck_itBehavesLike_builder(NSDictionary *flags, NSString *file, NSUInteger line);

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -62,8 +62,13 @@ QCKItBehavesLikeBlock qck_itBehavesLike_builder(NSDictionary *flags, NSString *f
     };
 }
 
-void qck_pending(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] pending:description closure:closure];
+QCKPendingBlock qck_pending_builder(NSString *file, NSUInteger line) {
+    return ^(NSString *description, QCKDSLEmptyBlock closure) {
+        [[World sharedWorld] pendingWithDescription:description
+                                               file:file
+                                               line:line
+                                            closure:closure];
+    };
 }
 
 void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure) {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ExampleTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ExampleTests.swift
@@ -1,3 +1,4 @@
+import XCTest
 @testable import Quick
 import Nimble
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ExampleTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ExampleTests.swift
@@ -1,0 +1,128 @@
+@testable import Quick
+import Nimble
+
+class ExampleTests: XCTestCase {
+    func test_uniqueIdentifier_uniquelyIdentifiesTheExampleAcrossASpec() {
+        let rootExampleGroup = ExampleGroup(
+            description: "root example group",
+            flags: [:],
+            isInternalRootExampleGroup: true
+        )
+
+        let rootExample = Example(
+            description: "root example",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        rootExampleGroup.appendExample(rootExample)
+
+        let groupContainingExamplesWithDuplicateDescriptions = ExampleGroup(
+            description: "inner group",
+            flags: [:]
+        )
+
+        let dupeExampleA = Example(
+            description: "duplicate description",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        let dupeExampleB = Example(
+            description: "duplicate description",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        let dupeExampleC = Example(
+            description: "duplicate description",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        groupContainingExamplesWithDuplicateDescriptions.appendExample(dupeExampleA)
+        groupContainingExamplesWithDuplicateDescriptions.appendExample(dupeExampleB)
+        groupContainingExamplesWithDuplicateDescriptions.appendExample(dupeExampleC)
+
+        rootExampleGroup.appendExampleGroup(groupContainingExamplesWithDuplicateDescriptions)
+
+        let groupContainingExamplesDuplicatedAcrossGroupsA = ExampleGroup(
+            description: "group duped across a spec",
+            flags: [:]
+        )
+        let exampleDupedAcrossSpecA = Example(
+            description: "example duped across different groups",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        groupContainingExamplesDuplicatedAcrossGroupsA.appendExample(exampleDupedAcrossSpecA)
+
+        let groupContainingExamplesDuplicatedAcrossGroupsB = ExampleGroup(
+            description: "group duped across a spec",
+            flags: [:]
+        )
+        let exampleDupedAcrossSpecB = Example(
+            description: "example duped across different groups",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+        groupContainingExamplesDuplicatedAcrossGroupsB.appendExample(exampleDupedAcrossSpecB)
+
+        rootExampleGroup.appendExampleGroup(groupContainingExamplesDuplicatedAcrossGroupsA)
+        rootExampleGroup.appendExampleGroup(groupContainingExamplesDuplicatedAcrossGroupsB)
+
+        let justAnotherGroup = ExampleGroup(
+            description: "just another group",
+            flags: [:]
+        )
+        let justAnotherExample = Example(
+            description: "just another example",
+            callsite: Callsite(file: "", line: 0),
+            flags: [:]
+        ) {}
+
+        justAnotherGroup.appendExample(justAnotherExample)
+
+        rootExampleGroup.appendExampleGroup(justAnotherGroup)
+
+        rootExampleGroup.assignUniqueIdentifiersToExamples()
+
+        expect(
+            rootExample.uniqueIdentifier
+            ).to(
+                equal("root_example")
+        )
+
+        expect(
+            dupeExampleA.uniqueIdentifier
+            ).to(
+                equal("inner_group_duplicate_description")
+        )
+
+        expect(
+            dupeExampleB.uniqueIdentifier
+            ).to(
+                equal("inner_group_duplicate_description_2")
+        )
+
+        expect(
+            dupeExampleC.uniqueIdentifier
+            ).to(
+                equal("inner_group_duplicate_description_3")
+        )
+
+        expect(
+            exampleDupedAcrossSpecA.uniqueIdentifier
+            ).to(
+                equal("group_duped_across_a_spec_example_duped_across_different_groups")
+        )
+
+        expect(
+            exampleDupedAcrossSpecB.uniqueIdentifier
+            ).to(
+                equal("group_duped_across_a_spec_example_duped_across_different_groups_2")
+        )
+
+        expect(
+            justAnotherExample.uniqueIdentifier
+            ).to(
+                equal("just_another_group_just_another_example")
+        )
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -21,7 +21,15 @@ class FunctionalTests_PendingSpec: QuickSpec {
         describe("a describe block containing only one enabled example") {
             beforeEach { oneExampleBeforeEachExecutedCount += 1 }
             it("an example that will run") {}
-            pending("an example that will not run") {}
+            pending("an example that will not run") {
+                expect(true).to(beFalsy())
+            }
+            pending("uniquely prints when descriptions are identical") {
+                expect(true).to(beFalsy())
+            }
+            pending("uniquely prints when descriptions are identical") {
+                expect(true).to(beFalsy())
+            }
         }
 
         describe("a describe block containing only pending examples") {


### PR DESCRIPTION
This PR addresses #770 by doing two things: 
1) Assigning unique identifiers to all examples based on the description chain of the example, adding numbers at the end to deduplicate if necessary. 
2) Elevating `pending` elements to full-fledged example objects that print these unique identifiers but still do not run their content. 

There are a couple specific things that I would appreciate feedback on:
- For the sake of trying to change one thing at a time (at least in spirit), I changed the `Filter.pending` flag to `Filter.excluded`. This is because I did not know whether there was some strong reason that `xit` and the like were removed entirely from the Quick test list as opposed to just neutering their content. I'll lean on @modocache and @jeffh to hopefully provide any history they can. It makes sense to me and would simplify the code to just treat `x`-type examples the same as pending, but I don't want to make that decision alone. 

  Also, @shx7, will you need those `xit`, `xdescribe`, etc examples to print `Pending: blah_blah_blah` as well? If so, then we'll definitely have to make some more changes. Fortunately, I already experimented with that and it will be easy for me to do. I just need to know whether that's what we want. 

- Tests only start appending digits once its apparent they are duplicated. In other words, a set of tests which happen to be duplicated will have the following identifiers:
```
test_with_duplicated_identifier
test_with_duplicated_identifier_2
test_with_duplicated_identifier_3
```
Notice that the first one does not have a `1` appended to it. @shx7 will that satisfy the ask? 

I still have a couple things to do on this PR, but wanted to start a review of the code and a conversation about its progress ASAP. I'll maintain the list here:

- Prepend unique identifiers with test class name
- (maybe) Refactor `xit` and its like elements to use the new pending code

Cheers, y'all. 
