### PR TITLE
Add an overload for `it` which takes `Behavior` as a parameter 

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -219,7 +219,7 @@ public func xit(_ description: String, flags: FilterFlags = [:], file: FileStrin
 }
 
 /**
-    Use this to quicklu mark an `itBehavesLike` closure as pending.
+    Use this to quickly mark an `itBehavesLike` closure as pending.
     This disables the example group defined by this behavior and ensures the code within is never run.
 */
 public func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -132,6 +132,22 @@ public func it(_ description: String, flags: FilterFlags = [:], file: FileString
 }
 
 /**
+    Inserts the examples defined using a `Behavior` into the current example group.
+    The shared examples are executed at this location, as if they were written out manually.
+    This function also passes a strongly-typed context that can be evaluated to give the shared examples extra information on the subject of the example.
+
+    - parameter behavior: The type of `Behavior` class defining the example group to be executed.
+    - parameter context: A closure that, when evaluated, returns an instance of `Behavior`'s context type to provide its example group with extra information on the subject of the example.
+    - parameter flags: A mapping of string keys to booleans that can be used to filter examples or example groups.
+    Empty by default.
+    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+    - parameter line: The line containing the current example group. A sensible default is provided.
+ */
+public func it<C>(_ behavior: Quick.Behavior<C>.Type, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+    itBehavesLike(behavior, flags: flags, file: file, line: line, context: context)
+}
+
+/**
     Inserts the examples defined using a `sharedExamples` function into the current example group.
     The shared examples are executed at this location, as if they were written out manually.
 
@@ -219,6 +235,14 @@ public func xit(_ description: String, flags: FilterFlags = [:], file: FileStrin
 }
 
 /**
+ Use this to quickly mark an `it` closure as pending.
+ This disables the example group defined by this behavior and ensures the code within is never run.
+ */
+public func xit<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+    World.sharedWorld.xitBehavesLike(behavior, context: context, flags: flags, file: file, line: line)
+}
+
+/**
     Use this to quickly mark an `itBehavesLike` closure as pending.
     This disables the example group defined by this behavior and ensures the code within is never run.
 */
@@ -247,6 +271,13 @@ public func fcontext(_ description: String, flags: FilterFlags = [:], closure: (
 */
 public func fit(_ description: String, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, closure: @escaping () -> Void) {
     World.sharedWorld.fit(description, flags: flags, file: file, line: line, closure: closure)
+}
+
+/**
+ Use this to quickly focus on `it` closure.
+ */
+public func fit<C>(_ behavior: Behavior<C>.Type, flags: FilterFlags = [:], file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+    World.sharedWorld.fitBehavesLike(behavior, context: context, flags: flags, file: file, line: line)
 }
 
 /**

--- a/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_BehaviorTests_Behaviors.swift
+++ b/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_BehaviorTests_Behaviors.swift
@@ -18,3 +18,11 @@ class FunctionalTests_BehaviorTests_Behavior2: Behavior<Void> {
         it("passes three times") { expect(true).to(beTruthy()) }
     }
 }
+
+class FunctionalTests_BehaviorTests_Behavior3: Behavior<Void> {
+    override static func spec(_ aContext: @escaping () -> Void) {
+        it("passes once") { expect(true).to(beTruthy()) }
+        it("passes twice") { expect(true).to(beTruthy()) }
+        it("passes three times") { expect(true).to(beTruthy()) }
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -9,6 +9,12 @@ class FunctionalTests_BehaviorTests_Spec: QuickSpec {
     }
 }
 
+class FunctionalTests_ItBehaviorTests_Spec: QuickSpec {
+    override func spec() {
+        it(FunctionalTests_BehaviorTests_Behavior3.self) { () }
+    }
+}
+
 class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
     override func spec() {
         itBehavesLike(FunctionalTests_BehaviorTests_Behavior.self) {
@@ -42,7 +48,9 @@ final class BehaviorTests: XCTestCase, XCTestCaseProvider {
             ("testBehaviorPassContextToExamples",
              testBehaviorPassContextToExamples),
             ("testBehaviorExecutesThreeExamples",
-             testBehaviorExecutesThreeExamples)
+             testBehaviorExecutesThreeExamples),
+             ("testItOverloadWithBehavior",
+              testItOverloadWithBehavior)
         ]
     }
 
@@ -55,5 +63,11 @@ final class BehaviorTests: XCTestCase, XCTestCaseProvider {
     func testBehaviorPassContextToExamples() {
         let result = qck_runSpec(FunctionalTests_BehaviorTests_ContextSpec.self)
         XCTAssert(result!.hasSucceeded)
+    }
+
+    func testItOverloadWithBehavior() {
+        let result = qck_runSpec(FunctionalTests_ItBehaviorTests_Spec.self)
+        XCTAssert(result!.hasSucceeded)
+        XCTAssertEqual(result!.executionCount, 3)
     }
 }


### PR DESCRIPTION
The PR is a byproduct of [my article](https://vojtastavik.com/2019/07/22/advanced-testing-using-behavior-in-quick/) about using `Behavior` in Quick.

Sometimes if find it difficult to define Behavior's name such that it works nicely with `itBehavesLike`. As a workaround, I use a custom overload for `it` which accepts `Behavior` as a parameter.

Example:
```
class ShouldNotHaveMemoryLeaks<T>: Behavior<T> where T: AnyObject {
  override class func spec(_ aContext: @escaping () -> T) {
    it("should be released from memory") { ... }
}

class MacrelSpec: QuickSpec {
  override func spec() {
    it(ShouldNotHaveMemoryLeaks.self) { Macrel() }
  }
} 
```

This is a purely additive feature; this PR doesn't touch any existing behavior.