### PR TITLE
[refactoring] Remove _QuickSelectorWrapper and use String instead

### DIFF
--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -71,13 +71,13 @@ open class QuickSpec: QuickSpecBase {
         _ = allTests
     }
 
-    override open class func _qck_testMethodSelectors() -> [_QuickSelectorWrapper] {
+    override open class func _qck_testMethodSelectors() -> [String] {
         let examples = World.sharedWorld.examples(self)
 
         var selectorNames = Set<String>()
         return examples.map { example in
             let selector = addInstanceMethod(for: example, classSelectorNames: &selectorNames)
-            return _QuickSelectorWrapper(selector: selector)
+            return NSStringFromSelector(selector)
         }
     }
 

--- a/Sources/QuickSpecBase/QuickSpecBase.m
+++ b/Sources/QuickSpecBase/QuickSpecBase.m
@@ -1,22 +1,5 @@
 #import "QuickSpecBase.h"
 
-#pragma mark - _QuickSelectorWrapper
-
-@interface _QuickSelectorWrapper ()
-@property(nonatomic, assign) SEL selector;
-@end
-
-@implementation _QuickSelectorWrapper
-
-- (instancetype)initWithSelector:(SEL)selector {
-    self = [super init];
-    _selector = selector;
-    return self;
-}
-
-@end
-
-
 #pragma mark - _QuickSpecBase
 
 @implementation _QuickSpecBase
@@ -33,11 +16,11 @@
  @return An array of invocations that execute the newly defined example methods.
  */
 + (NSArray<NSInvocation *> *)testInvocations {
-    NSArray<_QuickSelectorWrapper *> *wrappers = [self _qck_testMethodSelectors];
-    NSMutableArray<NSInvocation *> *invocations = [NSMutableArray arrayWithCapacity:wrappers.count];
+    NSArray<NSString *> *selectors = [self _qck_testMethodSelectors];
+    NSMutableArray<NSInvocation *> *invocations = [NSMutableArray arrayWithCapacity:selectors.count];
 
-    for (_QuickSelectorWrapper *wrapper in wrappers) {
-        SEL selector = wrapper.selector;
+    for (NSString *selectorString in selectors) {
+        SEL selector = NSSelectorFromString(selectorString);
         NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
         invocation.selector = selector;
@@ -48,7 +31,7 @@
     return invocations;
 }
 
-+ (NSArray<_QuickSelectorWrapper *> *)_qck_testMethodSelectors {
++ (NSArray<NSString *> *)_qck_testMethodSelectors {
     return @[];
 }
 

--- a/Sources/QuickSpecBase/include/QuickSpecBase.h
+++ b/Sources/QuickSpecBase/include/QuickSpecBase.h
@@ -1,11 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-@interface _QuickSelectorWrapper : NSObject
-- (instancetype)initWithSelector:(SEL)selector;
-@end
-
 @interface _QuickSpecBase : XCTestCase
-+ (NSArray<_QuickSelectorWrapper *> *)_qck_testMethodSelectors;
++ (NSArray<NSString *> *)_qck_testMethodSelectors;
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 @end


### PR DESCRIPTION
There should be no behavioral change.