### PR TITLE
[refactoring] Reduce uses of AnyClass, replace them with QuickSpec.Type where possible

### DIFF
--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -72,7 +72,7 @@ open class QuickSpec: QuickSpecBase {
     }
 
     override open class func _qck_testMethodSelectors() -> [String] {
-        let examples = World.sharedWorld.examples(self)
+        let examples = World.sharedWorld.examples(forSpecClass: self)
 
         var selectorNames = Set<String>()
         return examples.map { example in
@@ -115,7 +115,7 @@ open class QuickSpec: QuickSpecBase {
 
         gatherExamplesIfNeeded()
 
-        let examples = World.sharedWorld.examples(self)
+        let examples = World.sharedWorld.examples(forSpecClass: self)
         let result = examples.map { example -> (String, (QuickSpec) -> () throws -> Void) in
             return (example.name, { spec in
                 return {
@@ -130,7 +130,7 @@ open class QuickSpec: QuickSpecBase {
 
     internal static func gatherExamplesIfNeeded() {
         let world = World.sharedWorld
-        let rootExampleGroup = world.rootExampleGroupForSpecClass(self)
+        let rootExampleGroup = world.rootExampleGroup(forSpecClass: self)
         if rootExampleGroup.examples.isEmpty {
             world.performWithCurrentExampleGroup(rootExampleGroup) {
                 self.init().spec()

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -113,11 +113,11 @@ final internal class World: _WorldBase {
                 it("is at the top level") {}
             }
 
-        - parameter cls: The QuickSpec class for which to retrieve the root example group.
+        - parameter specClass: The QuickSpec class for which to retrieve the root example group.
         - returns: The root example group for the class.
     */
-    internal func rootExampleGroupForSpecClass(_ cls: AnyClass) -> ExampleGroup {
-        let name = String(describing: cls)
+    internal func rootExampleGroup(forSpecClass specClass: QuickSpec.Type) -> ExampleGroup {
+        let name = String(describing: specClass)
 
         if let group = specs[name] {
             return group
@@ -141,23 +141,16 @@ final internal class World: _WorldBase {
         - parameter specClass: The QuickSpec subclass for which examples are to be returned.
         - returns: A list of examples to be run as test invocations.
     */
-    internal func examples(_ specClass: AnyClass) -> [Example] {
+    internal func examples(forSpecClass specClass: QuickSpec.Type) -> [Example] {
         // 1. Grab all included examples.
         let included = includedExamples
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.
-        let spec = rootExampleGroupForSpecClass(specClass).examples.filter { included.contains($0) }
+        let spec = rootExampleGroup(forSpecClass: specClass).examples.filter { included.contains($0) }
         // 3. Remove all excluded examples.
         return spec.filter { example in
             !self.configuration.exclusionFilters.reduce(false) { $0 || $1(example) }
         }
     }
-
-#if canImport(Darwin)
-    @objc(examplesForSpecClass:)
-    internal func objc_examples(_ specClass: AnyClass) -> [Example] {
-        return examples(specClass)
-    }
-#endif
 
     // MARK: Internal
 


### PR DESCRIPTION
There should be no behavioral change.