### PR TITLE
Fixing bug #1025

### DIFF
--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -37,6 +37,7 @@ extension QuickConfiguration {
             guard
                 let subclass = classes[Int(index)],
                 let superclass = class_getSuperclass(subclass),
+                type(of: superclass) == QuickConfiguration.Type.self,
                 superclass is QuickConfiguration.Type
                 else { continue }
 

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -52,6 +52,7 @@ extension QuickSpec {
                 guard
                     let subclass = classes[Int(index)],
                     let superclass = class_getSuperclass(subclass),
+                    type(of: superclass) == QuickSpec.Type.self,
                     superclass is QuickSpec.Type
                     else { continue }
 


### PR DESCRIPTION
This PR fixes bug #1025. 

The `enumerateSubclasses` function in `QuickConfiguration` and `QuickTestObservation` uses the `is` keyword to determine if a class is an instance of `QuickConfiguration` or `QuickSpec`. For some reason, this does not work with all classes and causes a [crash](https://github.com/Quick/Quick/issues/1025#issuecomment-717888950) when running tests.

The solution implemented in this PR was proposed by @iDevPro.

More information on the issue can be found here #1025.