### PR TITLE
Use `#if canImport` implemented in Swift 4.1 (SE-0075)

### DIFF
--- a/Sources/Quick/Callsite.swift
+++ b/Sources/Quick/Callsite.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 @objcMembers
 public class _CallsiteBase: NSObject {}
 #else

--- a/Sources/Quick/Configuration/Configuration.swift
+++ b/Sources/Quick/Configuration/Configuration.swift
@@ -72,7 +72,7 @@ final public class Configuration: NSObject {
         provided with metadata on the example that the closure is being run
         prior to.
     */
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     @objc(beforeEachWithMetadata:)
     public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         exampleHooks.appendBefore(closure)
@@ -109,7 +109,7 @@ final public class Configuration: NSObject {
         is provided with metadata on the example that the closure is being
         run after.
     */
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     @objc(afterEachWithMetadata:)
     public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
         exampleHooks.appendAfter(closure)

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -10,7 +10,7 @@ open class QuickConfiguration: NSObject {
     open class func configure(_ configuration: Configuration) {}
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 
 internal func qck_enumerateSubclasses<T: AnyObject>(_ klass: T.Type, block: (T.Type) -> Void) {
     var classesCount = objc_getClassList(nil, 0)

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -56,7 +56,7 @@ extension World {
         currentExampleGroup.hooks.appendBefore(closure)
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     @objc(beforeEachWithMetadata:)
     internal func beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
         currentExampleGroup.hooks.appendBefore(closure)
@@ -74,7 +74,7 @@ extension World {
         currentExampleGroup.hooks.appendAfter(closure)
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     @objc(afterEachWithMetadata:)
     internal func afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
         currentExampleGroup.hooks.appendAfter(closure)
@@ -172,7 +172,7 @@ extension World {
         self.itBehavesLike(behavior, context: context, flags: pendingFlags, file: file, line: line)
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     @objc(itWithDescription:flags:file:line:closure:)
     internal func objc_it(_ description: String, flags: FilterFlags, file: String, line: UInt, closure: @escaping () -> Void) {
         it(description, flags: flags, file: file, line: line, closure: closure)

--- a/Sources/Quick/ErrorUtility.swift
+++ b/Sources/Quick/ErrorUtility.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal func raiseError(_ message: String) -> Never {
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     NSException(name: .internalInconsistencyException, reason: message, userInfo: nil).raise()
 #endif
 

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -3,7 +3,7 @@ import Foundation
 private var numberOfExamplesRun = 0
 private var numberOfIncludedExamples = 0
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 @objcMembers
 public class _ExampleBase: NSObject {}
 #else

--- a/Sources/Quick/ExampleMetadata.swift
+++ b/Sources/Quick/ExampleMetadata.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 @objcMembers
 public class _ExampleMetadataBase: NSObject {}
 #else

--- a/Sources/Quick/Filter.swift
+++ b/Sources/Quick/Filter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 @objcMembers
 public class _FilterBase: NSObject {}
 #else

--- a/Sources/Quick/NSBundle+CurrentTestBundle.swift
+++ b/Sources/Quick/NSBundle+CurrentTestBundle.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 
 import Foundation
 

--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Foundation
 
 extension NSString {

--- a/Sources/Quick/QuickMain.swift
+++ b/Sources/Quick/QuickMain.swift
@@ -3,7 +3,7 @@ import XCTest
 // NOTE: This file is not intended to be included in the Xcode project or CocoaPods.
 //       It is picked up by the Swift Package Manager during its build process.
 
-#if SWIFT_PACKAGE && os(Linux)
+#if SWIFT_PACKAGE && !canImport(Darwin)
 
 /// When using Quick with swift-corelibs-xctest, automatic discovery of specs and
 /// configurations is not available. Instead, you should create a standalone

--- a/Sources/Quick/QuickSelectedTestSuiteBuilder.swift
+++ b/Sources/Quick/QuickSelectedTestSuiteBuilder.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Foundation
 
 /**

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -5,7 +5,7 @@ import XCTest
 
 #if SWIFT_PACKAGE
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import QuickSpecBase
 
 public typealias QuickSpecBase = _QuickSpecBase
@@ -16,7 +16,7 @@ public typealias QuickSpecBase = XCTestCase
 open class QuickSpec: QuickSpecBase {
     open func spec() {}
 
-#if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+#if !canImport(Darwin)
     public required init() {
         super.init(name: "", testClosure: { _ in })
     }

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 
 import XCTest
 

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -12,7 +12,7 @@ public typealias SharedExampleContext = () -> [String: Any]
 */
 public typealias SharedExampleClosure = (@escaping SharedExampleContext) -> Void
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 @objcMembers
 internal class _WorldBase: NSObject {}
 #else
@@ -51,7 +51,7 @@ final internal class World: _WorldBase {
         within this test suite. This is only true within the context of Quick
         functional tests.
     */
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     // Convention of generating Objective-C selector has been changed on Swift 3
     @objc(isRunningAdditionalSuites)
     internal var isRunningAdditionalSuites = false
@@ -152,7 +152,7 @@ final internal class World: _WorldBase {
         }
     }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     @objc(examplesForSpecClass:)
     internal func objc_examples(_ specClass: AnyClass) -> [Example] {
         return examples(specClass)

--- a/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
+++ b/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
@@ -30,7 +30,7 @@ public extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 
     extension XCTestCase {
         override open func tearDown() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -50,7 +50,7 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
                 afterEach { afterEachOrder.append(.noExamples) }
             }
         }
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including afterEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -35,7 +35,7 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
                 beforeEach { beforeEachOrder.append(.noExamples) }
             }
         }
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including beforeEach in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -17,7 +17,7 @@ class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
     }
 }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 class FunctionalTests_BehaviorTests_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Quick
 import Nimble
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 class QuickContextTests: QuickSpec {
     override func spec() {
         describe("Context") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 import Quick
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 
 final class DescribeTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (DescribeTests) -> () throws -> Void)] {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -16,7 +16,7 @@ class FunctionalTests_ItSpec: QuickSpec {
             expect(exampleMetadata!.example.name).to(equal(name))
         }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 
         describe("when an example has a unique name") {
             it("has a unique name") {}
@@ -113,7 +113,7 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
     func testAllExamplesAreExecuted() {
         let result = qck_runSpec(FunctionalTests_ItSpec.self)
         XCTAssertEqual(result?.executionCount, 10)

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -15,7 +15,7 @@ class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
     }
 }
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if canImport(Darwin) && !SWIFT_PACKAGE
 class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
     override func spec() {
         describe("error handling when misusing ordering") {


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md

There should be no behavioral change, just replacing `#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)` with `#if canImport(Darwin)`.