### PR TITLE
Fix test cases discoverage in Xcode 13.3 

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -119,6 +119,9 @@
 		64076D231D6D7E6B00E2B499 /* AfterSuiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64076D1D1D6D7D0B00E2B499 /* AfterSuiteTests.swift */; };
 		64076D261D6D80B500E2B499 /* AfterSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */; };
 		64076D271D6D80B500E2B499 /* AfterSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */; };
+		754F536D27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754F536C27F19F3C0078174B /* QuickTestExamplesLoader.swift */; };
+		754F536E27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754F536C27F19F3C0078174B /* QuickTestExamplesLoader.swift */; };
+		754F536F27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754F536C27F19F3C0078174B /* QuickTestExamplesLoader.swift */; };
 		79FE27DF22DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
 		79FE27E022DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
 		79FE27E122DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */; };
@@ -364,6 +367,7 @@
 		64076D1A1D6D7CEA00E2B499 /* QuickAfterSuite - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64076D1D1D6D7D0B00E2B499 /* AfterSuiteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AfterSuiteTests.swift; sourceTree = "<group>"; };
 		64076D241D6D80B500E2B499 /* AfterSuiteTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AfterSuiteTests+ObjC.m"; sourceTree = "<group>"; };
+		754F536C27F19F3C0078174B /* QuickTestExamplesLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickTestExamplesLoader.swift; sourceTree = "<group>"; };
 		79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpec_SelectedTests.swift; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
@@ -781,6 +785,7 @@
 				CD3451461E4703D4000C8633 /* QuickMain.swift */,
 				CD3451471E4703D4000C8633 /* QuickSpec.swift */,
 				CD21A025247C1385002C4762 /* QuickTestObservation.swift */,
+				754F536C27F19F3C0078174B /* QuickTestExamplesLoader.swift */,
 				34F375A619515CA700CE1B99 /* World.swift */,
 				34F3759E19515CA700CE1B99 /* Example.swift */,
 				DA02C91819A8073100093156 /* ExampleMetadata.swift */,
@@ -1327,6 +1332,7 @@
 				1F118D021BDCA536005013A2 /* SuiteHooks.swift in Sources */,
 				1F118CFB1BDCA536005013A2 /* QuickConfiguration.m in Sources */,
 				34C5860A1C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
+				754F536F27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */,
 				1F118D041BDCA536005013A2 /* Example.swift in Sources */,
 				1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */,
 				DED3036D1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
@@ -1415,6 +1421,7 @@
 				DA02C91A19A8073100093156 /* ExampleMetadata.swift in Sources */,
 				34C586091C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				DA408BE719FF5599005DF92A /* SuiteHooks.swift in Sources */,
+				754F536E27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */,
 				34F375BA19515CA700CE1B99 /* QuickSpec.m in Sources */,
 				DED3036C1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				CE590E1C1C431FE300253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
@@ -1551,6 +1558,7 @@
 				CE57CEDD1C430BD200D63004 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				DA02C91919A8073100093156 /* ExampleMetadata.swift in Sources */,
 				CE57CEDF1C430BD200D63004 /* QuickTestSuite.swift in Sources */,
+				754F536D27F19F3C0078174B /* QuickTestExamplesLoader.swift in Sources */,
 				34C586081C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				DED3036B1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */,

--- a/Sources/Quick/QuickTestExamplesLoader.swift
+++ b/Sources/Quick/QuickTestExamplesLoader.swift
@@ -1,0 +1,76 @@
+#if !SWIFT_PACKAGE
+
+import Foundation
+
+/// Singleton which can call `buildExamplesIfNeeded` on each `QuickSpec` subclass once per lifetime of application
+@objc internal final class QuickTestExamplesLoader: NSObject {
+    @objc(sharedInstance)
+    static let shared = QuickTestExamplesLoader()
+
+    private var didBuildExamples = false
+
+    private override init() {}
+
+    /// Iterates over all subclasses of `QuickSpec` and calls `buildExamplesIfNeeded` method on each one once per lifetime of application.
+    ///
+    /// If an exception occurs when compiling examples, report it to the user. Chances are they
+    /// included an expectation outside of a "it", "describe", or "context" block.
+    @objc func buildExamplesIfNeeded() {
+        guard didBuildExamples == false else { return }
+        didBuildExamples = true
+
+        QuickSpec.enumerateSubclasses { specClass in
+            // This relies on `_QuickSpecInternal`.
+            (specClass as AnyClass).buildExamplesIfNeeded()
+        }
+    }
+}
+
+/// A dummy protocol for calling the internal `+[QuickSpec buildExamplesIfNeeded]` method
+/// which is defined in Objective-C from Swift.
+@objc private protocol _QuickSpecInternal {
+    static func buildExamplesIfNeeded()
+}
+
+// swiftlint:disable:next todo
+// TODO: Unify this with QuickConfiguration's equivalent
+private extension QuickSpec {
+    static func enumerateSubclasses(
+        subclasses: [QuickSpec.Type]? = nil,
+        _ block: (QuickSpec.Type) -> Void
+    ) {
+        let subjects: [QuickSpec.Type]
+        if let subclasses = subclasses {
+            subjects = subclasses
+        } else {
+            let classesCount = objc_getClassList(nil, 0)
+
+            guard classesCount > 0 else {
+                return
+            }
+
+            let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
+            defer { free(classes) }
+
+            objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
+
+            var specSubclasses: [QuickSpec.Type] = []
+            for index in 0..<classesCount {
+                guard
+                    let subclass = classes[Int(index)],
+                    let superclass = class_getSuperclass(subclass),
+                    superclass is QuickSpec.Type
+                    else { continue }
+
+                // swiftlint:disable:next force_cast
+                specSubclasses.append(subclass as! QuickSpec.Type)
+            }
+
+            subjects = specSubclasses
+        }
+
+        subjects.forEach(block)
+    }
+}
+
+#endif

--- a/Sources/Quick/QuickTestExamplesLoader.swift
+++ b/Sources/Quick/QuickTestExamplesLoader.swift
@@ -28,13 +28,13 @@ import Foundation
 
 /// A dummy protocol for calling the internal `+[QuickSpec buildExamplesIfNeeded]` method
 /// which is defined in Objective-C from Swift.
-@objc private protocol _QuickSpecInternal {
+@objc protocol _QuickSpecInternal {
     static func buildExamplesIfNeeded()
 }
 
 // swiftlint:disable:next todo
 // TODO: Unify this with QuickConfiguration's equivalent
-private extension QuickSpec {
+extension QuickSpec {
     static func enumerateSubclasses(
         subclasses: [QuickSpec.Type]? = nil,
         _ block: (QuickSpec.Type) -> Void

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -3,66 +3,12 @@
 import Foundation
 import XCTest
 
-/// A dummy protocol for calling the internal `+[QuickSpec buildExamplesIfNeeded]` method
-/// which is defined in Objective-C from Swift.
-@objc internal protocol _QuickSpecInternal {
-    static func buildExamplesIfNeeded()
-}
-
 @objc internal final class QuickTestObservation: NSObject, XCTestObservation {
-    @objc(sharedInstance)
-    static let shared = QuickTestObservation()
+    private let examplesGlobalLoader = QuickTestExamplesLoader.shared
 
     // Quick hooks into this event to compile example groups for each QuickSpec subclasses.
-    //
-    // If an exception occurs when compiling examples, report it to the user. Chances are they
-    // included an expectation outside of a "it", "describe", or "context" block.
     func testBundleWillStart(_ testBundle: Bundle) {
-        QuickSpec.enumerateSubclasses { specClass in
-            // This relies on `_QuickSpecInternal`.
-            (specClass as AnyClass).buildExamplesIfNeeded()
-        }
-    }
-}
-
-// swiftlint:disable:next todo
-// TODO: Unify this with QuickConfiguration's equivalent
-extension QuickSpec {
-    internal static func enumerateSubclasses(
-        subclasses: [QuickSpec.Type]? = nil,
-        _ block: (QuickSpec.Type) -> Void
-    ) {
-        let subjects: [QuickSpec.Type]
-        if let subclasses = subclasses {
-            subjects = subclasses
-        } else {
-            let classesCount = objc_getClassList(nil, 0)
-
-            guard classesCount > 0 else {
-                return
-            }
-
-            let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
-            defer { free(classes) }
-
-            objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), classesCount)
-
-            var specSubclasses: [QuickSpec.Type] = []
-            for index in 0..<classesCount {
-                guard
-                    let subclass = classes[Int(index)],
-                    let superclass = class_getSuperclass(subclass),
-                    superclass is QuickSpec.Type
-                    else { continue }
-
-                // swiftlint:disable:next force_cast
-                specSubclasses.append(subclass as! QuickSpec.Type)
-            }
-
-            subjects = specSubclasses
-        }
-
-        subjects.forEach(block)
+        examplesGlobalLoader.buildExamplesIfNeeded()
     }
 }
 

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -24,6 +24,10 @@ static QuickSpec *currentSpec = nil;
  @return An array of invocations that execute the newly defined example methods.
  */
 + (NSArray *)testInvocations {
+    // Xcode 13.3 hack, see this issue for more info: https://github.com/Quick/Quick/issues/1123
+    // In case of fix in later versions next line can be removed
+    [[QuickTestExamplesLoader sharedInstance] buildExamplesIfNeeded];
+
     NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
     NSMutableArray *invocations = [NSMutableArray arrayWithCapacity:[examples count]];
     

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -163,5 +163,6 @@ static QuickSpec *currentSpec = nil;
 
 __attribute__((constructor))
 static void registerQuickTestObservation(void) {
-    [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:[QuickTestObservation sharedInstance]];
+    QuickTestObservation *observation = [QuickTestObservation new];
+    [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:observation];
 }


### PR DESCRIPTION
Fix for #1123 

# How to reproduce?

1. Create a project with Quick using Xcode 13.3
2. Add unit tests
3. Run all tests

Expected results:
* Your tests evaluated

Actual results:
* Xcode couldn't discover any test and didn't run it
 
# What behavior was changed?

When running tests in Xcode 13.3 notification `testBundleWillStart` is called after method `testInvocations` of each QuickTest subclass. 
This means that when Xcode asks your QuickTest subclass for test cases to run (calling `testInvocations`) it gets empty array because test cases array will be computed on `testBundleWillStart` call.

# A less complex solution

The first solution that comes to mind is just to call `[self buildExamplesIfNeeded]` inside `testInvocations` method. This one works well at first sight and could help to remove `QuickTestObservation` and `QuickTestExamplesLoader` at all. 
But.
But there was [a commit](https://github.com/Quick/Quick/commit/6cf120fdd875c3077a37aa2d0561ec326e8a4e70) in which @ikesyo removes `[self buildExamplesIfNeeded]` from `testInvocations` (in past it already was there) and creates `QuickTestObservation`. And the reason of this changes is broken focus behaviour. Focus feature needs all examples to be computed before any test execution.