### PR TITLE
Add left alignment spaces for copyright in template files

### DIFF
--- a/Quick Templates/Quick Configuration Class.xctemplate/Objective-C/___FILEBASENAME___.h
+++ b/Quick Templates/Quick Configuration Class.xctemplate/Objective-C/___FILEBASENAME___.h
@@ -3,7 +3,7 @@
 //  ___PROJECTNAME___
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//___COPYRIGHT___
+//  ___COPYRIGHT___
 //
 
 @import Quick;

--- a/Quick Templates/Quick Configuration Class.xctemplate/Objective-C/___FILEBASENAME___.m
+++ b/Quick Templates/Quick Configuration Class.xctemplate/Objective-C/___FILEBASENAME___.m
@@ -3,7 +3,7 @@
 //  ___PROJECTNAME___
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//___COPYRIGHT___
+//  ___COPYRIGHT___
 //
 
 #import "___FILEBASENAMEASIDENTIFIER___.h"

--- a/Quick Templates/Quick Configuration Class.xctemplate/Swift/___FILEBASENAME___.swift
+++ b/Quick Templates/Quick Configuration Class.xctemplate/Swift/___FILEBASENAME___.swift
@@ -3,7 +3,7 @@
 //  ___PROJECTNAME___
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//___COPYRIGHT___
+//  ___COPYRIGHT___
 //
 
 import Quick

--- a/Quick Templates/Quick Spec Class.xctemplate/Objective-C/___FILEBASENAME___.m
+++ b/Quick Templates/Quick Spec Class.xctemplate/Objective-C/___FILEBASENAME___.m
@@ -3,7 +3,7 @@
 //  ___PROJECTNAME___
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//___COPYRIGHT___
+//  ___COPYRIGHT___
 //
 
 #import <Quick/Quick.h>

--- a/Quick Templates/Quick Spec Class.xctemplate/Swift/___FILEBASENAME___.swift
+++ b/Quick Templates/Quick Spec Class.xctemplate/Swift/___FILEBASENAME___.swift
@@ -3,7 +3,7 @@
 //  ___PROJECTNAME___
 //
 //  Created by ___FULLUSERNAME___ on ___DATE___.
-//___COPYRIGHT___
+//  ___COPYRIGHT___
 //
 
 import Quick


### PR DESCRIPTION
Templates had added Xcode Header in #540 , but it was not aligned.

---
BTW, In recent Xcode' template can be defined header with only `// ___ FILEHEADER___`.

It seemed to be a preferable fix, but I don't know whether it is available in past Xcode  versions.
so I fixed only the space.