### PR TITLE
Update docs - vieiwDidAppear not be called automatically in iOS SDK 13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: bundle install
       - run: bundle exec danger
         env:

--- a/Documentation/en-us/TestingApps.md
+++ b/Documentation/en-us/TestingApps.md
@@ -15,7 +15,7 @@ presented within the app. When testing a `UIViewController`, however, you'll
 need to trigger these yourself. You can do so in one of three ways:
 
 1. Accessing `UIViewController.view`, which triggers things like `UIViewController.viewDidLoad()`.
-2. Use `UIViewController.beginAppearanceTransition()` to trigger most lifecycle events.
+2. Use `UIViewController.beginAppearanceTransition()` and `viewController.endAppearanceTransition()` to trigger most lifecycle events. Note - as of iOS SDK 13.0, this no longer triggers `UIViewController.viewDidAppear()`.
 3. Directly calling methods like `UIViewController.viewDidLoad()` or `UIViewController.viewWillAppear()`.
 
 ```swift
@@ -47,7 +47,7 @@ class BananaViewControllerSpec: QuickSpec {
 
     describe("the view") {
       beforeEach {
-        // Method #2: Triggers .viewDidLoad(), .viewWillAppear(), and .viewDidAppear() events.
+        // Method #2: Triggers .viewDidLoad(), .viewWillAppear() events.
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
       }
@@ -94,7 +94,7 @@ describe(@"-viewDidLoad", ^{
 
 describe(@"the view", ^{
   beforeEach(^{
-    // Method #2: Triggers .viewDidLoad(), .viewWillAppear(), and .viewDidAppear() events.
+    // Method #2: Triggers .viewDidLoad(), .viewWillAppear() events.
     [viewController beginAppearanceTransition:YES animated:NO];
     [viewController endAppearanceTransition];
   });

--- a/Documentation/en-us/TestingApps.md
+++ b/Documentation/en-us/TestingApps.md
@@ -15,7 +15,7 @@ presented within the app. When testing a `UIViewController`, however, you'll
 need to trigger these yourself. You can do so in one of three ways:
 
 1. Accessing `UIViewController.view`, which triggers things like `UIViewController.viewDidLoad()`.
-2. Use `UIViewController.beginAppearanceTransition()` and `viewController.endAppearanceTransition()` to trigger most lifecycle events. Note - as of iOS SDK 13.0, this no longer triggers `UIViewController.viewDidAppear()`.
+2. Use `UIViewController.beginAppearanceTransition()` and `UIViewController.endAppearanceTransition()` to trigger most lifecycle events. Note - as of iOS SDK 13.0, this no longer triggers `UIViewController.viewDidAppear()`.
 3. Directly calling methods like `UIViewController.viewDidLoad()` or `UIViewController.viewWillAppear()`.
 
 ```swift
@@ -47,7 +47,7 @@ class BananaViewControllerSpec: QuickSpec {
 
     describe("the view") {
       beforeEach {
-        // Method #2: Triggers .viewDidLoad(), .viewWillAppear() events.
+        // Method #2: Triggers .viewDidLoad() and .viewWillAppear() events.
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
       }
@@ -94,7 +94,7 @@ describe(@"-viewDidLoad", ^{
 
 describe(@"the view", ^{
   beforeEach(^{
-    // Method #2: Triggers .viewDidLoad(), .viewWillAppear() events.
+    // Method #2: Triggers .viewDidLoad() and .viewWillAppear() events.
     [viewController beginAppearanceTransition:YES animated:NO];
     [viewController endAppearanceTransition];
   });


### PR DESCRIPTION
iOS SDK 13.0 (Xcode 11) does not call `UIViewController.viewDidAppear()` anymore when calling  ` viewController.beginAppearanceTransition()` and `UIViewController.endAppearanceTransition()` when testing views directly.  This looks like a behavior change not directly related to Quick, but think the docs need to be updated.

See https://github.com/Quick/Quick/issues/941.

 - [ ] Does this have tests?
 - [X] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
