### PR TITLE
Fix `afterSuite` blocks not running when having excluded tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'cocoapods', '~> 1.10'
 gem 'danger'
 gem 'rake'
+gem 'xcpretty'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'cocoapods', '~> 1.10'
 gem 'danger'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     rake (13.0.3)
     rchardet (1.8.0)
     rexml (3.2.4)
+    rouge (2.0.7)
     ruby-macho (1.4.0)
     ruby2_keywords (0.0.4)
     sawyer (0.8.2)
@@ -130,6 +131,8 @@ GEM
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
+    xcpretty (0.3.0)
+      rouge (~> 2.0.7)
 
 PLATFORMS
   ruby
@@ -138,6 +141,7 @@ DEPENDENCIES
   cocoapods (~> 1.10)
   danger
   rake
+  xcpretty
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (4.0.6)
+    rake (13.0.3)
     rchardet (1.8.0)
     rexml (3.2.4)
     ruby-macho (1.4.0)
@@ -136,6 +137,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.10)
   danger
+  rake
 
 BUNDLED WITH
    2.1.4

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -243,7 +243,11 @@ final internal class World: _WorldBase {
         }
 
         if included.isEmpty && configuration.runAllWhenEverythingFiltered {
-            return all
+            let exceptExcluded = all.filter { example in
+                return !self.configuration.exclusionFilters.contains { $0(example) }
+            }
+
+            return exceptExcluded
         } else {
             return included
         }

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -63,7 +63,7 @@ static QuickSpec *currentSpec = nil;
     World *world = [World sharedWorld];
 
     if ([world isRootExampleGroupInitializedForSpecClass:[self class]]) {
-        // The examples fot this subclass have been already built. Skipping.
+        // The examples for this subclass have been already built. Skipping.
         return;
     }
 

--- a/Tests/QuickTests/QuickAfterSuiteTests/AfterSuiteTests.swift
+++ b/Tests/QuickTests/QuickAfterSuiteTests/AfterSuiteTests.swift
@@ -14,6 +14,10 @@ class AfterSuiteTests: QuickSpec {
         it("is executed before afterSuite") {
             expect(afterSuiteTestsWasExecuted).to(beFalsy())
         }
+
+        xit("is not executed") {
+            expect(false).to(beFalse())
+        }
     }
 
     override class func tearDown() {


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
The logic used to determine whether the `afterSuite` blocks should be called or not.
It also adds missing gems required for the `bundle exec rake` command mentioned in the `CONTRIBUTING.md` file.

 - What code was refactored / updated to support this change?
`World.swift`

 - What issues are related to this PR? Or why was this change introduced? 
Fixes #809.
Related to #488.

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

