### PR TITLE
Add support for running a single test

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -128,6 +128,9 @@
 		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
+		8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
+		8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
@@ -367,6 +370,7 @@
 		79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpec_SelectedTests.swift; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
+		8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SelectedTests+ObjC.m"; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrossReferencingSpecs.swift; sourceTree = "<group>"; };
 		CD1F6502226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestObservationCenter+QCKSuspendObservation.swift"; sourceTree = "<group>"; };
@@ -617,6 +621,7 @@
 				DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */,
 				DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */,
 				479C31E11A36156E00DA8718 /* ItTests+ObjC.m */,
+				8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */,
 				4715903F1A488F3F00FBA644 /* PendingTests+ObjC.m */,
 				4748E8931A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m */,
 				4728253A1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m */,
@@ -1378,6 +1383,7 @@
 				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
 				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
 				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
+				8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D712264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
@@ -1466,6 +1472,7 @@
 				AED9C8641CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590411A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919E19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
+				8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D702264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
@@ -1602,6 +1609,7 @@
 				AED9C8631CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590401A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919D19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
+				8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D6F2264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -21,24 +21,36 @@ internal protocol QuickTestSuiteBuilder {
  build dynamic test suites for XCTest to execute.
  */
 public class QuickTestSuite: XCTestSuite {
+    /** Resets the built test suites
+
+        Exposed for testing reasons only.
+     */
+    @objc
+    internal static func reset() {
+        builtTestSuites = []
+    }
 
     private static var builtTestSuites: Set<String> = Set()
 
     /**
-     Construct a test suite for a specific, selected subset of test cases (rather
+     Construct a test suite for a specific, selected subset of tests and test cases (rather
      than the default, which as all test cases).
 
      If this method is called multiple times for the same test case class, e.g..
 
-        FooSpec/testFoo
-        FooSpec/testBar
+        FooSpec, testBar
+        FooSpec, testBar
 
      It is expected that the first call should return a valid test suite, and
      all subsequent calls should return `nil`.
+
+     - Parameter forTestCaseWithName: The name of the `XCTastCase`/`QuickSpec` subclass.
+     - Parameter testName: The name of the individual test to run (if specified).
+     - Returns: A valid test case (if tests were added to the test suite to run), or nil (if tests were not added to the test suite to run)
      */
     @objc
-    public static func selectedTestSuite(forTestCaseWithName name: String) -> QuickTestSuite? {
-        guard let builder = QuickSelectedTestSuiteBuilder(forTestCaseWithName: name) else { return nil }
+    public static func selectedTestSuite(forTestCaseWithName name: String, testName: String?) -> QuickTestSuite? {
+        guard let builder = QuickSelectedTestSuiteBuilder(forTestCaseWithName: name, testName: testName) else { return nil }
 
         let (inserted, _) = builtTestSuites.insert(builder.testSuiteClassName)
         if inserted {

--- a/Sources/Quick/QuickTestSuite.swift
+++ b/Sources/Quick/QuickTestSuite.swift
@@ -44,7 +44,7 @@ public class QuickTestSuite: XCTestSuite {
      It is expected that the first call should return a valid test suite, and
      all subsequent calls should return `nil`.
 
-     - Parameter forTestCaseWithName: The name of the `XCTastCase`/`QuickSpec` subclass.
+     - Parameter name: The name of the `XCTastCase`/`QuickSpec` subclass.
      - Parameter testName: The name of the individual test to run (if specified).
      - Returns: A valid test case (if tests were added to the test suite to run), or nil (if tests were not added to the test suite to run)
      */

--- a/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
+++ b/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
@@ -43,7 +43,8 @@
     FooSpec/testBar
  */
 + (nullable instancetype)qck_hooked_testSuiteForTestCaseWithName:(nonnull NSString *)name {
-    return [QuickTestSuite selectedTestSuiteForTestCaseWithName:name];
+    NSArray<NSString *> *components = [name componentsSeparatedByString:@"/"];
+    return [QuickTestSuite selectedTestSuiteForTestCaseWithName:[components firstObject] testName:[components count] > 1 ? [components lastObject] : nil];
 }
 
 /// Starting with Xcode 12.5 XCTest uses `testClassSuitesForTestIdentifiers:` instead of `testSuiteForTestCaseWithName:`
@@ -57,12 +58,18 @@
     for (id testIdentifier in arg1) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        SEL identifierStringSel = NSSelectorFromString(@"_identifierString");
-        id identifierString = [testIdentifier performSelector:identifierStringSel];
+        SEL componentsSel = NSSelectorFromString(@"components");
+        NSArray<NSString *> *components = [testIdentifier performSelector:componentsSel];
 #pragma clang diagnostic pop
+
+        NSString *testCaseName = [components firstObject];
+        NSString *testName = nil;
+        if ([components count] > 1) {
+            testName = [components lastObject];
+        }
         
         // Get suite for current XCTTestIdentifier
-        QuickTestSuite *quickSuite = [QuickTestSuite selectedTestSuiteForTestCaseWithName:identifierString];
+        QuickTestSuite *quickSuite = [QuickTestSuite selectedTestSuiteForTestCaseWithName:testCaseName testName:testName];
         
         // Add all tests from current XCTTestIdentifier to resulting suite
         for (XCTest *test in quickSuite.tests) {

--- a/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
+++ b/Tests/QuickTests/QuickTestHelpers/XCTestCaseProvider.swift
@@ -22,7 +22,7 @@ protocol XCTestCaseNameProvider {
 
 protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
 
-extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
+extension XCTestCaseProvider {
     var allTestNames: [String] {
         return type(of: self).allTests.map { name, _ in
             return name

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
@@ -1,0 +1,85 @@
+@import XCTest;
+@import Quick;
+@import Nimble;
+
+#import "QuickTests-Swift.h"
+#import "QCKSpecRunner.h"
+
+@interface FakeTestIdentifier : NSObject
+
+@property (nonatomic, copy) NSArray *components;
+
+- (instancetype)initWithComponents:(NSArray *)components;
+
+@end
+
+@implementation FakeTestIdentifier
+
+- (instancetype)initWithComponents:(NSArray *)components {
+    if ((self = [super init])) {
+        self.components = components;
+    }
+    return self;
+}
+
+@end
+
+@interface XCTestSuite (Private_Headers)
+
+/// Starting with Xcode 12.5 XCTest uses `testClassSuitesForTestIdentifiers:` instead of `testSuiteForTestCaseWithName:`
++ (instancetype)testClassSuitesForTestIdentifiers:(id)arg1 skippingTestIdentifiers:(id)arg2 randomNumberGenerator:(long long)arg3;
+
+@end
+
+QuickSpecBegin(FunctionalTests_SimulateTests_Objc)
+it(@"example1", ^{});
+it(@"example2", ^{});
+it(@"example3", ^{});
+QuickSpecEnd
+
+// Invoking private methods in Swift is incredibly janky
+// this functionality is tested in Objective-C.
+
+QuickSpecBegin(FunctionalTests_SelectedTests_Xcode12_5_ObjC)
+
+beforeEach(^{
+    [QuickTestSuite reset];
+});
+
+it(@"correctly grabs only the tests specified", ^{
+    NSArray *testIdentifiers = @[
+        [[FakeTestIdentifier alloc] initWithComponents:@[
+            @"FunctionalTests_SimulateTests_Objc",
+            @"example1",
+        ]]
+    ];
+    XCTestSuite *suite = [XCTestSuite testClassSuitesForTestIdentifiers:testIdentifiers skippingTestIdentifiers:nil randomNumberGenerator:0];
+
+    expect(suite.tests).to(haveCount(1));
+    expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {
+        return [test.name isEqualToString:@"-[FunctionalTests_SimulateTests_Objc example1]"];
+    }));
+});
+
+it(@"correctly grabs all tests in a test case if no specific test is specified", ^{
+    NSArray *testIdentifiers = @[
+        [[FakeTestIdentifier alloc] initWithComponents:@[
+            @"FunctionalTests_SimulateTests_Objc"
+        ]]
+    ];
+    XCTestSuite *suite = [XCTestSuite testClassSuitesForTestIdentifiers:testIdentifiers skippingTestIdentifiers:nil randomNumberGenerator:0];
+
+    expect(suite.tests).to(haveCount(3));
+    expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {
+        return [test.name isEqualToString:@"-[FunctionalTests_SimulateTests_Objc example1]"];
+    }));
+    expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {
+        return [test.name isEqualToString:@"-[FunctionalTests_SimulateTests_Objc example2]"];
+    }));
+    expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {
+        return [test.name isEqualToString:@"-[FunctionalTests_SimulateTests_Objc example3]"];
+    }));
+});
+
+QuickSpecEnd
+

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
@@ -47,6 +47,10 @@ beforeEach(^{
 });
 
 it(@"correctly grabs only the tests specified", ^{
+    if ([XCTestSuite respondsToSelector:@selector(testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:)] == NO) {
+        XCTSkip(@"Skipping. XCTestSuite does not respond to testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:");
+        return;
+    }
     NSArray *testIdentifiers = @[
         [[FakeTestIdentifier alloc] initWithComponents:@[
             @"FunctionalTests_SimulateTests_Objc",
@@ -62,6 +66,10 @@ it(@"correctly grabs only the tests specified", ^{
 });
 
 it(@"correctly grabs all tests in a test case if no specific test is specified", ^{
+    if ([XCTestSuite respondsToSelector:@selector(testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:)] == NO) {
+        XCTSkip(@"Skipping. XCTestSuite does not respond to testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:");
+        return;
+    }
     NSArray *testIdentifiers = @[
         [[FakeTestIdentifier alloc] initWithComponents:@[
             @"FunctionalTests_SimulateTests_Objc"

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -1,7 +1,7 @@
 #if canImport(Darwin) && !SWIFT_PACKAGE
 
 import Nimble
-import Quick
+@testable import Quick
 import XCTest
 
 // The regression tests for https://github.com/Quick/Quick/issues/891
@@ -20,7 +20,7 @@ class SimulateSelectedTests_TestCase: QuickSpec {
     }
 }
 
-class SimulareAllTests_TestCase: QuickSpec {
+class SimulateAllTests_TestCase: QuickSpec {
     override func spec() {
         it("example1") { }
         it("example2") { }
@@ -32,7 +32,7 @@ class QuickSpec_SelectedTests: XCTestCase {
 
     func testQuickSpecTestInvocationsForAllTests() {
         // Simulate running 'All tests'
-        let invocations = SimulareAllTests_TestCase.testInvocations
+        let invocations = SimulateAllTests_TestCase.testInvocations
         expect(invocations).to(haveCount(3))
 
         let selectorNames = invocations.map { $0.selector.description }
@@ -46,6 +46,21 @@ class QuickSpec_SelectedTests: XCTestCase {
 
         let selectorNames = invocations.map { $0.selector.description }
         expect(selectorNames).to(contain(["example1", "example2", "example3"]))
+    }
+
+    func testQuickSpecRequestingNoTestCase() {
+        QuickTestSuite.reset()
+
+        let suite = XCTestSuite(forTestCaseWithName: "SimulateSelectedTests_TestCase")
+        expect(suite.tests).to(haveCount(3))
+    }
+
+    func testQuickSpecRequestingOneTestCase() {
+        QuickTestSuite.reset()
+
+        let suite = XCTestSuite(forTestCaseWithName: "SimulateSelectedTests_TestCase/example1")
+        expect(suite.tests).to(haveCount(1))
+        expect(suite.tests).to(allPass { $0?.name.contains("example1") == true })
     }
 }
 


### PR DESCRIPTION
This implements half of the functionality of [zacwest's PR](https://github.com/Quick/Quick/pull/936), but in a more maintainable manner (this implementation uses `XCTTestIdentifier -components`, whereas zacwest's tries to parse the string from `_identifierString`, which doesn't work as well because `_identifierString` can return either swift-formatted (`foo/myMethod()`) or objc-formatted (`foo/myMethod`) identifiers).
This allows you to select an individual (or set of) test from the Test Navigator in Xcode and run only that test.

This also adds tests guaranteeing the functionality works, though it is split between tests written in objc and swift.

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
     - This adds the ability to run an individual test. You can do this in Xcode using the Test Navigator. Eventually (not in this PR), I'd love to figure out a way to have the "test diamonds" appear next to all the "it" tests.
 - What code was refactored / updated to support this change?
    - Moved logic for determining name of test case class to run from `QuickSelectedTestSuiteBuilder testCaseClassForTestCaseWithName` to `XCTestSuite+qck_hooked_testSuiteForTestCaseWithName:` (the part where we do the `[name componentsSeparatedByString:@"/"]`). This was done to support pulling out the individual test name using mechanisms that XCTest gives us.
     - Instead of parsing the `XCTTestIdentifier._identifierString` property to figure out which test case to run, we use the `components` property of `XCTTestIdentifier`, which gives us the test case class to run (`components.firstObject`), then the individual test to run (`components.lastObject`, there are only ever 2 objects in the `components` array).
     - Changed `QuickTestSuite.selectedTestSuite(forTestCaseWithName:)` to `QuickTestSuite.selectedTestSuite(forTestCaseWithName:testName:)`, which takes an optional `testName` (for the individual test to run) and constructs the objective-c style name of the test, to later filter down for the exact test to run.

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - Does not break the public API.
 - [x] Is this a new feature (Requires minor version bump)?

