### PR TITLE
[CI] Fix GitHub Actions breakage and restore Travis build matrix for older Xcode versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   xcode:
     name: Xcode ${{ matrix.xcode }}
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: [10.1, 10.3, 11]
+        xcode: [11, 11.1, 11.2]
     steps:
     - uses: actions/checkout@v1
       with:
@@ -27,10 +27,10 @@ jobs:
 
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: [10.1, 10.3, 11]
+        xcode: [11, 11.1, 11.2]
     steps:
     - uses: actions/checkout@v1
     - run: sudo xcode-select -s '/Applications/Xcode_${{ matrix.xcode }}.app'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,28 @@ matrix:
       script:
         - PODSPEC=1 ./script/travis-script-macos
         - bundle exec danger
+    - &xcode
+      name: Xcode 10.1 / Swift 4.2
+      os: osx
+      env:
+        - XCODE_ACTION="build-for-testing test-without-building"
+      osx_image: xcode10.1
+      script:
+        - PLATFORM=macos ./script/travis-script-macos
+        - PLATFORM=macos_static ./script/travis-script-macos
+        - PLATFORM=ios ./script/travis-script-macos
+        - PLATFORM=tvos ./script/travis-script-macos
+    - <<: *xcode
+      name: Xcode 10.3 / Swift 5.0
+      osx_image: xcode10.3
+    - &swiftpm_darwin
+      name: SwiftPM / Darwin / Swift 4.2
+      os: osx
+      osx_image: xcode10.1
+      script: PLATFORM=swiftpm ./script/travis-script-macos
+    - <<: *swiftpm_darwin
+      name: SwiftPM / Darwin / Swift 5.0
+      osx_image: xcode10.3
     - &swiftpm_linux
       name: SwiftPM / Linux / Swift 4.2.4
       os: linux

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace "test" do
   desc "Run unit tests for all iOS targets"
   task :ios do |t|
     run "set -o pipefail && xcodebuild -workspace Quick.xcworkspace -scheme Quick-iOS -destination 'generic/platform=iOS' OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' clean build | xcpretty"
-    run "set -o pipefail && xcodebuild -workspace Quick.xcworkspace -scheme Quick-iOS -destination 'platform=iOS Simulator,name=iPhone 6' OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' clean #{xcode_action} | xcpretty"
+    run "set -o pipefail && xcodebuild -workspace Quick.xcworkspace -scheme Quick-iOS -destination 'platform=iOS Simulator,name=iPhone 8' OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' clean #{xcode_action} | xcpretty"
   end
 
   desc "Run unit tests for all tvOS targets"


### PR DESCRIPTION
Due to https://github.blog/changelog/2019-11-06-github-actions-macos-virtual-environment-updated-to-catalina/

Ref: https://github.com/Quick/Nimble/pull/712
