### PR TITLE
Update Nimble to 7.1.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
-          "version": "7.1.1"
+          "revision": "9c1379fdcd58c4f2278aea5e029394ba9a2b8f07",
+          "version": "7.1.3"
         }
       }
     ]


### PR DESCRIPTION
https://github.com/Quick/Nimble/releases/tag/v7.1.3

For `1.x-branch`: https://github.com/Quick/Quick/pull/807