### PR TITLE
Fix individual tests run in Xcode 12.5

### DIFF
--- a/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
+++ b/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
@@ -20,6 +20,10 @@
     Method testCaseWithName = class_getClassMethod(self, @selector(testSuiteForTestCaseWithName:));
     Method hooked_testCaseWithName = class_getClassMethod(self, @selector(qck_hooked_testSuiteForTestCaseWithName:));
     method_exchangeImplementations(testCaseWithName, hooked_testCaseWithName);
+    
+    Method testClassSuitesForTestIdentifiers = class_getClassMethod(self, NSSelectorFromString(@"testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:"));
+    Method hooked_testClassSuitesForTestIdentifiers = class_getClassMethod(self, @selector(qck_hooked_testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:));
+    method_exchangeImplementations(testClassSuitesForTestIdentifiers, hooked_testClassSuitesForTestIdentifiers);
 }
 
 /**
@@ -40,6 +44,33 @@
  */
 + (nullable instancetype)qck_hooked_testSuiteForTestCaseWithName:(nonnull NSString *)name {
     return [QuickTestSuite selectedTestSuiteForTestCaseWithName:name];
+}
+
+/// Starting with Xcode 12.5 XCTest uses `testClassSuitesForTestIdentifiers:` instead of `testSuiteForTestCaseWithName:`
++ (id)qck_hooked_testClassSuitesForTestIdentifiers:(id)arg1 skippingTestIdentifiers:(id)arg2 randomNumberGenerator:(long long)arg3 {
+    // Create resulting suite
+    XCTestSuite *suite = [[XCTestSuite alloc] initWithName:@"Selected by Quick"];
+    
+    // Enumerating all XCTTestIdentifiers
+    // - `arg1` is _XCTTestIdentifierSet_Set
+    // - `testIdentifier` is _XCTTestIdentifier_Double
+    for (id testIdentifier in arg1) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        SEL identifierStringSel = NSSelectorFromString(@"_identifierString");
+        id identifierString = [testIdentifier performSelector:identifierStringSel];
+#pragma clang diagnostic po
+        
+        // Get suite for current XCTTestIdentifier
+        QuickTestSuite *quickSuite = [QuickTestSuite selectedTestSuiteForTestCaseWithName:identifierString];
+        
+        // Add all tests from current XCTTestIdentifier to resulting suite
+        for (XCTest *test in quickSuite.tests) {
+            [suite addTest:test];
+        }
+    }
+    
+    return suite;
 }
 
 @end

--- a/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
+++ b/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
@@ -59,7 +59,7 @@
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         SEL identifierStringSel = NSSelectorFromString(@"_identifierString");
         id identifierString = [testIdentifier performSelector:identifierStringSel];
-#pragma clang diagnostic po
+#pragma clang diagnostic pop
         
         // Get suite for current XCTTestIdentifier
         QuickTestSuite *quickSuite = [QuickTestSuite selectedTestSuiteForTestCaseWithName:identifierString];


### PR DESCRIPTION
Fix for #1094 
 # How to reproduce?
 1. Create project with one failing Quick spec in Xcode 12.5+
 2. Run all tests
 3. Now we have 1/1 failed tests
 4. Rerun that single test by clicking the corresponding test diamond in the gutter
 
Expected results:
- Test failed

Actual results:
- Test succeeded


 # What behavior was changed?
 Starting with Xcode 12.5 XCTest.framework not calling `testSuiteForTestCaseWithName:` when running individual tests.
Instead it calls `testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:`

So we swizzle `testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:` and  create resulting suite where tests from all QuickTestSuites are stored