### PR TITLE
Use Objective-C runtime's `isSubclass(of:)` API for checking superclass

### DIFF
--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -37,7 +37,7 @@ extension QuickConfiguration {
             guard
                 let subclass = classes[Int(index)],
                 let superclass = class_getSuperclass(subclass),
-                superclass is QuickConfiguration.Type
+                superclass.isSubclass(of: QuickConfiguration.self)
                 else { continue }
 
             // swiftlint:disable:next force_cast

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -52,7 +52,7 @@ extension QuickSpec {
                 guard
                     let subclass = classes[Int(index)],
                     let superclass = class_getSuperclass(subclass),
-                    superclass is QuickSpec.Type
+                    superclass.isSubclass(of: QuickSpec.self)
                     else { continue }
 
                 // swiftlint:disable:next force_cast


### PR DESCRIPTION
A possible fix for #1025.