### PR TITLE
Delegate `recordFailure` to `QuickSpec.current`

### DIFF
--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -120,6 +120,32 @@ open class QuickSpec: QuickSpecBase {
             self.init().spec()
         }
     }
+
+    // MARK: Delegation to `QuickSpec.current`.
+
+    override public func recordFailure(
+        withDescription description: String,
+        inFile filePath: String,
+        atLine lineNumber: Int,
+        expected: Bool
+    ) {
+        guard self === Self.current else {
+            Self.current.recordFailure(
+                withDescription: description,
+                inFile: filePath,
+                atLine: lineNumber,
+                expected: expected
+            )
+            return
+        }
+
+        super.recordFailure(
+            withDescription: description,
+            inFile: filePath,
+            atLine: lineNumber,
+            expected: expected
+        )
+    }
 }
 
 #endif

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -139,14 +139,22 @@ static QuickSpec *currentSpec = nil;
                               inFile:(NSString *)filePath
                               atLine:(NSUInteger)lineNumber
                             expected:(BOOL)expected {
+    if (self != [QuickSpec current]) {
+        [[QuickSpec current] recordFailureWithDescription:description
+                                                   inFile:filePath
+                                                   atLine:lineNumber
+                                                 expected:expected];
+        return;
+    }
+
     if (self.example.isSharedExample) {
         filePath = self.example.callsite.file;
         lineNumber = self.example.callsite.line;
     }
-    [currentSpec.testRun recordFailureWithDescription:description
-                                               inFile:filePath
-                                               atLine:lineNumber
-                                             expected:expected];
+    [super recordFailureWithDescription:description
+                                 inFile:filePath
+                                 atLine:lineNumber
+                               expected:expected];
 }
 
 @end


### PR DESCRIPTION
refs:
- #888 
- Possibly fix #939 