### PR TITLE
Support Cocoapods 1.5

### DIFF
--- a/Sources/QuickObjectiveC/DSL/World+DSL.h
+++ b/Sources/QuickObjectiveC/DSL/World+DSL.h
@@ -1,4 +1,9 @@
+#if __has_include("Quick-Swift.h")
+#import "Quick-Swift.h"
+#else
 #import <Quick/Quick-Swift.h>
+#endif
+
 
 @interface World (SWIFT_EXTENSION(Quick))
 - (void)beforeSuite:(void (^ __nonnull)(void))closure;

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -1,7 +1,12 @@
 #import "QuickSpec.h"
 #import "QuickConfiguration.h"
 #import "World.h"
+#if __has_include("Quick-Swift.h")
+#import "Quick-Swift.h"
+#else
 #import <Quick/Quick-Swift.h>
+#endif
+
 
 static QuickSpec *currentSpec = nil;
 

--- a/Sources/QuickObjectiveC/World.h
+++ b/Sources/QuickObjectiveC/World.h
@@ -1,4 +1,8 @@
+#if __has_include("Quick-Swift.h")
+#import "Quick-Swift.h"
+#else
 #import <Quick/Quick-Swift.h>
+#endif
 
 @class ExampleGroup;
 @class ExampleMetadata;

--- a/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
+++ b/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
@@ -1,6 +1,11 @@
 #import <XCTest/XCTest.h>
 #import <objc/runtime.h>
+#if __has_include("Quick-Swift.h")
+#import "Quick-Swift.h"
+#else
 #import <Quick/Quick-Swift.h>
+#endif
+
 
 @interface XCTestSuite (QuickTestSuiteBuilder)
 @end


### PR DESCRIPTION
This PR fixes #780 in relation to Cocoapods 1.5. In this new version of Cocoapods, some things have changed in how header files are found. The recommendation from the Cocoapods team seems to be to change the imports to this:

```
#if __has_include("Quick-Swift.h")
#import "Quick-Swift.h"
#else
#import <Quick/Quick-Swift.h>
#endif
```

I tested this against my app and it seems to work fine with no side-effects. 