### PR TITLE
[1.x] Fix unrecognized selector crash on static linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
         - PLATFORM=macos
         - XCODE_ACTION="build-for-testing test-without-building"
     - os: osx
+      osx_image: xcode9.3
+      env:
+        - PLATFORM=macos_static
+        - XCODE_ACTION="build-for-testing test-without-building"
+    - os: osx
       env:
         - PLATFORM=ios
         - XCODE_ACTION="build-for-testing test-without-building"

--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,11 @@ namespace "test" do
     run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-macOS clean #{xcode_action}"
   end
 
+  desc "Run unit tests for all macOS targets using static linking"
+  task :macos_static do |t|
+    run " MACH_O_TYPE=staticlib xcodebuild -workspace Quick.xcworkspace -scheme Quick-macOS clean #{xcode_action}"
+  end
+
   desc "Run unit tests for the current platform built by the Swift Package Manager"
   task :swiftpm do |t|
     env = { "SWIFT_PACKAGE_TEST_Quick" => "true" }

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -35,11 +35,11 @@ extension NSString {
 ///
 /// See: https://github.com/Quick/Quick/issues/785
 @objc
-public class QCKObjCStringUtils: NSObject {
+class QCKObjCStringUtils: NSObject {
     override private init() {}
 
     @objc
-    public static func c99ExtendedIdentifier(from string: String) -> String {
+    static func c99ExtendedIdentifier(from string: String) -> String {
         return string.c99ExtendedIdentifier
     }
 }

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -1,8 +1,7 @@
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 
-public extension NSString {
-
+extension NSString {
     private static var invalidCharacters: CharacterSet = {
         var invalidCharacters = CharacterSet()
 
@@ -22,12 +21,25 @@ public extension NSString {
         return invalidCharacters
     }()
 
-    @objc(qck_c99ExtendedIdentifier)
     var c99ExtendedIdentifier: String {
         let validComponents = components(separatedBy: NSString.invalidCharacters)
         let result = validComponents.joined(separator: "_")
 
         return result.isEmpty ? "_" : result
+    }
+}
+
+/// Extension methods or properties for NSObject subclasses are somehow invisible
+/// from the Objective-C runtime on static linking, so let's make a wrapper class.
+///
+/// See: https://github.com/Quick/Quick/issues/785
+@objc
+public class ObjCStringUtils: NSObject {
+    override private init() {}
+
+    @objc
+    public static func c99ExtendedIdentifier(from string: String) -> String {
+        return string.c99ExtendedIdentifier
     }
 }
 #endif

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -21,7 +21,8 @@ extension NSString {
         return invalidCharacters
     }()
 
-    var c99ExtendedIdentifier: String {
+    @objc(qck_c99ExtendedIdentifier)
+    public var c99ExtendedIdentifier: String {
         let validComponents = components(separatedBy: NSString.invalidCharacters)
         let result = validComponents.joined(separator: "_")
 

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -21,6 +21,8 @@ extension NSString {
         return invalidCharacters
     }()
 
+    /// This API is not meant to be used outside Quick, so will be unavaialbe in
+    /// a next major version.
     @objc(qck_c99ExtendedIdentifier)
     public var c99ExtendedIdentifier: String {
         let validComponents = components(separatedBy: NSString.invalidCharacters)
@@ -30,10 +32,11 @@ extension NSString {
     }
 }
 
-/// Extension methods or properties for NSObject subclasses are somehow invisible
-/// from the Objective-C runtime on static linking, so let's make a wrapper class.
+/// Extension methods or properties for NSObject subclasses are invisible from
+/// the Objective-C runtime on static linking unless the consumers add `-ObjC`
+/// linker flag, so let's make a wrapper class to mitigate that situation.
 ///
-/// See: https://github.com/Quick/Quick/issues/785
+/// See: https://github.com/Quick/Quick/issues/785 and https://github.com/Quick/Quick/pull/803
 @objc
 class QCKObjCStringUtils: NSObject {
     override private init() {}

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -34,7 +34,7 @@ extension NSString {
 ///
 /// See: https://github.com/Quick/Quick/issues/785
 @objc
-public class ObjCStringUtils: NSObject {
+public class QCKObjCStringUtils: NSObject {
     override private init() {}
 
     @objc

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -110,7 +110,7 @@ static QuickSpec *currentSpec = nil;
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];
 
-    NSString *originalName = [ObjCStringUtils c99ExtendedIdentifierFrom:example.name];
+    NSString *originalName = [QCKObjCStringUtils c99ExtendedIdentifierFrom:example.name];
     NSString *selectorName = originalName;
     NSUInteger i = 2;
     

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -109,8 +109,8 @@ static QuickSpec *currentSpec = nil;
     });
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];
-    
-    NSString *originalName = example.name.qck_c99ExtendedIdentifier;
+
+    NSString *originalName = [ObjCStringUtils c99ExtendedIdentifierFrom:example.name];
     NSString *selectorName = originalName;
     NSUInteger i = 2;
     


### PR DESCRIPTION
~~Extension methods or properties for NSObject subclasses are somehow invisible from the Objective-C runtime on static linking, so let's make a wrapper class.~~

Extension methods or properties for NSObject subclasses are invisible from the Objective-C runtime on static linking unless the consumers add `-ObjC` linker flag, so let's make a wrapper class to mitigate that situation.

Fixes #785.