### PR TITLE
Add (before|after)EachAutoreleasepool hooks

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		1B77503622844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
 		1B77503722844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
 		1B77503822844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
+		1BDDC5FC228461500060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BDDC5FA228461380060F8E2 /* AutoreleasepoolTests+ObjC.m */; };
+		1BDDC5FD228461510060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BDDC5FA228461380060F8E2 /* AutoreleasepoolTests+ObjC.m */; };
+		1BDDC5FE228461520060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BDDC5FA228461380060F8E2 /* AutoreleasepoolTests+ObjC.m */; };
 		1F118CDF1BDCA4AB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
 		1F118CF51BDCA4BB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
 		1F118CFB1BDCA536005013A2 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE714FD19FF6A62005905B8 /* QuickConfiguration.m */; };
@@ -482,6 +485,7 @@
 
 /* Begin PBXFileReference section */
 		1B77503522844254002C6143 /* AutoreleasepoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoreleasepoolTests.swift; sourceTree = "<group>"; };
+		1BDDC5FA228461380060F8E2 /* AutoreleasepoolTests+ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AutoreleasepoolTests+ObjC.m"; sourceTree = "<group>"; };
 		1F118CD51BDCA4AB005013A2 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F118CDE1BDCA4AB005013A2 /* Quick - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F118CF01BDCA4BB005013A2 /* QuickFocused - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickFocused - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -736,6 +740,7 @@
 			isa = PBXGroup;
 			children = (
 				470D6EC91A43409600043E50 /* AfterEachTests+ObjC.m */,
+				1BDDC5FA228461380060F8E2 /* AutoreleasepoolTests+ObjC.m */,
 				47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */,
 				47876F7B1A4999B0002575C7 /* BeforeSuiteTests+ObjC.m */,
 				DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */,
@@ -1501,6 +1506,7 @@
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
 				CD582D772264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */,
+				1BDDC5FE228461520060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */,
 				34C586051C4ABD4100D4F057 /* XCTestCaseProvider.swift in Sources */,
 				8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */,
 				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
@@ -1589,6 +1595,7 @@
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D752264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586031C4ABD4000D4F057 /* XCTestCaseProvider.swift in Sources */,
+				1BDDC5FD228461510060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */,
 				8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */,
 				47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECC1A43442900043E50 /* AfterEachTests+ObjC.m in Sources */,
@@ -1717,6 +1724,7 @@
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D732264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586011C4ABD3F00D4F057 /* XCTestCaseProvider.swift in Sources */,
+				1BDDC5FC228461500060F8E2 /* AutoreleasepoolTests+ObjC.m in Sources */,
 				8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */,
 				47FAEA361A3F49E6005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECB1A43442400043E50 /* AfterEachTests+ObjC.m in Sources */,

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1B77503622844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
+		1B77503722844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
+		1B77503822844254002C6143 /* AutoreleasepoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77503522844254002C6143 /* AutoreleasepoolTests.swift */; };
 		1F118CDF1BDCA4AB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
 		1F118CF51BDCA4BB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
 		1F118CFB1BDCA536005013A2 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE714FD19FF6A62005905B8 /* QuickConfiguration.m */; };
@@ -478,6 +481,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B77503522844254002C6143 /* AutoreleasepoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoreleasepoolTests.swift; sourceTree = "<group>"; };
 		1F118CD51BDCA4AB005013A2 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F118CDE1BDCA4AB005013A2 /* Quick - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F118CF01BDCA4BB005013A2 /* QuickFocused - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickFocused - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -806,6 +810,7 @@
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
 				CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */,
+				1B77503522844254002C6143 /* AutoreleasepoolTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1490,6 +1495,7 @@
 				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
 				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
 				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
+				1B77503822844254002C6143 /* AutoreleasepoolTests.swift in Sources */,
 				CD582D712264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
@@ -1577,6 +1583,7 @@
 				AED9C8641CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590411A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919E19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
+				1B77503722844254002C6143 /* AutoreleasepoolTests.swift in Sources */,
 				CD582D702264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
@@ -1704,6 +1711,7 @@
 				AED9C8631CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590401A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919D19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
+				1B77503622844254002C6143 /* AutoreleasepoolTests.swift in Sources */,
 				CD582D6F2264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -138,6 +138,26 @@ public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
 }
 
 /**
+     Defines a closure to be run after each example's autoreleasepool in the current
+     example group is released. This closure is not run for pending or otherwise
+     disabled examples. An example group may contain an unlimited number of afterEach.
+     They'll be run in the order they're defined, but you shouldn't rely on that behavior.
+
+     - parameter closure: The closure to be run after each example.
+ */
+public func afterEachAutoreleasepool(_ closure: @escaping AfterExampleClosure) {
+    World.sharedWorld.afterEachAutoreleasepool(closure)
+}
+
+/**
+ Identical to Quick.DSL.afterEach, except the closure is provided with
+ metadata on the example that the closure is being run after.
+ */
+public func afterEachAutoreleasepool(_ closure: @escaping AfterExampleWithMetadataClosure) {
+    World.sharedWorld.afterEachAutoreleasepool(closure: closure)
+}
+
+/**
     Defines an example. Examples use assertions to demonstrate how code should
     behave. These are like "tests" in XCTest.
 

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -97,6 +97,27 @@ public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
 }
 
 /**
+    Defines a closure to be run prior the creation of the autorelease pool for each
+    example in the current example group. This closure is not run for pending
+    or otherwise disabled examples. An example group may contain an unlimited
+    number of beforeEachAutoreleasepool. They'll be run in the order they're defined,
+    but you shouldn't rely on that behavior.
+
+     - parameter closure: The closure to be run prior to each example.
+ */
+public func beforeEachAutoreleasepool(_ closure: @escaping BeforeExampleClosure) {
+    World.sharedWorld.beforeEachAutoreleasepool(closure)
+}
+
+/**
+    Identical to Quick.DSL.beforeEachAutoreleasepool, except the closure is provided with
+    metadata on the example that the closure is being run prior to.
+ */
+public func beforeEachAutoreleasepool(_ closure: @escaping BeforeExampleWithMetadataClosure) {
+    World.sharedWorld.beforeEachAutoreleasepool(closure: closure)
+}
+
+/**
     Defines a closure to be run after each example in the current example
     group. This closure is not run for pending or otherwise disabled examples.
     An example group may contain an unlimited number of afterEach. They'll be

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -67,6 +67,24 @@ extension World {
     }
 #endif
 
+    internal func beforeEachAutoreleasepool(_ closure: @escaping BeforeExampleClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'beforeEachAutoreleasepool' cannot be used inside '\(currentPhase)', 'beforeEachAutoreleasepool' may only be used inside 'context' or 'describe'. ")
+        }
+        currentExampleGroup.hooks.appendBeforeAutoreleasepool(closure)
+    }
+
+#if canImport(Darwin)
+    @objc(beforeEachAutoreleasepoolWithMetadata:)
+    internal func beforeEachAutoreleasepool(closure: @escaping BeforeExampleWithMetadataClosure) {
+        currentExampleGroup.hooks.appendBeforeAutoreleasepool(closure)
+    }
+#else
+    internal func beforeEachAutoreleasepool(closure: @escaping BeforeExampleWithMetadataClosure) {
+        currentExampleGroup.hooks.appendBeforeAutoreleasepool(closure)
+    }
+#endif
+
     internal func afterEach(_ closure: @escaping AfterExampleClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'. ")

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -103,6 +103,24 @@ extension World {
     }
 #endif
 
+    internal func afterEachAutoreleasepool(_ closure: @escaping AfterExampleClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'afterEachAutoreleasepool' cannot be used inside '\(currentPhase)', 'afterEachAutoreleasepool' may only be used inside 'context' or 'describe'. ")
+        }
+        currentExampleGroup.hooks.appendAfterAutoreleasepool(closure)
+    }
+
+#if canImport(Darwin)
+    @objc(afterEachAutoreleasepoolWithMetadata:)
+    internal func afterEachAutoreleasepool(closure: @escaping AfterExampleWithMetadataClosure) {
+        currentExampleGroup.hooks.appendAfterAutoreleasepool(closure)
+    }
+#else
+    internal func afterEachAutoreleasepool(closure: @escaping AfterExampleWithMetadataClosure) {
+        currentExampleGroup.hooks.appendAfterAutoreleasepool(closure)
+    }
+#endif
+
     @nonobjc
     internal func it(_ description: String, flags: FilterFlags, file: FileString, line: UInt, closure: @escaping () -> Void) {
         if beforesCurrentlyExecuting {

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -72,6 +72,10 @@ final public class Example: _ExampleBase {
             world.currentExampleMetadata = nil
         }
 
+        for beforePool in group!.autoreleasepoolBefores {
+            beforePool(exampleMetadata)
+        }
+
         autoreleasepool {
             world.exampleHooks.executeBefores(exampleMetadata)
             group!.phase = .beforesExecuting

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -94,6 +94,10 @@ final public class Example: _ExampleBase {
             world.exampleHooks.executeAfters(exampleMetadata)
         }
 
+        for afterPool in group!.autoreleasepoolAfters {
+            afterPool(exampleMetadata)
+        }
+
         world.numberOfExamplesRun += 1
 
         if !world.isRunningAdditionalSuites && world.numberOfExamplesRun >= world.cachedIncludedExampleCount {

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -72,21 +72,23 @@ final public class Example: _ExampleBase {
             world.currentExampleMetadata = nil
         }
 
-        world.exampleHooks.executeBefores(exampleMetadata)
-        group!.phase = .beforesExecuting
-        for before in group!.befores {
-            before(exampleMetadata)
-        }
-        group!.phase = .beforesFinished
+        autoreleasepool {
+            world.exampleHooks.executeBefores(exampleMetadata)
+            group!.phase = .beforesExecuting
+            for before in group!.befores {
+                before(exampleMetadata)
+            }
+            group!.phase = .beforesFinished
 
-        closure()
+            closure()
 
-        group!.phase = .aftersExecuting
-        for after in group!.afters {
-            after(exampleMetadata)
+            group!.phase = .aftersExecuting
+            for after in group!.afters {
+                after(exampleMetadata)
+            }
+            group!.phase = .aftersFinished
+            world.exampleHooks.executeAfters(exampleMetadata)
         }
-        group!.phase = .aftersFinished
-        world.exampleHooks.executeAfters(exampleMetadata)
 
         world.numberOfExamplesRun += 1
 

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -70,6 +70,14 @@ final public class ExampleGroup: NSObject {
         return closures
     }
 
+    internal var autoreleasepoolBefores: [BeforeExampleWithMetadataClosure] {
+        var closures = Array(hooks.autoreleasepoolBefores.reversed())
+        walkUp { group in
+            closures.append(contentsOf: Array(group.hooks.autoreleasepoolBefores.reversed()))
+        }
+        return Array(closures.reversed())
+    }
+
     internal func walkDownExamples(_ callback: (_ example: Example) -> Void) {
         for example in childExamples {
             callback(example)

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -78,6 +78,14 @@ final public class ExampleGroup: NSObject {
         return Array(closures.reversed())
     }
 
+    internal var autoreleasepoolAfters: [AfterExampleWithMetadataClosure] {
+        var closures = hooks.autoreleasepoolAfters
+        walkUp { group in
+            closures.append(contentsOf: group.hooks.autoreleasepoolAfters)
+        }
+        return closures
+    }
+
     internal func walkDownExamples(_ callback: (_ example: Example) -> Void) {
         for example in childExamples {
             callback(example)

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -4,6 +4,7 @@
 final internal class ExampleHooks {
     internal var befores: [BeforeExampleWithMetadataClosure] = []
     internal var afters: [AfterExampleWithMetadataClosure] = []
+    internal var autoreleasepoolBefores: [BeforeExampleWithMetadataClosure] = []
     internal var phase: HooksPhase = .nothingExecuted
 
     internal func appendBefore(_ closure: @escaping BeforeExampleWithMetadataClosure) {
@@ -20,6 +21,14 @@ final internal class ExampleHooks {
 
     internal func appendAfter(_ closure: @escaping AfterExampleClosure) {
         afters.append { (_: ExampleMetadata) in closure() }
+    }
+
+    internal func appendBeforeAutoreleasepool(_ closure: @escaping BeforeExampleWithMetadataClosure) {
+        autoreleasepoolBefores.append(closure)
+    }
+
+    internal func appendBeforeAutoreleasepool(_ closure: @escaping BeforeExampleClosure) {
+        autoreleasepoolBefores.append { (_: ExampleMetadata) in closure() }
     }
 
     internal func executeBefores(_ exampleMetadata: ExampleMetadata) {

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -5,6 +5,7 @@ final internal class ExampleHooks {
     internal var befores: [BeforeExampleWithMetadataClosure] = []
     internal var afters: [AfterExampleWithMetadataClosure] = []
     internal var autoreleasepoolBefores: [BeforeExampleWithMetadataClosure] = []
+    internal var autoreleasepoolAfters: [AfterExampleWithMetadataClosure] = []
     internal var phase: HooksPhase = .nothingExecuted
 
     internal func appendBefore(_ closure: @escaping BeforeExampleWithMetadataClosure) {
@@ -29,6 +30,14 @@ final internal class ExampleHooks {
 
     internal func appendBeforeAutoreleasepool(_ closure: @escaping BeforeExampleClosure) {
         autoreleasepoolBefores.append { (_: ExampleMetadata) in closure() }
+    }
+
+    internal func appendAfterAutoreleasepool(_ closure: @escaping AfterExampleWithMetadataClosure) {
+        autoreleasepoolAfters.append(closure)
+    }
+
+    internal func appendAfterAutoreleasepool(_ closure: @escaping AfterExampleClosure) {
+        autoreleasepoolAfters.append { (_: ExampleMetadata) in closure() }
     }
 
     internal func executeBefores(_ exampleMetadata: ExampleMetadata) {

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -59,8 +59,12 @@ QUICK_EXPORT void qck_describe(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_context(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_beforeEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure);
+QUICK_EXPORT void qck_beforeEachAutoreleasepool(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_beforeEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure);
 QUICK_EXPORT void qck_afterEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure);
+QUICK_EXPORT void qck_afterEachAutoreleasepool(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_afterEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure);
 QUICK_EXPORT void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
@@ -150,6 +154,27 @@ static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
 }
 
 /**
+    Defines a closure to be run prior the creation of the autorelease pool for each
+    example in the current example group. This closure is not run for pending
+    or otherwise disabled examples. An example group may contain an unlimited
+    number of beforeEachAutoreleasepool. They'll be run in the order they're defined,
+    but you shouldn't rely on that behavior.
+
+    @param closure The closure to be run prior to each example.
+ */
+static inline void beforeEachAutoreleasepool(QCKDSLEmptyBlock closure) {
+    qck_beforeEachAutoreleasepool(closure);
+}
+
+/**
+    Identical to QCKDSL.beforeEachAutoreleasepool, except the closure is provided with
+    metadata on the example that the closure is being run prior to.
+ */
+static inline void beforeEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_beforeEachAutoreleasepoolWithMetadata(closure);
+}
+
+/**
     Defines a closure to be run after each example in the current example
     group. This closure is not run for pending or otherwise disabled examples.
     An example group may contain an unlimited number of afterEach. They'll be
@@ -167,6 +192,26 @@ static inline void afterEach(QCKDSLEmptyBlock closure) {
  */
 static inline void afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     qck_afterEachWithMetadata(closure);
+}
+
+/**
+    Defines a closure to be run after each example's autoreleasepool in the current
+    example group is released. This closure is not run for pending or otherwise
+    disabled examples. An example group may contain an unlimited number of afterEach.
+    They'll be run in the order they're defined, but you shouldn't rely on that behavior.
+
+    @param closure The closure to be run after each example.
+ */
+static inline void afterEachAutoreleasepool(QCKDSLEmptyBlock closure) {
+    qck_afterEachAutoreleasepool(closure);
+}
+
+/**
+    Identical to QCKDSL.afterEachAutoreleasepool, except the closure is provided with
+    metadata on the example that the closure is being run after.
+ */
+static inline void afterEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_afterEachAutoreleasepoolWithMetadata(closure);
 }
 
 /**

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -34,12 +34,28 @@ void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     [[World sharedWorld] beforeEachWithMetadata:closure];
 }
 
+void qck_beforeEachAutoreleasepool(QCKDSLEmptyBlock closure) {
+    [[World sharedWorld] beforeEachAutoreleasepool:closure];
+}
+
+void qck_beforeEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    [[World sharedWorld] beforeEachAutoreleasepoolWithMetadata:closure];
+}
+
 void qck_afterEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] afterEach:closure];
 }
 
 void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     [[World sharedWorld] afterEachWithMetadata:closure];
+}
+
+void qck_afterEachAutoreleasepool(QCKDSLEmptyBlock closure) {
+    [[World sharedWorld] afterEachAutoreleasepool:closure];
+}
+
+void qck_afterEachAutoreleasepoolWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    [[World sharedWorld] afterEachAutoreleasepoolWithMetadata:closure];
 }
 
 QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line) {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AutoreleasepoolTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AutoreleasepoolTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import Quick
+import Nimble
+
+private enum ExecutionOrderType {
+    case outerBeforeEachAutoreleasePool
+    case outerAfterEachAutoreleasePool
+    case outerBeforeEach
+    case outerAfterEach
+
+    case innerBeforeEachAutoreleasePool
+    case innerAfterEachAutoreleasePool
+    case innerBeforeEach
+    case innerAfterEach
+
+    case example1
+    case example2
+
+    case noExamples
+}
+
+private var executionOrder = [ExecutionOrderType]()
+
+class FunctionalTests_AutoreleasepoolSpec: QuickSpec {
+    override func spec() {
+        describe("execution order") {
+            beforeEachAutoreleasepool { executionOrder.append(.outerBeforeEachAutoreleasePool) }
+            afterEachAutoreleasepool { executionOrder.append(.outerAfterEachAutoreleasePool) }
+
+            beforeEach { executionOrder.append(.outerBeforeEach) }
+            afterEach { executionOrder.append(.outerAfterEach) }
+
+            it("executes only outer closures [1]") { executionOrder.append(.example1) }
+
+            context("when there are nested closures") {
+                beforeEachAutoreleasepool { executionOrder.append(.innerBeforeEachAutoreleasePool) }
+                afterEachAutoreleasepool { executionOrder.append(.innerAfterEachAutoreleasePool) }
+
+                beforeEach { executionOrder.append(.innerBeforeEach) }
+                afterEach { executionOrder.append(.innerAfterEach) }
+
+                it("executes the outer and inner closures [2]") { executionOrder.append(.example2) }
+            }
+
+            context("when there are nested closures without examples") {
+                beforeEachAutoreleasepool { executionOrder.append(.noExamples) }
+                afterEachAutoreleasepool { executionOrder.append(.noExamples) }
+            }
+        }
+
+#if canImport(Darwin) && !SWIFT_PACKAGE
+        describe("error handling when misusing ordering") {
+            it("should throw an exception when including beforeEachAutoreleasepool in it block") {
+                expect {
+                    beforeEachAutoreleasepool { }
+                }.to(raiseException { (exception: NSException) in
+                    expect(exception.name).to(equal(NSExceptionName.internalInconsistencyException))
+                    expect(exception.reason).to(equal("'beforeEachAutoreleasepool' cannot be used inside 'it', 'beforeEachAutoreleasepool' may only be used inside 'context' or 'describe'. "))
+                })
+            }
+
+            it("should throw an exception when including afterEachAutoreleasepool in it block") {
+                expect {
+                    afterEachAutoreleasepool { }
+                }.to(raiseException { (exception: NSException) in
+                    expect(exception.name).to(equal(NSExceptionName.internalInconsistencyException))
+                    expect(exception.reason).to(equal("'afterEachAutoreleasepool' cannot be used inside 'it', 'afterEachAutoreleasepool' may only be used inside 'context' or 'describe'. "))
+                })
+            }
+        }
+#endif
+    }
+}
+
+final class AutoreleasepoolTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (AutoreleasepoolTests) -> () throws -> Void)] {
+        return [
+            ("testAutoreleasepoolClosuresOrdering", testAutoreleasepoolClosuresOrdering)
+        ]
+    }
+
+    func testAutoreleasepoolClosuresOrdering() {
+        executionOrder = []
+
+        qck_runSpec(FunctionalTests_AutoreleasepoolSpec.self)
+        let expectedOrder: [ExecutionOrderType] = [
+            // [1] The outer autoreleasepool closures wrap beforeEach/afterEach closures.
+            .outerBeforeEachAutoreleasePool, .outerBeforeEach,
+            .example1,
+            .outerAfterEach, .outerAfterEachAutoreleasePool,
+
+            // [2] The nested autoreleasepool closures wrap the nested beforeEach/afterEach closures.
+            .outerBeforeEachAutoreleasePool, .innerBeforeEachAutoreleasePool,
+            .outerBeforeEach, .innerBeforeEach,
+            .example2,
+            .innerAfterEach, .outerAfterEach,
+            .innerAfterEachAutoreleasePool, .outerAfterEachAutoreleasePool
+        ]
+
+        XCTAssertEqual(executionOrder, expectedOrder)
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/AutoreleasepoolTests+ObjC.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/AutoreleasepoolTests+ObjC.m
@@ -1,0 +1,85 @@
+@import XCTest;
+@import Quick;
+
+#import "QCKSpecRunner.h"
+
+typedef NS_ENUM(NSUInteger, ExecutionOrderType) {
+    OuterBeforeEachAutoreleasePool,
+    OuterAfterEachAutoreleasePool,
+    OuterBeforeEach,
+    OuterAfterEach,
+
+    InnerBeforeEachAutoreleasePool,
+    InnerAfterEachAutoreleasePool,
+    InnerBeforeEach,
+    InnerAfterEach,
+
+    Example1,
+    Example2,
+
+    NoExamples,
+};
+
+static NSMutableArray *executionOrder;
+
+QuickSpecBegin(FunctionalTests_AutoreleasepoolSpec_ObjC)
+
+beforeEachAutoreleasepool(^{ [executionOrder addObject:@(OuterBeforeEachAutoreleasePool)]; });
+afterEachAutoreleasepool(^{ [executionOrder addObject:@(OuterAfterEachAutoreleasePool)]; });
+
+beforeEach(^{ [executionOrder addObject:@(OuterBeforeEach)]; });
+afterEach(^{ [executionOrder addObject:@(OuterAfterEach)]; });
+
+it(@"executes only outer closures [1]", ^{ [executionOrder addObject:@(Example1)]; });
+
+context(@"when there are nested closures", ^{
+    beforeEachAutoreleasepool(^{ [executionOrder addObject:@(InnerBeforeEachAutoreleasePool)]; });
+    afterEachAutoreleasepool(^{ [executionOrder addObject:@(InnerAfterEachAutoreleasePool)]; });
+
+    beforeEach(^{ [executionOrder addObject:@(InnerBeforeEach)]; });
+    afterEach(^{ [executionOrder addObject:@(InnerAfterEach)]; });
+
+    it(@"executes the outer and inner closures [2]", ^{ [executionOrder addObject:@(Example2)]; });
+});
+
+context(@"when there are nested closures without examples", ^{
+    beforeEachAutoreleasepool(^{ [executionOrder addObject:@(NoExamples)]; });
+    afterEachAutoreleasepool(^{ [executionOrder addObject:@(NoExamples)]; });
+});
+
+QuickSpecEnd
+
+@interface AutoreleasepoolTests_ObjC : XCTestCase; @end
+
+@implementation AutoreleasepoolTests_ObjC
+
+- (void)setUp {
+    executionOrder = [NSMutableArray array];
+    [super setUp];
+}
+
+- (void)tearDown {
+    executionOrder = [NSMutableArray array];
+    [super tearDown];
+}
+
+- (void)testAutoreleasepoolClosuresOrdering {
+    qck_runSpec([FunctionalTests_AutoreleasepoolSpec_ObjC class]);
+    NSArray *expectedOrder = @[
+        // [1] The outer autoreleasepool closures wrap beforeEach/afterEach closures.
+        @(OuterBeforeEachAutoreleasePool), @(OuterBeforeEach),
+        @(Example1),
+        @(OuterAfterEach), @(OuterAfterEachAutoreleasePool),
+
+        // [2] The nested autoreleasepool closures wrap the nested beforeEach/afterEach closures.
+        @(OuterBeforeEachAutoreleasePool), @(InnerBeforeEachAutoreleasePool),
+        @(OuterBeforeEach), @(InnerBeforeEach),
+        @(Example2),
+        @(InnerAfterEach), @(OuterAfterEach),
+        @(InnerAfterEachAutoreleasePool), @(OuterAfterEachAutoreleasePool)
+   ];
+
+    XCTAssertEqualObjects(executionOrder, expectedOrder);
+}
+
+@end


### PR DESCRIPTION
This PR wraps the example execution into `autoreleasepool` and adds two more hooks: `beforeEachAutoreleasepool` and `afterEachAutoreleasepool`.

## Motivation
The main motivations for adding `afterEachAutoreleasepool` is to provide an easy way to test memory leaks. Example:
```swift
var viewController: UIViewController!
weak var weakViewController: UIViewController?

beforeEach { 
  viewController = .init() 
  weakViewController = viewController
}

describe("something") { ... }

afterEach { 
  // Remove the strong reference to the controller
  viewController = nil
}

afterEachAutoreleasepool { 
  // Check the view controller is no longer in the memory
  expect(weakViewController).to(beNil())
}
```

It's possible to test _certain_ objects for memory leaks without wrapping them into `autoreleasepool` with the following approach:
```swift
afterEach { 
  weakObject = object
  object = nil
  expect(weakObject).to(beNil())
}
```
However, this **doesn't work for `UIViewController`s**! 
_(see: https://stackoverflow.com/questions/45890020/uiviewcontroller-variables-persist-after-deallocation/45910208)_ 

`UIViewController` is such a fundamental class in iOS, I think it deserves to have a special treatment like this. Especially, when it's so susceptible to memory leaks.

`beforeEachAutoreleasepool` was added mainly to maintain the `before`/`after` symmetry with other hooks.

## Alternative
This PR is a concrete implementation of the use case suggested by @pcantrell at https://github.com/Quick/Quick/pull/820. I find the solution in this PR easier to use and less error-prone.

## Checklist
_What behavior was changed?_
None.

_What code was refactored / updated to support this change?_
The example execution was wrapped into `autoreleaspool`. This shouldn't have any effect on the functionality.

_What issues are related to this PR? Or why was this change introduced?_
I couldn't find an easy way to test whether my view controllers leak memory.

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?

