### PR TITLE
[1.x] clear world.currentExampleMetadata after example run

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -81,6 +81,9 @@ final public class Example: _ExampleBase {
 
         let exampleMetadata = ExampleMetadata(example: self, exampleIndex: numberOfExamplesRun)
         world.currentExampleMetadata = exampleMetadata
+        defer {
+            world.currentExampleMetadata = nil
+        }
 
         world.exampleHooks.executeBefores(exampleMetadata)
         group!.phase = .beforesExecuting


### PR DESCRIPTION
Cherry-picks #716.

This actually fixes Xcode 10's parallel testing problem: https://github.com/Quick/Quick/issues/801#issuecomment-402518207.