### PR TITLE
[refactoring] Build examples only for classes without root example group

### DIFF
--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -110,6 +110,17 @@ final internal class World: _WorldBase {
     }
 
     /**
+     Returns `true` if the root example group for the given spec class has been already initialized.
+
+     - parameter specClass: The QuickSpec class for which is checked for the existing root example group.
+     - returns: Whether the root example group for the given spec class has been already initialized or not.
+     */
+    internal func isRootExampleGroupInitialized(forSpecClass specClass: QuickSpec.Type) -> Bool {
+        let name = String(describing: specClass)
+        return specs.keys.contains(name)
+    }
+
+    /**
         Returns an internally constructed root example group for the given
         QuickSpec class.
 

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -84,13 +84,12 @@ static QuickSpec *currentSpec = nil;
     [QuickConfiguration class];
     World *world = [World sharedWorld];
 
-    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:self];
-
-    if ([rootExampleGroup examples].count > 0) {
+    if ([world isRootExampleGroupInitializedForSpecClass:[self class]]) {
         // The examples fot this subclass have been already built. Skipping.
         return;
     }
 
+    ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:[self class]];
     [world performWithCurrentExampleGroup:rootExampleGroup closure:^{
         QuickSpec *spec = [self new];
 


### PR DESCRIPTION
This commit fixes the crash reported in https://github.com/Quick/Quick/pull/901#issuecomment-530600416 .