### PR TITLE
Fix empty 'Selected tests' suites

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -119,6 +119,9 @@
 		64076D231D6D7E6B00E2B499 /* AfterSuiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64076D1D1D6D7D0B00E2B499 /* AfterSuiteTests.swift */; };
 		64076D261D6D80B500E2B499 /* AfterSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */; };
 		64076D271D6D80B500E2B499 /* AfterSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */; };
+		79FE27DF22DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
+		79FE27E022DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
+		79FE27E122DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
 		7B44ADBE1C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
 		7B44ADBF1C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
 		7B44ADC01C5444940007AF2E /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B44ADBD1C5444940007AF2E /* HooksPhase.swift */; };
@@ -505,6 +508,7 @@
 		64076D1A1D6D7CEA00E2B499 /* QuickAfterSuite - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64076D1D1D6D7D0B00E2B499 /* AfterSuiteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterSuiteTests.swift; sourceTree = "<group>"; };
 		64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AfterSuiteTests+ObjC.m"; sourceTree = "<group>"; };
+		79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpec_SelectedTests.swift; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
@@ -806,6 +810,7 @@
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
 				CDB2A956226B714400C0F199 /* SubclassOfSubclassWithStructPropertyTests.swift */,
+				79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1468,6 +1473,7 @@
 			files = (
 				1F118D381BDCA6E1005013A2 /* Configuration+BeforeEachTests.swift in Sources */,
 				1F118D121BDCA556005013A2 /* ItTests.swift in Sources */,
+				79FE27E122DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				1F118D1C1BDCA556005013A2 /* BeforeSuiteTests.swift in Sources */,
 				1F118D1D1BDCA556005013A2 /* BeforeSuiteTests+ObjC.m in Sources */,
 				1F118D0E1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
@@ -1555,6 +1561,7 @@
 			files = (
 				DAE714F819FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAA7C0D719F777EB0093D1D9 /* BeforeEachTests.swift in Sources */,
+				79FE27E022DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				DA8F919A19F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F11B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253C1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
@@ -1682,6 +1689,7 @@
 			files = (
 				DAE714F719FF6812005905B8 /* Configuration+AfterEach.swift in Sources */,
 				DAB067E919F7801C00F970AC /* BeforeEachTests.swift in Sources */,
+				79FE27DF22DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				DA8F919919F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F01B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
 				4728253B1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -84,7 +84,7 @@ static QuickSpec *currentSpec = nil;
     [QuickConfiguration class];
     World *world = [World sharedWorld];
 
-    NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
+    NSArray *examples = [world examplesForSpecClass:[self class]];
     if (examples.count > 0) {
         // The examples fot this subclass have been already built. Skipping.
         return;

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -24,29 +24,15 @@ static QuickSpec *currentSpec = nil;
  included an expectation outside of a "it", "describe", or "context" block.
  */
 + (XCTestSuite *)defaultTestSuite {
-    [QuickConfiguration class];
+    [self buildExamplesIfNeeded];
 
-    World *world = [World sharedWorld];
-    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:self];
-    [world performWithCurrentExampleGroup:rootExampleGroup closure:^{
-        QuickSpec *spec = [self new];
+    // Add instance methods for this class' examples.
+    NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
+    NSMutableSet<NSString*> *selectorNames = [NSMutableSet set];
 
-        @try {
-            [spec spec];
-        }
-        @catch (NSException *exception) {
-            [NSException raise:NSInternalInconsistencyException
-                        format:@"An exception occurred when building Quick's example groups.\n"
-             @"Some possible reasons this might happen include:\n\n"
-             @"- An 'expect(...).to' expectation was evaluated outside of "
-             @"an 'it', 'context', or 'describe' block\n"
-             @"- 'sharedExamples' was called twice with the same name\n"
-             @"- 'itBehavesLike' was called with a name that is not registered as a shared example\n\n"
-             @"Here's the original exception: '%@', reason: '%@', userInfo: '%@'",
-             exception.name, exception.reason, exception.userInfo];
-        }
-        [self testInvocations];
-    }];
+    for (Example *example in examples) {
+        [self addInstanceMethodForExample:example classSelectorNames:selectorNames];
+    }
 
     return [super defaultTestSuite];
 }
@@ -58,6 +44,8 @@ static QuickSpec *currentSpec = nil;
  @return An array of invocations that execute the newly defined example methods.
  */
 + (NSArray *)testInvocations {
+    [self buildExamplesIfNeeded];
+
     NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
     NSMutableArray *invocations = [NSMutableArray arrayWithCapacity:[examples count]];
     
@@ -85,6 +73,43 @@ static QuickSpec *currentSpec = nil;
 }
 
 #pragma mark - Internal Methods
+
+/**
+ Runs the `spec` method and builds the examples for this class.
+
+ It's safe to call this method multiple times. If the examples for the class have been built, invocation
+ of this method has no effect.
+ */
++ (void)buildExamplesIfNeeded {
+    [QuickConfiguration class];
+    World *world = [World sharedWorld];
+
+    NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
+    if (examples.count > 0) {
+        // The examples fot this subclass have been already built. Skipping.
+        return;
+    }
+
+    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:self];
+    [world performWithCurrentExampleGroup:rootExampleGroup closure:^{
+        QuickSpec *spec = [self new];
+
+        @try {
+            [spec spec];
+        }
+        @catch (NSException *exception) {
+            [NSException raise:NSInternalInconsistencyException
+                        format:@"An exception occurred when building Quick's example groups.\n"
+             @"Some possible reasons this might happen include:\n\n"
+             @"- An 'expect(...).to' expectation was evaluated outside of "
+             @"an 'it', 'context', or 'describe' block\n"
+             @"- 'sharedExamples' was called twice with the same name\n"
+             @"- 'itBehavesLike' was called with a name that is not registered as a shared example\n\n"
+             @"Here's the original exception: '%@', reason: '%@', userInfo: '%@'",
+             exception.name, exception.reason, exception.userInfo];
+        }
+    }];
+}
 
 /**
  QuickSpec uses this method to dynamically define a new instance method for the

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -28,7 +28,7 @@ class SimulareAllTests_TestCase: QuickSpec {
     }
 }
 
-class QuickSpec_SelectedTests: QuickSpec {
+class QuickSpec_SelectedTests: XCTestCase {
 
     func testQuickSpecTestInvocationsForAllTests() {
         // Simulate running 'All tests'

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -1,0 +1,52 @@
+#if canImport(Darwin)
+
+import Nimble
+import Quick
+import XCTest
+
+// The regression tests for https://github.com/Quick/Quick/issues/891
+
+class SimulateSelectedTests_TestCase: QuickSpec {
+    override class var defaultTestSuite: QuickTestSuite {
+        // XCTest doesn't call `defaultTestSuite` when running only selected tests.
+        // We simulate this behavior by not calling super.
+        return .init(name: "Selected tests")
+    }
+
+    override func spec() {
+        it("example1") { }
+        it("example2") { }
+        it("example3") { }
+    }
+}
+
+class SimulareAllTests_TestCase: QuickSpec {
+    override func spec() {
+        it("example1") { }
+        it("example2") { }
+        it("example3") { }
+    }
+}
+
+class QuickSpec_SelectedTests: QuickSpec {
+
+    func testQuickSpecTestInvocationsForAllTests() {
+        // Simulate running 'All tests'
+        let invocations = SimulareAllTests_TestCase.testInvocations
+        expect(invocations.count) == 3
+
+        let selectorNames = invocations.map { $0.selector.description }
+        expect(selectorNames).to(contain(["example1", "example2", "example3"]))
+    }
+
+    func testQuickSpecTestInvocationsForSelectedTests() {
+        // Simulate running 'Selected tests'
+        let invocations = SimulateSelectedTests_TestCase.testInvocations
+        expect(invocations.count) == 3
+
+        let selectorNames = invocations.map { $0.selector.description }
+        expect(selectorNames).to(contain(["example1", "example2", "example3"]))
+    }
+}
+
+#endif

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -33,7 +33,7 @@ class QuickSpec_SelectedTests: XCTestCase {
     func testQuickSpecTestInvocationsForAllTests() {
         // Simulate running 'All tests'
         let invocations = SimulareAllTests_TestCase.testInvocations
-        expect(invocations.count) == 3
+        expect(invocations).to(haveCount(3))
 
         let selectorNames = invocations.map { $0.selector.description }
         expect(selectorNames).to(contain(["example1", "example2", "example3"]))
@@ -42,7 +42,7 @@ class QuickSpec_SelectedTests: XCTestCase {
     func testQuickSpecTestInvocationsForSelectedTests() {
         // Simulate running 'Selected tests'
         let invocations = SimulateSelectedTests_TestCase.testInvocations
-        expect(invocations.count) == 3
+        expect(invocations).to(haveCount(3))
 
         let selectorNames = invocations.map { $0.selector.description }
         expect(selectorNames).to(contain(["example1", "example2", "example3"]))

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -1,4 +1,4 @@
-#if canImport(Darwin)
+#if canImport(Darwin) && !SWIFT_PACKAGE
 
 import Nimble
 import Quick


### PR DESCRIPTION
This PR fixes the regression introduced in a3ece4f. Closes #891 

The `defaultTestSuite` method wasn't called when the 'Selected tests' type of test suite was executed. This caused the `spec` method not being invoked and the examples for the given class were never built.

This PR changes the behaviour and introduces a new `buildExamplesIfNeeded` method. This method can be called safely multiple times. We call it from both the `defaultTestSuite` and `testInvocations` methods. This ensures the examples are built properly no matter which method is called (or in which order).

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
