### PR TITLE
Fix Xcode documentation link of how to create xcworkspace

### DIFF
--- a/Documentation/en-us/InstallingQuick.md
+++ b/Documentation/en-us/InstallingQuick.md
@@ -22,7 +22,7 @@ you should be able to `import Quick` from within files in your test target.
 To link Quick and Nimble using Git submodules:
 
 1. Add submodule for Quick.
-2. If you don't already have a `.xcworkspace` for your project, create one. ([Here's how](https://developer.apple.com/library/ios/recipes/xcode_help-structure_navigator/articles/Adding_an_Existing_Project_to_a_Workspace.html))
+2. If you don't already have a `.xcworkspace` for your project, create one. ([Here's how](https://help.apple.com/xcode/mac/11.4/#/devf5378fca9))
 3. Add `Quick.xcodeproj` to your project's `.xcworkspace`.
 4. Add `Nimble.xcodeproj` to your project's `.xcworkspace`. It exists in `path/to/Quick/Externals/Nimble`. By adding Nimble from Quick's dependencies (as opposed to adding directly as a submodule), you'll ensure that you're using the correct version of Nimble for whatever version of Quick you're using.
 5. Link `Quick.framework` and `Nimble.framework` in your test target's

--- a/Documentation/ja/InstallingQuick.md
+++ b/Documentation/ja/InstallingQuick.md
@@ -21,7 +21,7 @@ Quick をテストに組み込むには３つの方法があります。
 Git submodules を使って Quick と Nimble をリンクします。手順の流れとしては下記の通りです。
 
 1. Quick を submodule として追加.
-2. プロジェクトで`.xcworkspace`を使っていなければ作成してください。 ([こちらを参照](https://developer.apple.com/library/ios/recipes/xcode_help-structure_navigator/articles/Adding_an_Existing_Project_to_a_Workspace.html))
+2. プロジェクトで`.xcworkspace`を使っていなければ作成してください。 ([こちらを参照](https://help.apple.com/xcode/mac/11.4/#/devf5378fca9))
 3. `Quick.xcodeproj` をプロジェクトの`.xcworkspace`に追加してください。
 4. `Nimble.xcodeproj` をプロジェクトの`.xcworkspace`に追加してください。 `Nimble.xcodeproj` は `path/to/Quick/Externals/Nimble` にあります。 Quick が依存している Niimble を追加することで Quick のバージョンと Nimble のバージョンを合わせられます。
 

--- a/Documentation/ko-kr/InstallingQuick.md
+++ b/Documentation/ko-kr/InstallingQuick.md
@@ -18,7 +18,7 @@ Quick은 예제들과 예제 그룹을 정의하는 구문을 제공합니다. N
 Git 서브 모듈을 사용하여 Quick과 Nimble을 링크하려면:
 
 1. Quick 서브 모듈을 추가하세요.
-2. `.xcworkspace` 가 프로젝트에 아직 없는 경우, 만드세요. ([방법은 이곳에](https://developer.apple.com/library/ios/recipes/xcode_help-structure_navigator/articles/Adding_an_Existing_Project_to_a_Workspace.html))
+2. `.xcworkspace` 가 프로젝트에 아직 없는 경우, 만드세요. ([방법은 이곳에](https://help.apple.com/xcode/mac/11.4/#/devf5378fca9))
 3. `Quick.xcodeproj`를 프로젝트의 `.xcworkspace` 에 추가하세요.
 4. `Nimble.xcodeproj` 또한 프로젝트의 `.xcworkspace` 에 추가하세요. `path/to/Quick/Externals/Nimble` 에 있습니다. Quick의 종속성에서 Nimble을 추가하면 (하위 모듈에서 바로 추가하는 것과 대조적으로), 당신이 사용하고 있는 Quick의 버전에 맞는 Nimble의 올바른 버전을 사용할 수 있게 됩니다.
 5.  `Quick.framework`와 `Nimble.framework`를 test target 프로젝트의 "Link Binary with Libraries" build phase에 링크시키세요.

--- a/Documentation/zh-cn/InstallingQuick.md
+++ b/Documentation/zh-cn/InstallingQuick.md
@@ -21,7 +21,7 @@ Quick 提供了定义例子和例子群的语法。 Nimble 提供了如 `expect(
 通过以下步骤可以使用 Git 的子模块(submodules) 为项目添加 Quick 和 Nimble ：
 
 1. 添加子模块 Quick。
-2. 为你的项目新建一个 `.xcworkspace` 文件，如果原本已经有这个文件，则跳过此步骤。 ([如何添加请看这里](https://developer.apple.com/library/ios/recipes/xcode_help-structure_navigator/articles/Adding_an_Existing_Project_to_a_Workspace.html))
+2. 为你的项目新建一个 `.xcworkspace` 文件，如果原本已经有这个文件，则跳过此步骤。 ([如何添加请看这里](https://help.apple.com/xcode/mac/11.4/#/devf5378fca9))
 3. 把 `Quick.xcodeproj` 添加到项目的 `.xcworkspace`中。
 4. 把 `Nimble.xcodeproj` 添加到项目的 `.xcworkspace`中。它所在的目录是： `path/to/Quick/Externals/Nimble`。 通过从 Quick 的依赖库中添加 Nimble (而不是直接添加为子模块)，可以确保无论所用的 Quick 是什么版本，都能使用正确版本的 Nimble 。
 5. 把 `Quick.framework` 和 `Nimble.framework` 添加到项目 "build phase" 选项页的 "Link Binary with Libraries" 列表中。


### PR DESCRIPTION
Resolves #723.

https://help.apple.com/xcode/mac/11.4/#/devf5378fca9 is the new location.