### PR TITLE
[Dangerfile] Avoid passing a bot account name to `github.api.organization_member`

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -35,7 +35,7 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 warn("Big PR") if git.lines_of_code > @SDM_DANGER_BIG_PR_LINES
 
 # Make a note about contributors not in the organization
-unless github.api.organization_member?('Quick', github.pr_author)
+if github.pr_author != "dependabot[bot]" && !github.api.organization_member?('Quick', github.pr_author)
   # Pay extra attention if they modify the podspec
   if git.modified_files.include?("*.podspec")
     warn "External contributor has edited the Podspec file"


### PR DESCRIPTION
There would be an error such as:

> <!--
>   0 Errors
>   0 Warnings
>   0 Messages
>   1 Markdown
> -->
> 
> ## Danger has errored
> [!] Invalid `Dangerfile` file: bad URI(is not URI?): "https://api.github.com/organizations/8083968/public_members/dependabot[bot]". Updating the Danger gem might fix the issue. Your Danger version: 8.0.0, latest Danger version: 8.0.4
> 
> ```
>  #  from Dangerfile:38
>  #  -------------------------------------------
>  #  # Make a note about contributors not in the organization
>  >  unless github.api.organization_member?('Quick', github.pr_author)
>  #    # Pay extra attention if they modify the podspec
>  #  -------------------------------------------
> ```
> 
> <p align="right" data-meta="generated_by_danger">
>   Generated by :no_entry_sign: <a href="https://danger.systems/">Danger</a>
> </p>
> 