### PR TITLE
Fix crash with combination of focused tests and shared examples registered in a unfocused spec class

### DIFF
--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -31,10 +31,16 @@ final public class ExampleGroup: NSObject {
         Returns a list of examples that belong to this example group,
         or to any of its descendant example groups.
     */
+    #if canImport(Darwin)
     @objc
     public var examples: [Example] {
         return childExamples + childGroups.flatMap { $0.examples }
     }
+    #else
+    public var examples: [Example] {
+        return childExamples + childGroups.flatMap { $0.examples }
+    }
+    #endif
 
     internal var name: String? {
         guard let parent = parent else {

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -31,6 +31,7 @@ final public class ExampleGroup: NSObject {
         Returns a list of examples that belong to this example group,
         or to any of its descendant example groups.
     */
+    @objc
     public var examples: [Example] {
         return childExamples + childGroups.flatMap { $0.examples }
     }

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -84,13 +84,13 @@ static QuickSpec *currentSpec = nil;
     [QuickConfiguration class];
     World *world = [World sharedWorld];
 
-    NSArray *examples = [world examplesForSpecClass:[self class]];
-    if (examples.count > 0) {
+    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:self];
+
+    if ([rootExampleGroup examples].count > 0) {
         // The examples fot this subclass have been already built. Skipping.
         return;
     }
 
-    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:self];
     [world performWithCurrentExampleGroup:rootExampleGroup closure:^{
         QuickSpec *spec = [self new];
 

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -48,6 +48,10 @@ class _FunctionalTests_FocusedSpec_Unfocused: QuickSpec {
             beforeEach { assert(false) }
             it("has an example that fails, but is never run") { fail() }
         }
+
+        sharedExamples("empty shared example") { _ in
+            // https://github.com/Quick/Quick/pull/901#issuecomment-530816224
+        }
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/Quick/Quick/pull/901#issuecomment-530600416

Based on #916 with Linux build failure fix.