### PR TITLE
[refactor] Convert some global variables into World's states

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-private var numberOfExamplesRun = 0
-private var numberOfIncludedExamples = 0
-
 #if canImport(Darwin)
 @objcMembers
 public class _ExampleBase: NSObject {}
@@ -65,15 +62,11 @@ final public class Example: _ExampleBase {
     public func run() {
         let world = World.sharedWorld
 
-        if numberOfIncludedExamples == 0 {
-            numberOfIncludedExamples = world.includedExampleCount
-        }
-
-        if numberOfExamplesRun == 0 {
+        if world.numberOfExamplesRun == 0 {
             world.suiteHooks.executeBefores()
         }
 
-        let exampleMetadata = ExampleMetadata(example: self, exampleIndex: numberOfExamplesRun)
+        let exampleMetadata = ExampleMetadata(example: self, exampleIndex: world.numberOfExamplesRun)
         world.currentExampleMetadata = exampleMetadata
         defer {
             world.currentExampleMetadata = nil
@@ -95,9 +88,9 @@ final public class Example: _ExampleBase {
         group!.phase = .aftersFinished
         world.exampleHooks.executeAfters(exampleMetadata)
 
-        numberOfExamplesRun += 1
+        world.numberOfExamplesRun += 1
 
-        if !world.isRunningAdditionalSuites && numberOfExamplesRun >= numberOfIncludedExamples {
+        if !world.isRunningAdditionalSuites && world.numberOfExamplesRun >= world.cachedIncludedExampleCount {
             world.suiteHooks.executeAfters()
         }
     }

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -46,6 +46,8 @@ final internal class World: _WorldBase {
 
     internal var currentExampleMetadata: ExampleMetadata?
 
+    internal var numberOfExamplesRun = 0
+
     /**
         A flag that indicates whether additional test suites are being run
         within this test suite. This is only true within the context of Quick
@@ -167,6 +169,8 @@ final internal class World: _WorldBase {
     internal var includedExampleCount: Int {
         return includedExamples.count
     }
+
+    internal lazy var cachedIncludedExampleCount: Int = self.includedExampleCount
 
     internal var beforesCurrentlyExecuting: Bool {
         let suiteBeforesExecuting = suiteHooks.phase == .beforesExecuting


### PR DESCRIPTION
This makes it easy to create separate World instances when running additional test suites.