### PR TITLE
Async tests proof of concept

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -126,7 +126,7 @@ public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
     - parameter file: The absolute path to the file containing the example. A sensible default is provided.
     - parameter line: The line containing the example. A sensible default is provided.
 */
-public func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+public func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) {
     World.sharedWorld.it(description, file: file, line: line, closure: closure)
 }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -83,7 +83,7 @@ extension World {
 #endif
 
     @nonobjc
-    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping () async throws -> Void) {
         if beforesCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'.")
         }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -51,6 +51,28 @@ class FunctionalTests_ItSpec: QuickSpec {
             }
 
         }
+        
+        describe("async tests") {
+            it("support await") {
+                func f() async -> Int {
+                    return 1
+                }
+                
+                expect(await f()) == 1
+            }
+            
+            it("captures errors") {
+                enum E: Error {
+                    case e1
+                }
+                
+                func f() async throws -> Int {
+                    throw E.e1
+                }
+                
+                expect(try await f()).to(throwError(errorType: E.self))
+            }
+        }
 
 #if !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {


### PR DESCRIPTION
Inspired by https://twitter.com/arekholko/status/1402031047014035458?s=21.
Proof of concept for #1084.

### Issues:
- This does not yet build.
- Not backwards compatible. I'm not sure how easy it will be to have async and regular variants of all APIs.
- `Example.run` implementation does not work. I made it block using `DispatchGroup` because the method can't be `async`, as it's used from `Objective-C`. I haven't looked too much into why this implementation is deadlocking, but I suspect this won't be the right way of doing this. Ideally we just hook into `XCTest`s ability to run `async` functions.
- As others have pointed out, `async`/`await` leads to an explosion of call-sites needing to become async. It actually got me thinking how useful it would be for `async` to work like `throws`: just like a method only throws if a called closure does, it would be great if `async` could propagate in the same manner.
- `Nimble` will need support for this too (for example, `Expression`).

