### PR TITLE
Update macOS version in Package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Quick",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
+        .macOS(.v10_13), .iOS(.v8), .tvOS(.v9)
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?

The package file specified the incorrect macOS version, which results in Quick not building on macOS, since `recordFailure` requires 10.13 or later. 

 - What code was refactored / updated to support this change?

I only updated the macOS version in the package file.

 - What issues are related to this PR? Or why was this change introduced?

https://github.com/Quick/Quick/issues/1007

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

