### PR TITLE
[SwiftPM] Update Package.swift to support Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,12 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
     name: "Quick",
+    platforms: [
+        .iOS(.v8), .macOS(.v10_10), .tvOS(.v9)
+    ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
     ],
@@ -36,5 +39,5 @@ let package = Package(
 #endif
         return targets
     }(),
-    swiftLanguageVersions: [.v4_2]
+    swiftLanguageVersions: [.v4_2, .v5]
 )

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,12 +1,9 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 
 import PackageDescription
 
 let package = Package(
     name: "Quick",
-    platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
-    ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
     ],
@@ -39,5 +36,5 @@ let package = Package(
 #endif
         return targets
     }(),
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [.v4_2]
 )


### PR DESCRIPTION
As upgrading to Swift 5, without having `platforms` the default deployment target is set to the latest version of each OS. It causes a compile error.

* Add `platforms`
* Add `.v5` to `swiftLanguageVersions`