### PR TITLE
Added empty default flags to xdescribe and xcontext

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -198,7 +198,7 @@ public func pending(_ description: String, closure: () -> Void) {
     Use this to quickly mark a `describe` closure as pending.
     This disables all examples within the closure.
 */
-public func xdescribe(_ description: String, flags: FilterFlags, closure: () -> Void) {
+public func xdescribe(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
     World.sharedWorld.xdescribe(description, flags: flags, closure: closure)
 }
 
@@ -206,7 +206,7 @@ public func xdescribe(_ description: String, flags: FilterFlags, closure: () -> 
     Use this to quickly mark a `context` closure as pending.
     This disables all examples within the closure.
 */
-public func xcontext(_ description: String, flags: FilterFlags, closure: () -> Void) {
+public func xcontext(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
     xdescribe(description, flags: flags, closure: closure)
 }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -28,6 +28,18 @@ class FunctionalTests_PendingSpec: QuickSpec {
             beforeEach { onlyPendingExamplesBeforeEachExecutedCount += 1 }
             pending("an example that will not run") {}
         }
+        describe("a describe block with a disabled context that will not run") {
+            xcontext("these examples will not run") {
+               it("does not run") {
+                  fail()
+               }
+            }
+        }
+        xdescribe("a describe block that will not run") {
+            it("does not run") {
+               fail()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Disabling a `describe` or a `context` by prefixing them with x, like `xdescribe` and `xcontext` would generate a compilation error complaining about a missing flags param, contrary to `it`/`xit`, `fdescribe` or `fcontext`.
With this PR the following will compile:
```swift
xdescribe("some description") {
    xcontext("some context description") {
         it("will not be run...") { fail() }
    }
}
```
This PR adds a default value to the flags parameter in DSL.swift and also corresponding tests in PendingTests.swift.