### PR TITLE
Specify header_dir in the podspec

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -18,6 +18,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v#{s.version}" }
   s.source_files = "Sources/**/*.{swift,h,m}"
 
+  s.header_dir = "Quick"
+
   s.public_header_files = [
     'Sources/QuickObjectiveC/Configuration/QuickConfiguration.h',
     'Sources/QuickObjectiveC/DSL/QCKDSL.h',


### PR DESCRIPTION
Hi! 👋
I'm working on many libraries for React Native (https://github.com/expo/expo specifically) and I'd like to migrate our existing unit tests from XCTest to Quick and Nimble. Each library is shipped as a pod and its tests are provided as CocoaPods `test_spec`, as you can see here:

https://github.com/expo/expo/blob/1eb8a11176368994763629de3db74478de27fa9f/packages/expo-modules-core/ios/ExpoModulesCore.podspec#L34-L39

However, with Quick and Nimble as a `test_spec` dependency, when I run the tests from Xcode I'm getting such errors:

![Screen Shot 2021-08-07 at 19 37 18](https://user-images.githubusercontent.com/1714764/128609152-dc589064-5854-46cd-8501-84a98d40fc6e.png)

As I've already seen similar issues with other libraries, I **quick**ly checked if `Quick.podspec` and `Nimble.podspec` have the `header_dir` set. They don't, so I added it and used these custom podspecs in my `Podfile` as here:

https://github.com/expo/expo/blob/1eb8a11176368994763629de3db74478de27fa9f/ios/Podfile#L22-L23

With this change, everything works fine! 🎉 I'm not entirely sure why this fixes the root problem, but it only affects local imports in the umbrella header generated by CocoaPods, so that `#import "Quick.h"` becomes `#import "Quick/Quick.h"`. 

@ikesyo if this change looks good to you, I'll go ahead and submit it to Nimble repo as well.



 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
