### PR TITLE
Fix Swift docs for non-named `configure` argument.

### DIFF
--- a/Documentation/en-us/ConfiguringQuick.md
+++ b/Documentation/en-us/ConfiguringQuick.md
@@ -9,7 +9,7 @@ overriding the `QuickConfiguration.Type.configure()` class method:
 import Quick
 
 class ProjectDataTestConfiguration: QuickConfiguration {
-  override class func configure(configuration: Configuration) {
+  override class func configure(_ configuration: Configuration) {
     // ...set options on the configuration object here.
   }
 }


### PR DESCRIPTION
This change fixes the docs for the `configure` method - which takes a non-named argument.

 - What behavior was changed? None
 - What code was refactored / updated to support this change? None
 - What issues are related to this PR? Or why was this change introduced? Because the docs were wrong.

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

