### PR TITLE
[1.x][SwiftPM] Update swiftLanguageVersions to 4 for Package@swift-4.swift

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -36,5 +36,5 @@ let package = Package(
 #endif
         return targets
     }(),
-    swiftLanguageVersions: [3]
+    swiftLanguageVersions: [4]
 )


### PR DESCRIPTION
This would make it possible for Quick 1.x to be consumed with Swift 5's SwiftPM which does not support Swift 3 mode anymore.