### PR TITLE
Fix XCTest lifecycle in Xcode13.3

### DIFF
--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -12,16 +12,24 @@ import XCTest
 @objc internal final class QuickTestObservation: NSObject, XCTestObservation {
     @objc(sharedInstance)
     static let shared = QuickTestObservation()
-
-    // Quick hooks into this event to compile example groups for each QuickSpec subclasses.
-    //
-    // If an exception occurs when compiling examples, report it to the user. Chances are they
-    // included an expectation outside of a "it", "describe", or "context" block.
-    func testBundleWillStart(_ testBundle: Bundle) {
+    
+    override init() {
+        super.init()
         QuickSpec.enumerateSubclasses { specClass in
             // This relies on `_QuickSpecInternal`.
             (specClass as AnyClass).buildExamplesIfNeeded()
         }
+    }
+
+    // Quick hooks into this event to compile example groups for each QuickSpec subclasses.
+    //
+    // If an exception occurs when compiling examples, report it to the user. Chances are theys
+    // included an expectation outside of a "it", "describe", or "context" block.
+    func testBundleWillStart(_ testBundle: Bundle) {
+//        QuickSpec.enumerateSubclasses { specClass in
+//            // This relies on `_QuickSpecInternal`.
+//            (specClass as AnyClass).buildExamplesIfNeeded()
+//        }
     }
 }
 


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
 - What code was refactored / updated to support this change?
 - What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

