### PR TITLE
Critical! Fix test cases discoverage in Xcode 13.3

### DIFF
--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -13,11 +13,20 @@ import XCTest
     @objc(sharedInstance)
     static let shared = QuickTestObservation()
 
+    private var didBuildAllExamples = false
+
     // Quick hooks into this event to compile example groups for each QuickSpec subclasses.
     //
     // If an exception occurs when compiling examples, report it to the user. Chances are they
     // included an expectation outside of a "it", "describe", or "context" block.
     func testBundleWillStart(_ testBundle: Bundle) {
+        buildAllExamplesIfNeeded()
+    }
+
+    @objc func buildAllExamplesIfNeeded() {
+        guard !didBuildAllExamples else { return }
+        didBuildAllExamples = true
+
         QuickSpec.enumerateSubclasses { specClass in
             // This relies on `_QuickSpecInternal`.
             (specClass as AnyClass).buildExamplesIfNeeded()

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -24,6 +24,10 @@ static QuickSpec *currentSpec = nil;
  @return An array of invocations that execute the newly defined example methods.
  */
 + (NSArray *)testInvocations {
+    // Xcode 13.3 hack, see this issue for more info: https://github.com/Quick/Quick/issues/1123
+    // In case of fix in later versions next line can be removed
+    [[QuickTestObservation sharedInstance] buildAllExamplesIfNeeded];
+
     NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
     NSMutableArray *invocations = [NSMutableArray arrayWithCapacity:[examples count]];
     


### PR DESCRIPTION
Fix for #1123 

# Why critical?

Because Quick does not work with Xcode 13.3.
 
## What behavior was changed?

When running tests in Xcode 13.3 notification `testBundleWillStart` is called after method `testInvocations` of each QuickTest subclass. 
This means that when Xcode asks your QuickTest subclass for test cases to run (calling `testInvocations`) it gets empty array because test cases array will be computed on `testBundleWillStart` call.

## Step 2

As suggested @jessesquires this is step 1 with most important changes that fix the problem. Step 2 will contain a bit of refactoring with extracting examples loading into separate class as now it looks a bit strange that `QuickSpec.testInvocations` method calls `QuickSpecObservation`.