### PR TITLE
Report skipped tests to Xcode

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -62,7 +62,7 @@ final public class Example: _ExampleBase {
         Executes the example closure, as well as all before and after
         closures defined in the its surrounding example groups.
     */
-    public func run() { // swiftlint:disable:this function_body_length
+    public func run() {
         let world = World.sharedWorld
 
         if world.numberOfExamplesRun == 0 {
@@ -83,31 +83,11 @@ final public class Example: _ExampleBase {
             do {
                 try closure()
             } catch {
-                let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
-                #if SWIFT_PACKAGE
-                let file = callsite.file.description
-                #else
-                let file = callsite.file
-                #endif
-
-                // XCTIssue is unavailable (not implemented yet) on swift-corelibs-xctest (for non-Apple platforms)
-                #if canImport(Darwin)
-                let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
-                let sourceCodeContext = XCTSourceCodeContext(location: location)
-                let issue = XCTIssue(
-                    type: .thrownError,
-                    compactDescription: description,
-                    sourceCodeContext: sourceCodeContext
-                )
-                QuickSpec.current.record(issue)
-                #else
-                QuickSpec.current.recordFailure(
-                    withDescription: description,
-                    inFile: file,
-                    atLine: Int(callsite.line),
-                    expected: false
-                )
-                #endif
+                if let testSkippedError = error as? XCTSkip {
+                    self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
+                } else {
+                    self.reportFailedTest(error, name: name, callsite: callsite)
+                }
             }
 
             self.group!.phase = .aftersExecuting
@@ -140,6 +120,103 @@ final public class Example: _ExampleBase {
             aggregateFlags[key] = value
         }
         return aggregateFlags
+    }
+
+    private func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) { // swiftlint:disable:this function_body_length
+        #if !canImport(Darwin)
+            return // This functionality is only supported by Apple's proprietary XCTest, not by swift-corelibs-xctest
+        #else // `NSSelectorFromString` requires the Objective-C runtime, which is not available on Linux.
+
+            let messageSuffix = """
+                \n
+                If nobody else has done so yet, please submit an issue to https://github.com/Quick/Quick/issues
+
+                For now, we'll just benignly ignore skipped tests.
+            """
+
+            guard let testRun = QuickSpec.current.testRun else {
+                print("""
+                     [Quick Warning]: `QuickSpec.current.testRun` was unexpectededly `nil`.
+                """ + messageSuffix)
+                return
+            }
+
+            let selector = NSSelectorFromString("recordSkipWithDescription:sourceCodeContext:")
+
+            guard testRun.responds(to: selector) else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed, as it no longer responds to
+                    the -[XCTSkip \(NSStringFromSelector(selector))] message necessary to report skipped tests to Xcode.
+                """ + messageSuffix)
+               return
+            }
+
+            guard let skippedTestContextAny = testSkippedError.errorUserInfo["XCTestErrorUserInfoKeySkippedTestContext"] else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected the `errorUserInfo` dictionary of the XCTSKip error to contain a value for the key
+                    "XCTestErrorUserInfoKeySkippedTestContext", but it didn't.
+                """ + messageSuffix)
+                return
+            }
+
+            // Uses an internal type "XCTSkippedTestContext", but "NSObject" will be sufficient for `perform(_:with:_with:)`.
+            guard let skippedTestContext = skippedTestContextAny as? NSObject else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `skippedTestContextAny` to have type `NSObject`,
+                    but we got an object of type \(type(of: skippedTestContextAny))
+                """ + messageSuffix)
+                return
+            }
+
+            guard let sourceCodeContextAny = skippedTestContext.value(forKey: "sourceCodeContext") else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `XCTSkippedTestContext` to have a `sourceCodeContext` property, but it did not.
+                """ + messageSuffix)
+                return
+            }
+
+            guard let sourceCodeContext = sourceCodeContextAny as? XCTSourceCodeContext else {
+                print("""
+                    [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `XCTSkippedTestContext.sourceCodeContext` to have type `XCTSourceCodeContext`,
+                    but we got an object of type \(type(of: sourceCodeContextAny)).
+                """ + messageSuffix)
+                return
+            }
+
+            testRun.perform(selector, with: testSkippedError.message, with: sourceCodeContext)
+        #endif
+    }
+
+    private func reportFailedTest(_ error: Error, name: String, callsite: Callsite) {
+        let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
+
+        #if SWIFT_PACKAGE
+            let file = callsite.file.description
+        #else
+            let file = callsite.file
+        #endif
+
+        #if !SWIFT_PACKAGE
+            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
+            let sourceCodeContext = XCTSourceCodeContext(location: location)
+            let issue = XCTIssue(
+                type: .thrownError,
+                compactDescription: description,
+                sourceCodeContext: sourceCodeContext
+            )
+            QuickSpec.current.record(issue)
+        #else
+            QuickSpec.current.recordFailure(
+                withDescription: description,
+                inFile: file,
+                atLine: Int(callsite.line),
+                expected: false
+            )
+        #endif
     }
 }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -133,11 +133,19 @@ class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
     }
 }
 
+final class FunctionalTests_SkippingTestsSpec: QuickSpec {
+    override func spec() {
+        it("supports skipping tests") { throw XCTSkip("This test is intentionally skipped") }
+        it("supports not skipping tests") { }
+    }
+}
+
 final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [
             ("testAllExamplesAreExecuted", testAllExamplesAreExecuted),
             ("testImplicitErrorHandling", testImplicitErrorHandling),
+            ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -171,5 +179,13 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(result.failureCount, 0)
         XCTAssertEqual(result.unexpectedExceptionCount, 1)
         XCTAssertEqual(result.totalFailureCount, 1)
+    }
+
+    func testSkippingExamplesAreCorrectlyReported() {
+        let result = qck_runSpec(FunctionalTests_SkippingTestsSpec.self)!
+        XCTAssertTrue(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.skipCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 0)
     }
 }


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
 
     When running on macOS, skipped tests will be reported in the Xcode test navigator, like so:
  
    <img width="206" alt="image" src="https://user-images.githubusercontent.com/5703449/131738975-fbed05b2-95e9-4703-a22d-a1076e500990.png">
 
    The skipped line will *not* be marked in the source code editor. It appears that Xcode only does that for statically defined tests (those marked <img width="16" alt="static test" src="https://user-images.githubusercontent.com/5703449/131739328-cdb175e5-abcb-422d-bdf1-c80583c918b1.png">), not runtime tests (those marked <img width="16" alt="run-time test" src="https://user-images.githubusercontent.com/5703449/131739332-740396a7-e2b6-4f4e-acff-d49d079db389.png">), which is what Quick uses exclusively.
  
     Future direction: when some tests are "focused", should we mark all other tests as skipped?

 - What code was refactored / updated to support this change?
 
     The general error-handling path was extracted into a private `reportFailedTest` method.
   
 - What issues are related to this PR? Or why was this change introduced?

    Resolves #1093

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation? *Idk, Should it?*
 - [ ] Does this break the public API (Requires major version bump)? No.
 - [x] Is this a new feature (Requires minor version bump)?

