### PR TITLE
Make `name` variable of `Behavior` open

### DIFF
--- a/Sources/Quick/Behavior.swift
+++ b/Sources/Quick/Behavior.swift
@@ -4,7 +4,11 @@
 
 open class Behavior<Context> {
 
-    public static var name: String { return String(describing: self) }
+    /**
+     Override this variable if you want to provide custom name for this example group.
+    */
+    open class var name: String { return String(describing: self) }
+
     /**
      override this method in your behavior to define a set of reusable examples.
 


### PR DESCRIPTION
The PR is a byproduct of [my article](https://vojtastavik.com/2019/07/22/advanced-testing-using-behavior-in-quick/) about using `Behavior` in Quick.

I believe the `name` variable of `Behavior` should be `open` so it's possible to override it and provide custom name, if needed.