### PR TITLE
Update deployment target

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }
 
   s.author       = "Quick Contributors"
-  s.ios.deployment_target = "7.0"
+  s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
 


### PR DESCRIPTION
Xcode 11 dropped support for iOS 7.0

