### PR TITLE
Add documentation for `Behavior<Context>`

### DIFF
--- a/Documentation/en-us/README.md
+++ b/Documentation/en-us/README.md
@@ -29,7 +29,7 @@ testing, consider reading them in the order they're introduced below:
   Read this to learn more about testing code that uses the AppKit and UIKit frameworks.
 - **[Testing with test doubles](TestUsingTestDoubles.md)**:
   Read this to learn what test doubles are and how to use them.
-- **[Reducing Test Boilerplate with Behaviors and Shared Assertions](SharedExamples.md)**:
+- **[Reducing Test Boilerplate with Shared Assertions](SharedExamples.md)**:
   Read this to learn how to share sets of assertions among your tests.
 - **[Configuring How Quick Behaves](ConfiguringQuick.md)**:
   Read this to learn how you can change how Quick behaves when running your test suite.

--- a/Documentation/en-us/README.md
+++ b/Documentation/en-us/README.md
@@ -29,7 +29,7 @@ testing, consider reading them in the order they're introduced below:
   Read this to learn more about testing code that uses the AppKit and UIKit frameworks.
 - **[Testing with test doubles](TestUsingTestDoubles.md)**:
   Read this to learn what test doubles are and how to use them.
-- **[Reducing Test Boilerplate with Shared Assertions](SharedExamples.md)**:
+- **[Reducing Test Boilerplate with Behaviors and Shared Assertions](SharedExamples.md)**:
   Read this to learn how to share sets of assertions among your tests.
 - **[Configuring How Quick Behaves](ConfiguringQuick.md)**:
   Read this to learn how you can change how Quick behaves when running your test suite.

--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -1,4 +1,4 @@
-# Reducing Test Boilerplate
+# Reducing Test Boilerplate with Shared Assertions
 
 In some cases, the same set of specifications apply to multiple objects.
 
@@ -40,6 +40,7 @@ class SomethingEdible: Behavior<Edible> {
     beforeEach {
       edible = context()
     }
+
     it("makes dolphins happy") {
       let dolphin = Dolphin(happy: false)
       dolphin.eat(edible)
@@ -54,6 +55,7 @@ class MackerelSpec: QuickSpec {
     beforeEach {
       mackerel = Mackerel()
     }
+
     itBehavesLike(SomethingEdible.self) { mackerel }
   }
 }
@@ -64,6 +66,7 @@ class CodSpec: QuickSpec {
     beforeEach {
       cod = Cod()
     }
+
     itBehavesLike(SomethingEdible.self) { cod }
   }
 }
@@ -71,7 +74,7 @@ class CodSpec: QuickSpec {
 
 Because `Behavior<Context>` uses Swift generics, it's not possible to use it from Objective-C.
 
- ## Shared Assertions
+## Shared Examples
 
 The example below defines a set of  "shared examples" for "something edible",
 and specifies that both mackerel and cod behave like "something edible":

--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -1,4 +1,4 @@
-# Reducing Test Boilerplate with Shared Assertions
+# Reducing Test Boilerplate
 
 In some cases, the same set of specifications apply to multiple objects.
 
@@ -6,6 +6,72 @@ For example, consider a protocol called `Edible`. When a dolphin
 eats something `Edible`, the dolphin becomes happy. `Mackerel` and
 `Cod` are both edible. Quick allows you to easily test that a dolphin is
 happy to eat either one.
+
+```swift
+protocol Edible { }
+
+class Dolphin {
+  private(set) var isHappy: Bool
+
+  init(happy: Bool) {
+    self.isHappy = happy
+  }
+
+  /// Makes Doplhin happy
+  func eat(_ edible: Edible) {
+    isHappy = true
+  }
+}
+
+class Mackerel: Edible { }
+class Cod: Edible { }
+```
+
+## Behavior<Context>
+
+The code below defines a `Behavior` object with a set of reusable
+examples. It also specifies that both mackerel and cod behave 
+like `SomethingEdible`:
+
+```swift
+class SomethingEdible: Behavior<Edible> {
+  override class func spec(_ context: @escaping () -> Edible) {
+    var edible: Edible!
+    beforeEach {
+      edible = context()
+    }
+    it("makes dolphins happy") {
+      let dolphin = Dolphin(happy: false)
+      dolphin.eat(edible)
+      expect(dolphin.isHappy).to(beTruthy())
+    }
+  }
+}
+
+class MackerelSpec: QuickSpec {
+  override func spec() {
+    var mackerel: Mackerel!
+    beforeEach {
+      mackerel = Mackerel()
+    }
+    itBehavesLike(SomethingEdible.self) { mackerel }
+  }
+}
+
+class CodSpec: QuickSpec {
+  override func spec() {
+    var cod: Cod!
+    beforeEach {
+      cod = Cod()
+    }
+    itBehavesLike(SomethingEdible.self) { cod }
+  }
+}
+```
+
+Because `Behavior<Context>` uses Swift generics, it's not possible to use it from Objective-C.
+
+ ## Shared Assertions
 
 The example below defines a set of  "shared examples" for "something edible",
 and specifies that both mackerel and cod behave like "something edible":

--- a/Sources/Quick/Behavior.swift
+++ b/Sources/Quick/Behavior.swift
@@ -6,7 +6,7 @@ open class Behavior<Context> {
 
     public static var name: String { return String(describing: self) }
     /**
-     override this method in your behavior to define a set of reusable examples.
+     Override this method in your behavior to define a set of reusable examples.
 
      This behaves just like an example group defines using `describe` or `context`--it may contain any number of `beforeEach`
      and `afterEach` closures, as well as any number of examples (defined using `it`).


### PR DESCRIPTION
I use Quick for several years and recently I accidentally discovered `Behavior`. I really love the feature! I realized that I didn't know about it because it's not mentioned anywhere in the documentation.

This PR adds another option to the `Reducing Test Boilerplate` documentation presenting an alternative solution using `Behavior<Context>`.