### PR TITLE
Add @escaping to Swift example

### DIFF
--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -18,7 +18,7 @@ import Nimble
 
 class EdibleSharedExamplesConfiguration: QuickConfiguration {
   override class func configure(_ configuration: Configuration) {
-    sharedExamples("something edible") { (sharedExampleContext: SharedExampleContext) in
+    sharedExamples("something edible") { (sharedExampleContext: @escaping SharedExampleContext) in
       it("makes dolphins happy") {
         let dolphin = Dolphin(happy: false)
         let edible = sharedExampleContext()["edible"]


### PR DESCRIPTION
`SharedExampleContext` should be marked with `@escaping` in Swift example code.