### PR TITLE
Fixes race conditions in QuickConfiguration

### DIFF
--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -21,7 +21,7 @@ extension QuickConfiguration {
     ///                    This block will be executed once for each subclass of QuickConfiguration.
     private static func enumerateSubclasses(_ block: (QuickConfiguration.Type) -> Void) {
         #if canImport(Darwin)
-        var classesCount = objc_getClassList(nil, 0)
+        let classesCount = objc_getClassList(nil, 0)
 
         guard classesCount > 0 else {
             return
@@ -30,7 +30,7 @@ extension QuickConfiguration {
         let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
         defer { free(classes) }
 
-        _ = objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
+        objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
 
         var configurationSubclasses: [QuickConfiguration.Type] = []
         for i in 0..<classesCount {

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -30,7 +30,7 @@ extension QuickConfiguration {
         let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
         defer { free(classes) }
 
-        classesCount = objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
+        _ = objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
 
         var configurationSubclasses: [QuickConfiguration.Type] = []
         for i in 0..<classesCount {


### PR DESCRIPTION
There is a possible crash in `QuickConfiguration` that may occur during race conditions with other threads because of the number of classes returned by `objc_getClassList` changes between calls. That causes `EXC_BAD_ACCESS` crash during accessing out of the bounds memory by `class_getSuperclass` if malloc guards enabled in Xcode scheme diagnostics tab.

I inserted a `sleep` between calls and prints so it became obvious:
```
classesCount: 29605
...
classesCount: 29634
```

```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGABRT)
Exception Codes:       EXC_I386_GPFLT
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
This process is running with libgmalloc.dylib (GuardMalloc) which may have forced the crash due to a memory access error.
 
==53933==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000000000 (pc 0x00010a63ee7c bp 0x7ffeeccbf030 sp 0x7ffeeccbf030 T721654)
==53933==The signal is caused by a READ memory access.
==53933==Hint: address points to the zero page.
    #0 0x10a63ee7b in swift_getObjCClassFromMetadata (libswiftCore.dylib:x86_64+0x2dae7b)
    #1 0x600022e65f91 in function signature specialization <Arg[0] = Dead, Arg[1] = Owned To Guaranteed> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (__C.QuickConfiguration.Type) -> () in closure #1 (Quick.Configuration) -> () in static (extension in Quick):__C.QuickConfiguration.(_configureSubclassesIfNeeded in _23AA58C2217AF53230C4FC2C661C414A)(world: Quick.World) -> (), Argument Types : [Quick.Configuration]> of static (extension in Quick):__C.QuickConfiguration.(enumerateSubclasses in _23AA58C2217AF53230C4FC2C661C414A)((__C.QuickConfiguration.Type) -> ()) -> () (Quick:x86_64+0x17f91)
    #2 0x600022e65b29 in @objc static (extension in Quick):__C.QuickConfiguration.configureSubclassesIfNeeded(world: Quick.World) -> () (Quick:x86_64+0x17b29)
    #3 0x600022e50974 in +[QuickConfiguration initialize] (Quick:x86_64+0x2974)
    #4 0x7fff513fc102 in CALLING_SOME_+initialize_METHOD (libobjc.A.dylib:x86_64+0x6102)
    #5 0x7fff513fcee8 in initializeNonMetaClass (libobjc.A.dylib:x86_64+0x6ee8)
    #6 0x7fff513fd4b9 in initializeAndMaybeRelock(objc_class*, objc_object*, mutex_tt<false>&, bool) (libobjc.A.dylib:x86_64+0x74b9)
    #7 0x7fff51407a5c in lookUpImpOrForward (libobjc.A.dylib:x86_64+0x11a5c)
    #8 0x7fff513f8218 in _objc_msgSend_uncached (libobjc.A.dylib:x86_64+0x2218)
    #9 0x600022e501a2 in +[QuickSpec buildExamplesIfNeeded] (Quick:x86_64+0x21a2)
    #10 0x600022e4fca0 in +[QuickSpec defaultTestSuite] (Quick:x86_64+0x1ca0)
    #11 0x10aa36f4a in +[XCTestSuite _suiteForBundleCache] (XCTest:x86_64+0x20f4a)
    #12 0x10aa395e0 in -[XCTestSuite _initWithTestConfiguration:] (XCTest:x86_64+0x235e0)
    #13 0x10aa39f95 in +[XCTestSuite testSuiteForTestConfiguration:] (XCTest:x86_64+0x23f95)
    #14 0x10aaba242 in __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke (XCTest:x86_64+0xa4242)
    #15 0x10aaba390 in __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke.84 (XCTest:x86_64+0xa4390)
    #16 0x10aa52592 in -[XCTestObservationCenter _observeTestExecutionForBlock:] (XCTest:x86_64+0x3c592)
    #17 0x10aaba04c in -[XCTTestRunSession runTestsAndReturnError:] (XCTest:x86_64+0xa404c)
    #18 0x10aa1bdd6 in -[XCTestDriver runTestsAndReturnError:] (XCTest:x86_64+0x5dd6)
    #19 0x10aaa7553 in _XCTestMain (XCTest:x86_64+0x91553)
    #20 0x1067a4be6 in __RunTests_block_invoke_2 (libXCTestBundleInject.dylib:x86_64+0x1be6)
    #21 0x7fff23bd429b in __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ (CoreFoundation:x86_64+0xa029b)
    #22 0x7fff23bd3a07 in __CFRunLoopDoBlocks (CoreFoundation:x86_64+0x9fa07)
    #23 0x7fff23bce893 in __CFRunLoopRun (CoreFoundation:x86_64+0x9a893)
    #24 0x7fff23bce065 in CFRunLoopRunSpecific (CoreFoundation:x86_64+0x9a065)
    #25 0x7fff384c0baf in GSEventRunModal (GraphicsServices:x86_64+0x3baf)
    #26 0x7fff48092d4c in UIApplicationMain (UIKitCore:x86_64+0xab7d4c)
    #27 0x102f4d9b9 in main AppDelegate.swift:24
    #28 0x7fff5227ec24 in start (libdyld.dylib:x86_64+0xc24)
 
==53933==Register values:
rax = 0xaaaaaaaaaaaaaaaa  rbx = 0xaaaaaaaaaaaaaaaa  rcx = 0x00007fff89eb4168  rdx = 0x0000000000003d80  
rdi = 0xaaaaaaaaaaaaaaaa  rsi = 0x00006000ef909298  rbp = 0x00007ffeeccbf030  rsp = 0x00007ffeeccbf030  
 r8 = 0x00006000ef909290   r9 = 0x00007fff52433339  r10 = 0x0000000000000019  r11 = 0xffffe00133ccaa38  
r12 = 0x00006000ef909298  r13 = 0x00007ffeeccbf070  r14 = 0x000000000000733e  r15 = 0x00006000ef764610  
UndefinedBehaviorSanitizer can not provide additional info.
==53933==ABORTING
 
abort() called
CoreSimulator 681.17.2 - Device: iPhone SE (D2D68BC8-1479-4568-A76B-6674A13D565C) - Runtime: iOS 13.3 (17C45) - DeviceType: iPhone SE

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff523bc2c6 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff52462bf1 pthread_kill + 284
2   libsystem_c.dylib             	0x00007fff5234ba5c abort + 120
3   libclang_rt.ubsan_iossim_dynamic.dylib	0x00000001098ded9c __sanitizer::Abort() + 60
4   libclang_rt.ubsan_iossim_dynamic.dylib	0x00000001098d6f64 __sanitizer::Die() + 196
5   libclang_rt.ubsan_iossim_dynamic.dylib	0x00000001098deb26 __sanitizer::HandleDeadlySignal(void*, void*, unsigned int, void (*)(__sanitizer::SignalContext const&, void const*, __sanitizer::BufferedStackTrace*), void const*) + 102
6   libsystem_platform.dylib      	0x00007fff52457b5d _sigtramp + 29
7   ???                           	000000000000000000 0 + 0
8   io.quick.Quick                	0x0000600022e65f92 specialized static QuickConfiguration.enumerateSubclasses(_:) + 242 (QuickConfiguration.swift:39)
9   io.quick.Quick                	0x0000600022e65b2a @objc static QuickConfiguration.configureSubclassesIfNeeded(world:) + 90
10  io.quick.Quick                	0x0000600022e50975 +[QuickConfiguration initialize] + 108 (QuickConfiguration.m:40)
11  libobjc.A.dylib               	0x00007fff513fc103 CALLING_SOME_+initialize_METHOD + 17
12  libobjc.A.dylib               	0x00007fff513fcee9 initializeNonMetaClass + 624
13  libobjc.A.dylib               	0x00007fff513fd4ba initializeAndMaybeRelock(objc_class*, objc_object*, mutex_tt<false>&, bool) + 157
14  libobjc.A.dylib               	0x00007fff51407a5d lookUpImpOrForward + 595
15  libobjc.A.dylib               	0x00007fff513f8219 _objc_msgSend_uncached + 73
16  io.quick.Quick                	0x0000600022e501a3 +[QuickSpec buildExamplesIfNeeded] + 44 (QuickSpec.m:85)
17  io.quick.Quick                	0x0000600022e4fca1 +[QuickSpec defaultTestSuite] + 54 (QuickSpec.m:30)
18  com.apple.dt.XCTest           	0x000000010aa36f4b +[XCTestSuite _suiteForBundleCache] + 628
19  com.apple.dt.XCTest           	0x000000010aa395e1 -[XCTestSuite _initWithTestConfiguration:] + 554
20  com.apple.dt.XCTest           	0x000000010aa39f96 +[XCTestSuite testSuiteForTestConfiguration:] + 53
21  com.apple.dt.XCTest           	0x000000010aaba243 __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke + 96
22  com.apple.dt.XCTest           	0x000000010aaba391 __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke.84 + 118
23  com.apple.dt.XCTest           	0x000000010aa52593 -[XCTestObservationCenter _observeTestExecutionForBlock:] + 588
24  com.apple.dt.XCTest           	0x000000010aaba04d -[XCTTestRunSession runTestsAndReturnError:] + 623
25  com.apple.dt.XCTest           	0x000000010aa1bdd7 -[XCTestDriver runTestsAndReturnError:] + 456
26  com.apple.dt.XCTest           	0x000000010aaa7554 _XCTestMain + 2484
27  libXCTestBundleInject.dylib   	0x00000001067a4be7 __RunTests_block_invoke_2 + 13
28  com.apple.CoreFoundation      	0x00007fff23bd429c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
29  com.apple.CoreFoundation      	0x00007fff23bd3a08 __CFRunLoopDoBlocks + 312
30  com.apple.CoreFoundation      	0x00007fff23bce894 __CFRunLoopRun + 1284
31  com.apple.CoreFoundation      	0x00007fff23bce066 CFRunLoopRunSpecific + 438
32  com.apple.GeoServices         	0x00007fff384c0bb0 GSEventRunModal + 65
33  com.apple.UIKitCore           	0x00007fff48092d4d UIApplicationMain + 1621
34  com.turvo.mobile.driver.dev   	0x0000000102f4d9ba main + 58 (AppDelegate.swift:24)
35  libdyld.dylib                 	0x00007fff5227ec25 start + 1
```



