### PR TITLE
Support QuickSpec.current on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,17 @@ matrix:
       sudo: required
       dist: trusty
       env:
-        - SWIFT_VERSION=4.2.1
+        - SWIFT_VERSION=4.2.4
       install: ./script/travis-install-linux
       script: ./script/travis-script-linux
     - <<: *swiftpm_linux
-      name: SwiftPM / Linux / Swift 5.0 Development
+      name: SwiftPM / Linux / Swift 5.0
       env:
-        - SWIFT_VERSION=5.0-DEVELOPMENT-SNAPSHOT-2019-02-28-a
+        - SWIFT_VERSION=5.0
+    - <<: *swiftpm_linux
+      name: SwiftPM / Linux / Swift Trunk Development
+      env:
+        - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2019-04-04-a
 
 notifications:
   email: false

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		CD261AC81DEC8B0000A8863C /* QuickConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickConfiguration.swift; sourceTree = "<group>"; };
 		CD3451461E4703D4000C8633 /* QuickMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickMain.swift; sourceTree = "<group>"; };
 		CD3451471E4703D4000C8633 /* QuickSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickSpec.swift; sourceTree = "<group>"; };
+		CD665CE0225A5BB9008F0AE6 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = SOURCE_ROOT; };
 		CE175D4D1E8D6B4900EB5E84 /* Behavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
 		CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorTests.swift; sourceTree = "<group>"; };
 		CE4A578D1EA7251C0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalTests_BehaviorTests_Behaviors.swift; sourceTree = "<group>"; };
@@ -915,6 +916,7 @@
 		DAEB6B9D1943873100289F44 /* QuickTests */ = {
 			isa = PBXGroup;
 			children = (
+				CD665CE0225A5BB9008F0AE6 /* LinuxMain.swift */,
 				DA8C00201A01E4B900CE58A6 /* QuickConfigurationTests.m */,
 				DA8F919419F31680006F6675 /* Helpers */,
 				DAEB6BCD194387D700289F44 /* Fixtures */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,42 +4,43 @@ import Quick
 @testable import QuickTests
 
 Quick.QCKMain([
-    FunctionalTests_AfterEachSpec.self,
     AfterSuiteTests.self,
+    Configuration_AfterEachSpec.self,
+    Configuration_BeforeEachSpec.self,
+    CurrentSpecTests.self,
+    FunctionalTests_AfterEachSpec.self,
     FunctionalTests_BeforeEachSpec.self,
     FunctionalTests_BeforeSuite_BeforeSuiteSpec.self,
     FunctionalTests_BeforeSuite_Spec.self,
     FunctionalTests_ItSpec.self,
     FunctionalTests_PendingSpec.self,
-    FunctionalTests_SharedExamples_BeforeEachSpec.self,
-    FunctionalTests_SharedExamples_Spec.self,
-    FunctionalTests_SharedExamples_ContextSpec.self,
-    Configuration_AfterEachSpec.self,
-    Configuration_BeforeEachSpec.self,
     FunctionalTests_CrossReferencingSpecA.self,
     FunctionalTests_CrossReferencingSpecB.self,
+    FunctionalTests_SharedExamples_BeforeEachSpec.self,
+    FunctionalTests_SharedExamples_ContextSpec.self,
+    FunctionalTests_SharedExamples_Spec.self,
     _FunctionalTests_FocusedSpec_Focused.self,
     _FunctionalTests_FocusedSpec_Unfocused.self
 ],
 configurations: [
-    FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,
-    FunctionalTests_SharedExamplesTests_SharedExamples.self,
     FunctionalTests_Configuration_AfterEach.self,
     FunctionalTests_Configuration_BeforeEach.self,
-    FunctionalTests_FocusedSpec_SharedExamplesConfiguration.self
+    FunctionalTests_FocusedSpec_SharedExamplesConfiguration.self,
+    FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples.self,
+    FunctionalTests_SharedExamplesTests_SharedExamples.self
 ],
 testCases: [
     testCase(AfterEachTests.allTests),
     testCase(BeforeEachTests.allTests),
     testCase(BeforeSuiteTests.allTests),
+    testCase(Configuration_AfterEachTests.allTests),
+    testCase(Configuration_BeforeEachTests.allTests),
     // testCase(DescribeTests.allTests),
+    testCase(FocusedTests.allTests),
+    testCase(FunctionalTests_CrossReferencingSpecA.allTests),
+    testCase(FunctionalTests_CrossReferencingSpecB.allTests),
     testCase(ItTests.allTests),
     testCase(PendingTests.allTests),
     testCase(SharedExamples_BeforeEachTests.allTests),
-    testCase(SharedExamplesTests.allTests),
-    testCase(Configuration_AfterEachTests.allTests),
-    testCase(Configuration_BeforeEachTests.allTests),
-    testCase(FocusedTests.allTests),
-    testCase(FunctionalTests_CrossReferencingSpecA.allTests),
-    testCase(FunctionalTests_CrossReferencingSpecB.allTests)
+    testCase(SharedExamplesTests.allTests)
 ])

--- a/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
@@ -2,12 +2,18 @@ import Quick
 import Nimble
 import Dispatch
 
-#if canImport(Darwin)
-
 class CurrentSpecTests: QuickSpec {
     override func spec() {
         it("returns the currently executing spec") {
-            expect(QuickSpec.current.name).to(match("currently_executing_spec"))
+            let name: String = {
+                let result = QuickSpec.current.name
+                #if canImport(Darwin)
+                return result.replacingOccurrences(of: "_", with: " ")
+                #else
+                return result
+                #endif
+            }()
+            expect(name).to(match("returns the currently executing spec"))
         }
 
         let currentSpecDuringSpecSetup = QuickSpec.current
@@ -17,10 +23,15 @@ class CurrentSpecTests: QuickSpec {
 
         it("supports XCTest expectations") {
             let expectation = QuickSpec.current.expectation(description: "great expectation")
-            DispatchQueue.main.async(execute: expectation.fulfill)
+            let fulfill: () -> Void
+            #if canImport(Darwin)
+            fulfill = expectation.fulfill
+            #else
+            // https://github.com/apple/swift-corelibs-xctest/blob/51afda0bc782b2d6a2f00fbdca58943faf6ccecd/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift#L233-L253
+            fulfill = { expectation.fulfill() }
+            #endif
+            DispatchQueue.main.async(execute: fulfill)
             QuickSpec.current.waitForExpectations(timeout: 1)
         }
     }
 }
-
-#endif


### PR DESCRIPTION
Ref: #645, #848

This is a preparation for #680 which uses `QuickSpec.current`.

 - [x] Does this have tests? Already exists
 - [x] Does this have documentation? Already exists
 - [x] Does this break the public API (Requires major version bump)? No
 - [x] Is this a new feature (Requires minor version bump)? Yes