### PR TITLE
[SwiftLint] Enable function_body_length rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,5 @@
 disabled_rules:
   - line_length
-  - function_body_length
 included:
   - Sources
   - Tests

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,3 +1,4 @@
 disabled_rules:
+  - function_body_length
   - identifier_name
   - type_name


### PR DESCRIPTION
ref: #641 