### PR TITLE
Don't call `+[QuickConfiguration initialize]` method manually

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -147,6 +147,9 @@
 		CD582D762264C137008F7CE6 /* QuickSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD582D722264C137008F7CE6 /* QuickSpecRunner.swift */; };
 		CD582D772264C137008F7CE6 /* QuickSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD582D722264C137008F7CE6 /* QuickSpecRunner.swift */; };
 		CD582D782264C137008F7CE6 /* QuickSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD582D722264C137008F7CE6 /* QuickSpecRunner.swift */; };
+		CDB2A957226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */; };
+		CDB2A958226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */; };
+		CDB2A959226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */; };
 		CDE5BDFD2268CE95006E2F66 /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD261AC81DEC8B0000A8863C /* QuickConfiguration.swift */; };
 		CDE5BDFE2268CE96006E2F66 /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD261AC81DEC8B0000A8863C /* QuickConfiguration.swift */; };
 		CDE5BDFF2268CE97006E2F66 /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD261AC81DEC8B0000A8863C /* QuickConfiguration.swift */; };
@@ -513,6 +516,7 @@
 		CD582D6E2264B371008F7CE6 /* QuickSpec+MethodList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuickSpec+MethodList.swift"; sourceTree = "<group>"; };
 		CD582D722264C137008F7CE6 /* QuickSpecRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpecRunner.swift; sourceTree = "<group>"; };
 		CD665CE0225A5BB9008F0AE6 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = SOURCE_ROOT; };
+		CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassOfSubclassWithStructPropertyTests.swift; sourceTree = "<group>"; };
 		CE175D4D1E8D6B4900EB5E84 /* Behavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
 		CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorTests.swift; sourceTree = "<group>"; };
 		CE4A578D1EA7251C0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalTests_BehaviorTests_Behaviors.swift; sourceTree = "<group>"; };
@@ -801,6 +805,7 @@
 				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
+				CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1471,6 +1476,7 @@
 				CE4A57911EA7252E0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DED3037F1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */,
 				1F118D0F1BDCA54B005013A2 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
+				CDB2A959226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */,
 				CD1F6507226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				1F118D101BDCA556005013A2 /* Configuration+AfterEach.swift in Sources */,
 				1F118D1A1BDCA556005013A2 /* PendingTests.swift in Sources */,
@@ -1557,6 +1563,7 @@
 				DA05D61119F73A3800771050 /* AfterEachTests.swift in Sources */,
 				DAB0137019FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
 				DA8F91A619F3208B006F6675 /* BeforeSuiteTests.swift in Sources */,
+				CDB2A958226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */,
 				CD1F6505226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				DA8C00221A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
 				CE4A578A1EA5DC270063C0D4 /* BehaviorTests.swift in Sources */,
@@ -1683,6 +1690,7 @@
 				CE4A57921EA725300063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DED3037D1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */,
 				DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */,
+				CDB2A957226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift in Sources */,
 				CD1F6503226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				DAB0136F19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
 				DA8F91A519F3208B006F6675 /* BeforeSuiteTests.swift in Sources */,

--- a/Sources/QuickObjectiveC/Configuration/QuickConfiguration.m
+++ b/Sources/QuickObjectiveC/Configuration/QuickConfiguration.m
@@ -35,19 +35,12 @@
 + (void)initialize {
     // Only enumerate over the subclasses of QuickConfiguration, not any of its subclasses.
     if ([self class] == [QuickConfiguration class]) {
-
-        // Only enumerate over subclasses once, even if +[QuickConfiguration initialize]
-        // were to be called several times. This is necessary because +[QuickSpec initialize]
-        // manually calls +[QuickConfiguration initialize].
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            [QuickConfiguration enumerateSubclasses:^(Class _Nonnull __unsafe_unretained klass) {
-                [[World sharedWorld] configure:^(Configuration *configuration) {
-                    [klass configure:configuration];
-                }];
+        [QuickConfiguration enumerateSubclasses:^(Class _Nonnull __unsafe_unretained klass) {
+            [[World sharedWorld] configure:^(Configuration *configuration) {
+                [klass configure:configuration];
             }];
-            [[World sharedWorld] finalizeConfiguration];
-        });
+        }];
+        [[World sharedWorld] finalizeConfiguration];
     }
 }
 

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -26,7 +26,7 @@ static QuickSpec *currentSpec = nil;
  included an expectation outside of a "it", "describe", or "context" block.
  */
 + (void)initialize {
-    [QuickConfiguration initialize];
+    [QuickConfiguration class];
 
     World *world = [World sharedWorld];
     [world performWithCurrentExampleGroup:[world rootExampleGroupForSpecClass:self] closure:^{

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -18,14 +18,12 @@ static QuickSpec *currentSpec = nil;
 #pragma mark - XCTestCase Overrides
 
 /**
- The runtime sends initialize to each class in a program just before the class, or any class
- that inherits from it, is sent its first message from within the program. QuickSpec hooks into
- this event to compile the example groups for this spec subclass.
+ QuickSpec hooks into this event to compile the example groups for this spec subclass.
 
  If an exception occurs when compiling the examples, report it to the user. Chances are they
  included an expectation outside of a "it", "describe", or "context" block.
  */
-+ (void)initialize {
++ (XCTestSuite *)defaultTestSuite {
     [QuickConfiguration class];
 
     World *world = [World sharedWorld];
@@ -48,6 +46,8 @@ static QuickSpec *currentSpec = nil;
         }
         [self testInvocations];
     }];
+
+    return [super defaultTestSuite];
 }
 
 /**

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -19,6 +19,8 @@ Quick.QCKMain([
     FunctionalTests_SharedExamples_BeforeEachSpec.self,
     FunctionalTests_SharedExamples_ContextSpec.self,
     FunctionalTests_SharedExamples_Spec.self,
+    FunctionalTests_SubclassSpec.self,
+    FunctionalTests_SubclassOfSubclassWithStructPropertySpec.self,
     _FunctionalTests_FocusedSpec_Focused.self,
     _FunctionalTests_FocusedSpec_Unfocused.self
 ],

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassOfSubclassWithStructPropertyTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassOfSubclassWithStructPropertyTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+import Quick
+
+// The regression test for https://github.com/Quick/Quick/issues/853
+
+class FunctionalTests_SubclassSpec: QuickSpec {}
+class FunctionalTests_SubclassOfSubclassWithStructPropertySpec: FunctionalTests_SubclassSpec {
+    let date = Date()
+
+    override func spec() {}
+}


### PR DESCRIPTION
Fixes #853.

This fixes a runtime crash when a subclass of QuickSpec is subclassed and the subclass has a Swift struct property. This avoids nested calls of `+[QuickConfiguration initialize]` and `objc_getClassList`.