### PR TITLE
Fixed testing error on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,8 +40,17 @@ var package = Package(
     }()
 )
 
-if isTesting {
-  package.dependencies.append(contentsOf: [
-    .Package(url: "https://github.com/Quick/Nimble.git", majorVersion: 7),
-  ])
+var downloadNimble = false
+
+#if os(macOS)
+    downloadNimble = isTesting
+
+#else 
+    downloadNimble = true
+#endif
+
+if(downloadNimble) {
+    package.dependencies.append(contentsOf: [
+        .Package(url: "https://github.com/Quick/Nimble.git", majorVersion: 7),
+    ])
 }


### PR DESCRIPTION
* While building on Linux, `isTesting` would evaluate to `false` and therefore `swift test` wouldn't finish compiling the test suites.
* Fixed by introducing a conditional compilation flag that while on Linux, defaults SPM to always downloading `Nimble`.
* Behavior in MacOS is unchanged.