### PR TITLE
[SwiftPM] Don't exclude QuickTests/Helpers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,9 @@ let package = Package(
                     "QuickAfterSuiteTests/AfterSuiteTests+ObjC.m",
                     "QuickFocusedTests/FocusedTests+ObjC.m",
                     "QuickTests/FunctionalTests/ObjC",
-                    "QuickTests/Helpers",
+                    "QuickTests/Helpers/QCKSpecRunner.h",
+                    "QuickTests/Helpers/QCKSpecRunner.m",
+                    "QuickTests/Helpers/QuickTestsBridgingHeader.h",
                     "QuickTests/QuickConfigurationTests.m",
                 ]
             ),

--- a/Tests/QuickTests/QuickTests/Helpers/QuickSpec+MethodList.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/QuickSpec+MethodList.swift
@@ -1,3 +1,4 @@
+#if canImport(Darwin) && !SWIFT_PACKAGE
 import Foundation
 import Quick
 
@@ -20,3 +21,4 @@ extension QuickSpec {
         return allSelectors
     }
 }
+#endif

--- a/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
@@ -1,3 +1,4 @@
+#if canImport(Darwin) && !SWIFT_PACKAGE
 import Foundation
 import XCTest
 @testable import Quick
@@ -57,3 +58,4 @@ class QuickSpecRunner: NSObject {
         return qck_runSpecs(specClasses)
     }
 }
+#endif

--- a/Tests/QuickTests/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/XCTestObservationCenter+QCKSuspendObservation.swift
@@ -1,3 +1,4 @@
+#if canImport(Darwin) && !SWIFT_PACKAGE
 import Foundation
 import XCTest
 
@@ -43,3 +44,4 @@ extension XCTestObservationCenter {
         return block()
     }
 }
+#endif


### PR DESCRIPTION
Instead let's conditionally compile them.

In a future, I'd like to reuse them in SwiftPM builds on Darwin.

Refs: #861, #860, #859, #858 