### PR TITLE
Fix running tests in parallel

### DIFF
--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
@@ -62,8 +62,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA9876B11A4C70EB0004AA17"

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-iOS.xcscheme
@@ -62,7 +62,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA9876B11A4C70EB0004AA17"
@@ -72,7 +73,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "64076CF81D6D7CD600E2B499"

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
@@ -62,8 +62,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA5663E71A4C8D8500193C88"

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-macOS.xcscheme
@@ -62,7 +62,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA5663E71A4C8D8500193C88"
@@ -72,7 +73,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "64076CE51D6D7C2000E2B499"

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
@@ -62,8 +62,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F118CEF1BDCA4BB005013A2"

--- a/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
+++ b/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
@@ -62,7 +62,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F118CEF1BDCA4BB005013A2"
@@ -72,7 +73,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "64076D0A1D6D7CEA00E2B499"

--- a/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
+++ b/Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m
@@ -20,10 +20,6 @@
     Method testCaseWithName = class_getClassMethod(self, @selector(testSuiteForTestCaseWithName:));
     Method hooked_testCaseWithName = class_getClassMethod(self, @selector(qck_hooked_testSuiteForTestCaseWithName:));
     method_exchangeImplementations(testCaseWithName, hooked_testCaseWithName);
-    
-    Method testClassSuitesForTestIdentifiers = class_getClassMethod(self, NSSelectorFromString(@"testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:"));
-    Method hooked_testClassSuitesForTestIdentifiers = class_getClassMethod(self, @selector(qck_hooked_testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:));
-    method_exchangeImplementations(testClassSuitesForTestIdentifiers, hooked_testClassSuitesForTestIdentifiers);
 }
 
 /**
@@ -45,39 +41,6 @@
 + (nullable instancetype)qck_hooked_testSuiteForTestCaseWithName:(nonnull NSString *)name {
     NSArray<NSString *> *components = [name componentsSeparatedByString:@"/"];
     return [QuickTestSuite selectedTestSuiteForTestCaseWithName:[components firstObject] testName:[components count] > 1 ? [components lastObject] : nil];
-}
-
-/// Starting with Xcode 12.5 XCTest uses `testClassSuitesForTestIdentifiers:` instead of `testSuiteForTestCaseWithName:`
-+ (id)qck_hooked_testClassSuitesForTestIdentifiers:(id)arg1 skippingTestIdentifiers:(id)arg2 randomNumberGenerator:(long long)arg3 {
-    // Create resulting suite
-    XCTestSuite *suite = [[XCTestSuite alloc] initWithName:@"Selected by Quick"];
-    
-    // Enumerating all XCTTestIdentifiers
-    // - `arg1` is _XCTTestIdentifierSet_Set
-    // - `testIdentifier` is _XCTTestIdentifier_Double
-    for (id testIdentifier in arg1) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        SEL componentsSel = NSSelectorFromString(@"components");
-        NSArray<NSString *> *components = [testIdentifier performSelector:componentsSel];
-#pragma clang diagnostic pop
-
-        NSString *testCaseName = [components firstObject];
-        NSString *testName = nil;
-        if ([components count] > 1) {
-            testName = [components lastObject];
-        }
-        
-        // Get suite for current XCTTestIdentifier
-        QuickTestSuite *quickSuite = [QuickTestSuite selectedTestSuiteForTestCaseWithName:testCaseName testName:testName];
-        
-        // Add all tests from current XCTTestIdentifier to resulting suite
-        for (XCTest *test in quickSuite.tests) {
-            [suite addTest:test];
-        }
-    }
-    
-    return suite;
 }
 
 @end

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/SelectedTests+ObjC.m
@@ -24,13 +24,6 @@
 
 @end
 
-@interface XCTestSuite (Private_Headers)
-
-/// Starting with Xcode 12.5 XCTest uses `testClassSuitesForTestIdentifiers:` instead of `testSuiteForTestCaseWithName:`
-+ (instancetype)testClassSuitesForTestIdentifiers:(id)arg1 skippingTestIdentifiers:(id)arg2 randomNumberGenerator:(long long)arg3;
-
-@end
-
 QuickSpecBegin(FunctionalTests_SimulateTests_Objc)
 it(@"example1", ^{});
 it(@"example2", ^{});
@@ -47,17 +40,11 @@ beforeEach(^{
 });
 
 it(@"correctly grabs only the tests specified", ^{
-    if ([XCTestSuite respondsToSelector:@selector(testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:)] == NO) {
-        XCTSkip(@"Skipping. XCTestSuite does not respond to testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:");
+    if ([XCTestSuite respondsToSelector:@selector(testSuiteForTestCaseWithName:)] == NO) {
+        XCTSkip(@"Skipping. XCTestSuite does not respond to testSuiteForTestCaseWithName:");
         return;
     }
-    NSArray *testIdentifiers = @[
-        [[FakeTestIdentifier alloc] initWithComponents:@[
-            @"FunctionalTests_SimulateTests_Objc",
-            @"example1",
-        ]]
-    ];
-    XCTestSuite *suite = [XCTestSuite testClassSuitesForTestIdentifiers:testIdentifiers skippingTestIdentifiers:nil randomNumberGenerator:0];
+    XCTestSuite *suite = [XCTestSuite testSuiteForTestCaseWithName:@"FunctionalTests_SimulateTests_Objc/example1"];
 
     expect(suite.tests).to(haveCount(1));
     expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {
@@ -66,16 +53,11 @@ it(@"correctly grabs only the tests specified", ^{
 });
 
 it(@"correctly grabs all tests in a test case if no specific test is specified", ^{
-    if ([XCTestSuite respondsToSelector:@selector(testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:)] == NO) {
-        XCTSkip(@"Skipping. XCTestSuite does not respond to testClassSuitesForTestIdentifiers:skippingTestIdentifiers:randomNumberGenerator:");
+    if ([XCTestSuite respondsToSelector:@selector(testSuiteForTestCaseWithName:)] == NO) {
+        XCTSkip(@"Skipping. XCTestSuite does not respond to testSuiteForTestCaseWithName:");
         return;
     }
-    NSArray *testIdentifiers = @[
-        [[FakeTestIdentifier alloc] initWithComponents:@[
-            @"FunctionalTests_SimulateTests_Objc"
-        ]]
-    ];
-    XCTestSuite *suite = [XCTestSuite testClassSuitesForTestIdentifiers:testIdentifiers skippingTestIdentifiers:nil randomNumberGenerator:0];
+    XCTestSuite *suite = [XCTestSuite testSuiteForTestCaseWithName:@"FunctionalTests_SimulateTests_Objc"];
 
     expect(suite.tests).to(haveCount(3));
     expect(suite.tests).to(containElementSatisfying(^BOOL(XCTest *test) {


### PR DESCRIPTION
Solves #1139

This reverts 90ec83d37cc8e943944ee07ed0ea9cf2f541c6b1. The original PR that introduced it has since been deleted, so I'm unsure exactly of the intention of that contribution. The commit mentions being able to run a selected test, which is still doable with this revert.

Tests here is setting some of the test targets for each of iOS, tvOS, and macOS to run in parallel.