### PR TITLE
[refactoring][QuickSpec.swift] Use `World.performWithCurrentExampleGroup`

### DIFF
--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -132,9 +132,9 @@ open class QuickSpec: QuickSpecBase {
         let world = World.sharedWorld
         let rootExampleGroup = world.rootExampleGroupForSpecClass(self)
         if rootExampleGroup.examples.isEmpty {
-            world.currentExampleGroup =  rootExampleGroup
-            self.init().spec()
-            world.currentExampleGroup = nil
+            world.performWithCurrentExampleGroup(rootExampleGroup) {
+                self.init().spec()
+            }
         }
     }
 }


### PR DESCRIPTION
There should be no behavioral change.