### PR TITLE
Fix Xcode 10 warning

### DIFF
--- a/Sources/Quick/Behavior.swift
+++ b/Sources/Quick/Behavior.swift
@@ -4,7 +4,7 @@
 
 open class Behavior<Context> {
 
-    open static var name: String { return String(describing: self) }
+    public static var name: String { return String(describing: self) }
     /**
      override this method in your behavior to define a set of reusable examples.
 


### PR DESCRIPTION
This PR will suppress the following warning:
```
Pods/Quick/Sources/Quick/Behavior.swift#L7: static declarations are implicitly ‘final’; use ‘public’ instead of ‘open’ 
open static var name: String { return String(describing: self) }
```

