### PR TITLE
[refactoring] Make test helpers non-public (internal)

### DIFF
--- a/Tests/QuickTests/QuickTestHelpers/SpecRunner.swift
+++ b/Tests/QuickTests/QuickTestHelpers/SpecRunner.swift
@@ -2,12 +2,12 @@
 import Nimble
 
 @discardableResult
-public func qck_runSpec(_ specClass: QuickSpec.Type) -> TestRun? {
+func qck_runSpec(_ specClass: QuickSpec.Type) -> TestRun? {
     return qck_runSpecs([specClass])
 }
 
 @discardableResult
-public func qck_runSpecs(_ specClasses: [QuickSpec.Type]) -> TestRun? {
+func qck_runSpecs(_ specClasses: [QuickSpec.Type]) -> TestRun? {
     Quick.World.sharedWorld.isRunningAdditionalSuites = true
 
     var executionCount: UInt = 0

--- a/Tests/QuickTests/QuickTestHelpers/TestRun.swift
+++ b/Tests/QuickTests/QuickTestHelpers/TestRun.swift
@@ -1,9 +1,4 @@
-public struct TestRun {
-    public var executionCount: UInt
-    public var hasSucceeded: Bool
-
-    public init(executionCount: UInt, hasSucceeded: Bool) {
-        self.executionCount = executionCount
-        self.hasSucceeded = hasSucceeded
-    }
+struct TestRun {
+    var executionCount: UInt
+    var hasSucceeded: Bool
 }

--- a/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
+++ b/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
@@ -10,19 +10,19 @@ import XCTest
 // Implementation note: This is broken down into two separate protocols because we need a
 // protocol with no Self references to which we can cast XCTestCase instances in a non-generic context.
 
-public protocol XCTestCaseProviderStatic {
+protocol XCTestCaseProviderStatic {
     // This should be explicitly implemented by XCTestCase subclasses
     static var allTests: [(String, (Self) -> () throws -> Void)] { get }
 }
 
-public protocol XCTestCaseNameProvider {
+protocol XCTestCaseNameProvider {
     // This does not need to be explicitly implemented because of the protocol extension below
     var allTestNames: [String] { get }
 }
 
-public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
+protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
 
-public extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
+extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
     var allTestNames: [String] {
         return type(of: self).allTests.map { name, _ in
             return name


### PR DESCRIPTION
Since they are in a test target, they don't need to be public.