### PR TITLE
Xcode 10: Adjust Build Phases order

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -994,9 +994,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F118CE61BDCA4AB005013A2 /* Build configuration list for PBXNativeTarget "Quick-tvOS" */;
 			buildPhases = (
+				1F118CD21BDCA4AB005013A2 /* Headers */,
 				1F118CD01BDCA4AB005013A2 /* Sources */,
 				1F118CD11BDCA4AB005013A2 /* Frameworks */,
-				1F118CD21BDCA4AB005013A2 /* Headers */,
 				1F118CD31BDCA4AB005013A2 /* Resources */,
 			);
 			buildRules = (
@@ -1048,9 +1048,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5A5D119319473F2100F6D13D /* Build configuration list for PBXNativeTarget "Quick-iOS" */;
 			buildPhases = (
+				5A5D117919473F2100F6D13D /* Headers */,
 				5A5D117719473F2100F6D13D /* Sources */,
 				5A5D117819473F2100F6D13D /* Frameworks */,
-				5A5D117919473F2100F6D13D /* Headers */,
 				5A5D117A19473F2100F6D13D /* Resources */,
 			);
 			buildRules = (
@@ -1184,9 +1184,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DAEB6BA41943873200289F44 /* Build configuration list for PBXNativeTarget "Quick-macOS" */;
 			buildPhases = (
+				DAEB6B8B1943873100289F44 /* Headers */,
 				DAEB6B891943873100289F44 /* Sources */,
 				DAEB6B8A1943873100289F44 /* Frameworks */,
-				DAEB6B8B1943873100289F44 /* Headers */,
 				DAEB6B8C1943873100289F44 /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
`Headers` should be placed before `Sources` to match with the Xcode 10's project template.

Fixes #799.

For CocoaPods users, they need to update `xcodeproj` gem: https://github.com/CocoaPods/Xcodeproj/blob/master/CHANGELOG.md#160-2018-08-16

> Create new targets with the Xcode 10 default ordering for build phases.