### PR TITLE
docs(DSL): fix typo

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -212,7 +212,7 @@ public func xit(_ description: String, file: FileString = #file, line: UInt = #l
 }
 
 /**
-    Use this to quicklu mark an `itBehavesLike` closure as pending.
+    Use this to quickly mark an `itBehavesLike` closure as pending.
     This disables the example group defined by this behavior and ensures the code within is never run.
 */
 public func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {


### PR DESCRIPTION
Fixes a typo in the documentation for the `xitBehavesLike` function