### PR TITLE
Add Swift 5 support to Quick.podspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - name: CocoaPods Lint & Danger
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       language: ruby
       script:
         - PODSPEC=1 ./script/travis-script-macos
@@ -17,7 +17,7 @@ matrix:
       os: osx
       env:
         - XCODE_ACTION="build-for-testing test-without-building"
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       script:
         - PLATFORM=macos ./script/travis-script-macos
         - PLATFORM=macos_static ./script/travis-script-macos
@@ -29,7 +29,7 @@ matrix:
     - &swiftpm_darwin
       name: SwiftPM / Darwin / Swift 4.2
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       script: PLATFORM=swiftpm ./script/travis-script-macos
     - <<: *swiftpm_darwin
       name: SwiftPM / Darwin / Swift 5.0

--- a/Quick.podspec
+++ b/Quick.podspec
@@ -40,5 +40,9 @@ Pod::Spec.new do |s|
   }
   
   s.cocoapods_version = '>= 1.4.0'
-  s.swift_version = '4.2'
+  if s.respond_to?(:swift_versions) then
+    s.swift_versions = ['4.2', '5.0']
+  else
+    s.swift_version = '4.2'
+  end
 end


### PR DESCRIPTION
Resolves issue #895. Based on Nimble.podspec

Checklist:
 - [x] Does this have tests? (No)
 - [x] Does this have documentation? (No)
 - [x] Does this break the public API (Requires major version bump)? (No)
 - [x] Is this a new feature (Requires minor version bump)?
This may require a minor version bump in order to propagate on CocoaPods correctly