### PR TITLE
Excluding Info.plist files from Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,9 @@ let package = Package(
                     "QuickTests/Helpers/QCKSpecRunner.m",
                     "QuickTests/Helpers/QuickTestsBridgingHeader.h",
                     "QuickTests/QuickConfigurationTests.m",
+                    "QuickFocusedTests/Info.plist",
+                    "QuickTests/Info.plist",
+                    "QuickAfterSuiteTests/Info.plist",
                 ]
             ),
             .testTarget(
@@ -36,7 +39,13 @@ let package = Package(
 #if os(macOS)
         targets.append(contentsOf: [
             .target(name: "QuickObjCRuntime", dependencies: []),
-            .target(name: "Quick", dependencies: [ "QuickObjCRuntime" ]),
+            .target(
+                name: "Quick",
+                dependencies: [ "QuickObjCRuntime" ],
+                exclude: [
+                    "Info.plist",
+                ]
+            ),
         ])
 #else
         targets.append(contentsOf: [


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
No

 - What code was refactored / updated to support this change?
 No

 - What issues are related to this PR? Or why was this change introduced?
Warnings are being generated by Xcode when the Quick was used using SPM

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

