### PR TITLE
POC: Result-builder based DSL

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -270,6 +270,9 @@
 		DED3037D1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
 		DED3037E1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
 		DED3037F1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */; };
+		FA16228528177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16228428177B5600C4DFC1 /* ResultBuilderTests.swift */; };
+		FA16228628177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16228428177B5600C4DFC1 /* ResultBuilderTests.swift */; };
+		FA16228728177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16228428177B5600C4DFC1 /* ResultBuilderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -443,6 +446,7 @@
 		DED3036A1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleModuleNameTests.swift; sourceTree = "<group>"; };
 		F8100E901A1E4447007595ED /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA16228428177B5600C4DFC1 /* ResultBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultBuilderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -701,6 +705,7 @@
 				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
 				79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */,
+				FA16228428177B5600C4DFC1 /* ResultBuilderTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1404,6 +1409,7 @@
 				DA3E168C243F8C23001F7CCA /* AroundEachTests.swift in Sources */,
 				8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */,
 				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
+				FA16228728177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */,
 				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
 				DA5CBB4B1EAFA61D00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */,
@@ -1495,6 +1501,7 @@
 				DA3E1689243F8C23001F7CCA /* AroundEachTests.swift in Sources */,
 				47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECC1A43442900043E50 /* AfterEachTests+ObjC.m in Sources */,
+				FA16228628177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */,
 				47876F7E1A49AD71002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB4A1EAFA61C00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */,
@@ -1634,6 +1641,7 @@
 				DA3E1686243F8C23001F7CCA /* AroundEachTests.swift in Sources */,
 				47FAEA361A3F49E6005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECB1A43442400043E50 /* AfterEachTests+ObjC.m in Sources */,
+				FA16228528177B5600C4DFC1 /* ResultBuilderTests.swift in Sources */,
 				47876F7D1A49AD63002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB491EAFA61A00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */,

--- a/Sources/Quick/ResultBuilderQuickSpec.swift
+++ b/Sources/Quick/ResultBuilderQuickSpec.swift
@@ -1,3 +1,10 @@
+struct Spec {
+	let rootGroup: ExampleGroup
+
+	init(@SpecBuilder builder: () -> ExampleGroup) {
+		self.rootGroup = builder()
+	}
+}
 
 protocol SpecPart {
 	func append(into: ExampleGroup)
@@ -23,12 +30,6 @@ struct Statement: SpecPart {
 	}
 }
 
-extension ExampleGroup {
-	func append(specPart: SpecPart) {
-		specPart.append(into: self)
-	}
-}
-
 @resultBuilder
 enum SpecBuilder {
 	static func buildExpression(_ expression: SpecPart) -> SpecPart {
@@ -41,42 +42,60 @@ enum SpecBuilder {
 	}
 
 	static func buildBlock(_ subgroups: SpecPart..., file: StaticString = #file, line: UInt = #line) -> SpecPart {
-		let group = ExampleGroup(description: "\(file):\(line)", flags: [:], isInternalRootExampleGroup: false)
-		subgroups.forEach(group.append(specPart:))
-		return group
-	}
-
-//	static func buildFinalResult(_ component: SpecPart) -> ExampleGroup {
-//		let rootGroup = ExampleGroup(
-//			description: "root example group",
-//			flags: [:],
-//			isInternalRootExampleGroup: true
-//		)
-//
-//		rootGroup.append(specPart: component)
-//
-//		return rootGroup
-//	}
-}
-
-class ResultBuilderQuickSpec: QuickSpec {
-	class func createSpecPart() -> ExampleGroup {
-		fatalError("Abstract method")
-	}
-
-	override func spec() {
-//		let rootExampleGroup = createSpecPart()
-//		dump(rootExampleGroup)
-//		World.sharedWorld.performWithCurrentExampleGroup(rootExampleGroup, closure: {})
-	}
-
-	class func describe_builder(_ description: String, flags: FilterFlags = [:], @SpecBuilder builder: () -> SpecPart) -> SpecPart {
-		let newGroup = ExampleGroup(description: description, flags: flags)
-		newGroup.append(specPart: builder())
+		// TODO: Can we elide these intermediate groups somehow?
+		let newGroup = ExampleGroup(description: "\(file):\(line)", flags: [:], isInternalRootExampleGroup: false)
+		subgroups.forEach { $0.append(into: newGroup) }
 		return newGroup
 	}
 
-	class func context_builder(_ description: String, flags: FilterFlags = [:], @SpecBuilder builder: () -> SpecPart) -> SpecPart {
+	static func buildFinalResult(_ component: SpecPart) -> ExampleGroup {
+		let rootGroup = ExampleGroup(
+			description: "root example group",
+			flags: [:],
+			isInternalRootExampleGroup: true
+		)
+
+		component.append(into: rootGroup)
+
+		return rootGroup
+	}
+}
+
+@resultBuilder
+enum SpecPartBuilder {
+	static func buildExpression(_ expression: SpecPart) -> SpecPart {
+		expression
+	}
+
+	// This allows statements (like assignments to variables) to be contained directly in the result builder call
+	// These will all be turned into `beforeEach` hooks.
+	static func buildExpression(_ expression: @escaping @autoclosure () -> Void) -> SpecPart {
+		Statement(closure: expression)
+	}
+
+	static func buildBlock(_ subgroups: SpecPart..., file: StaticString = #file, line: UInt = #line) -> SpecPart {
+		// TODO: Can we elide these intermediate groups somehow?
+		let newGroup = ExampleGroup(description: "\(file):\(line)", flags: [:], isInternalRootExampleGroup: false)
+		subgroups.forEach { $0.append(into: newGroup) }
+		return newGroup
+	}
+}
+
+class ResultBuilderQuickSpec: QuickSpec {
+	open class func spec() -> Spec {
+		fatalError("Abstract method")
+	}
+
+	class func describe_builder(_ description: String, flags: FilterFlags = [:], @SpecPartBuilder builder: () -> SpecPart) -> SpecPart {
+		let newGroup = ExampleGroup(description: description, flags: flags)
+
+		let newSpecPart = builder()
+		newSpecPart.append(into: newGroup)
+
+		return newGroup
+	}
+
+	class func context_builder(_ description: String, flags: FilterFlags = [:], @SpecPartBuilder builder: () -> SpecPart) -> SpecPart {
 		self.describe_builder(description, flags: flags, builder: builder)
 	}
 

--- a/Sources/Quick/ResultBuilderQuickSpec.swift
+++ b/Sources/Quick/ResultBuilderQuickSpec.swift
@@ -1,0 +1,88 @@
+
+protocol SpecPart {
+	func append(into: ExampleGroup)
+}
+
+extension ExampleGroup: SpecPart {
+	func append(into group: ExampleGroup) {
+		group.appendExampleGroup(self)
+	}
+}
+
+extension Example: SpecPart {
+	func append(into group: ExampleGroup) {
+		group.appendExample(self)
+	}
+}
+
+struct Statement: SpecPart {
+	let closure: () -> Void
+
+	func append(into group: ExampleGroup) {
+		group.hooks.appendBefore(self.closure)
+	}
+}
+
+extension ExampleGroup {
+	func append(specPart: SpecPart) {
+		specPart.append(into: self)
+	}
+}
+
+@resultBuilder
+enum SpecBuilder {
+	static func buildExpression(_ expression: SpecPart) -> SpecPart {
+		expression
+	}
+
+	// This allows statements (like assignments to variables) to be contained directly in the result builder call
+	static func buildExpression(_ expression: @escaping @autoclosure () -> Void) -> SpecPart {
+		Statement(closure: expression)
+	}
+
+	static func buildBlock(_ subgroups: SpecPart..., file: StaticString = #file, line: UInt = #line) -> SpecPart {
+		let group = ExampleGroup(description: "\(file):\(line)", flags: [:], isInternalRootExampleGroup: false)
+		subgroups.forEach(group.append(specPart:))
+		return group
+	}
+
+//	static func buildFinalResult(_ component: SpecPart) -> ExampleGroup {
+//		let rootGroup = ExampleGroup(
+//			description: "root example group",
+//			flags: [:],
+//			isInternalRootExampleGroup: true
+//		)
+//
+//		rootGroup.append(specPart: component)
+//
+//		return rootGroup
+//	}
+}
+
+class ResultBuilderQuickSpec: QuickSpec {
+	class func createSpecPart() -> ExampleGroup {
+		fatalError("Abstract method")
+	}
+
+	override func spec() {
+//		let rootExampleGroup = createSpecPart()
+//		dump(rootExampleGroup)
+//		World.sharedWorld.performWithCurrentExampleGroup(rootExampleGroup, closure: {})
+	}
+
+	class func describe_builder(_ description: String, flags: FilterFlags = [:], @SpecBuilder builder: () -> SpecPart) -> SpecPart {
+		let newGroup = ExampleGroup(description: description, flags: flags)
+		newGroup.append(specPart: builder())
+		return newGroup
+	}
+
+	class func context_builder(_ description: String, flags: FilterFlags = [:], @SpecBuilder builder: () -> SpecPart) -> SpecPart {
+		self.describe_builder(description, flags: flags, builder: builder)
+	}
+
+	class func it_builder(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) -> Example {
+		let callsite = Callsite(file: file, line: line)
+		let example = Example(description: description, callsite: callsite, flags: [:], closure: closure)
+		return example
+	}
+}

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -149,11 +149,18 @@ final internal class World: _WorldBase {
         if let group = specs[name] {
             return group
         } else {
-            let group = ExampleGroup(
-                description: "root example group",
-                flags: [:],
-                isInternalRootExampleGroup: true
-            )
+			let group: ExampleGroup
+
+			if let x = specClass as? ResultBuilderQuickSpec.Type {
+				group = x.createSpecPart()
+			} else {
+				group = ExampleGroup(
+					description: "root example group",
+					flags: [:],
+					isInternalRootExampleGroup: true
+				)
+			}
+
             specs[name] = group
             return group
         }
@@ -171,6 +178,7 @@ final internal class World: _WorldBase {
     internal func examples(forSpecClass specClass: QuickSpec.Type) -> [Example] {
         // 1. Grab all included examples.
         let included = includedExamples
+		
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.
         let spec = rootExampleGroup(forSpecClass: specClass).examples.filter { included.contains($0) }
         // 3. Remove all excluded examples.

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -152,7 +152,7 @@ final internal class World: _WorldBase {
 			let group: ExampleGroup
 
 			if let x = specClass as? ResultBuilderQuickSpec.Type {
-				group = x.createSpecPart()
+				group = x.spec().rootGroup
 			} else {
 				group = ExampleGroup(
 					description: "root example group",

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ResultBuilderTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ResultBuilderTests.swift
@@ -1,0 +1,93 @@
+//
+//  ResultBuilderTests.swift
+//  Quick
+//
+//  Created by Alex on 2022-04-25.
+//  Copyright © 2022 Brian Ivan Gesiak. All rights reserved.
+//
+
+import Nimble
+@testable import Quick
+import XCTest
+
+
+private enum BeforeEachType: String, CustomStringConvertible {
+	case outerOne
+	case outerTwo
+	case innerOne
+	case innerTwo
+	case innerThree
+	case noExamples
+
+	var description: String { self.rawValue }
+}
+
+private var beforeEachOrder = [BeforeEachType]()
+
+func build(@SpecBuilder builder: () -> SpecPart) -> ExampleGroup {
+	let rootGroup = ExampleGroup(
+		description: "root example group",
+		flags: [:],
+		isInternalRootExampleGroup: true
+	)
+
+	rootGroup.append(specPart: builder())
+
+	return rootGroup
+}
+
+class FunctionalTests_ResultBuilderBeforeEachSpec: ResultBuilderQuickSpec {
+	override class func createSpecPart() -> ExampleGroup {
+		build {
+			describe_builder("beforeEach ordering") {
+				print("hook evaluated")
+				beforeEachOrder.append(.outerOne)
+				beforeEachOrder.append(.outerTwo)
+
+				it_builder("executes the outer beforeEach closures once [1]") {
+					print("foo 1")
+				}
+				it_builder("executes the outer beforeEach closures a second time [2]") {
+					print("foo 2")
+				}
+				context_builder("when there are nested beforeEach") {
+					beforeEachOrder.append(.innerOne)
+					beforeEachOrder.append(.innerTwo)
+					beforeEachOrder.append(.innerThree)
+
+					it_builder("executes the outer and inner beforeEach closures [3]") {
+						print("foo 3")
+					}
+				}
+
+				context_builder("when there are nested beforeEach without examples") {
+					beforeEach { beforeEachOrder.append(.noExamples) }
+				}
+			}
+		}
+	}
+}
+
+final class ResultBuilderBeforeEachTests: XCTestCase, XCTestCaseProvider {
+	static var allTests: [(String, (ResultBuilderBeforeEachTests) -> () throws -> Void)] {
+		return [
+			("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
+		]
+	}
+
+	func testBeforeEachIsExecutedInTheCorrectOrder() {
+		beforeEachOrder = []
+
+		qck_runSpec(FunctionalTests_ResultBuilderBeforeEachSpec.self)
+		let expectedOrder: [BeforeEachType] = [
+			// [1] The outer beforeEach closures are executed from top to bottom.
+			.outerOne, .outerTwo,
+			// [2] The outer beforeEach closures are executed from top to bottom.
+			.outerOne, .outerTwo,
+			// [3] The outer beforeEach closures are executed from top to bottom,
+			//     then the inner beforeEach closures are executed from top to bottom.
+			.outerOne, .outerTwo, .innerOne, .innerTwo, .innerThree,
+		]
+		XCTAssertEqual(beforeEachOrder, expectedOrder)
+	}
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ResultBuilderTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ResultBuilderTests.swift
@@ -24,21 +24,9 @@ private enum BeforeEachType: String, CustomStringConvertible {
 
 private var beforeEachOrder = [BeforeEachType]()
 
-func build(@SpecBuilder builder: () -> SpecPart) -> ExampleGroup {
-	let rootGroup = ExampleGroup(
-		description: "root example group",
-		flags: [:],
-		isInternalRootExampleGroup: true
-	)
-
-	rootGroup.append(specPart: builder())
-
-	return rootGroup
-}
-
 class FunctionalTests_ResultBuilderBeforeEachSpec: ResultBuilderQuickSpec {
-	override class func createSpecPart() -> ExampleGroup {
-		build {
+	override class func spec() -> Spec {
+		Spec {
 			describe_builder("beforeEach ordering") {
 				print("hook evaluated")
 				beforeEachOrder.append(.outerOne)


### PR DESCRIPTION
This pr is a really rough POC that uses Swift's new [Result Builders](https://docs.swift.org/swift-book/ReferenceManual/Attributes.html#ID633).

I've found that setup code often needs to use fresh objects for each examples, which requires using `beforeEach`. But to access any of the values initialized in `beforeEach`, they need to be declared in the parent scope, and they must be optional, which is a nuance:

```swift
override func spec() {
    describe("The issue with beforeEach") {
        let aValueINeedForMyTest = thisIsOnlyCalledOnce()

        let iWantAFreshValueForEveryTest: THenItHasToBeOptional!

        beforeEach {
            iWantAFreshValueForEveryTest = thisIsWhereYouNeedToReinitializeIt()
        }
        
        it("uses the values") {
            use(aValueINeedForMyTest)
            use(iWantAFreshValueForEveryTest)
        }

        it("should get a fresh value") {
            use(iWantAFreshValueForEveryTest)
        }
    }
}
```

This new Result Builder based DSL lets you express the same thing using:

```swift
override class func spec() -> Spec {
    Spec {
        describe("The issue with beforeEach") {
            let aValueINeedForMyTest = thisIsCalledTwiceNow() // This is called twice now
            let iWantAFreshValueForEveryTest = lookMaNoOptionals()
            
            it("uses the values") {
                use(aValueINeedForMyTest)
                use(iWantAFreshValueForEveryTest)
            }

            it("should get a fresh value") {
                use(iWantAFreshValueForEveryTest)
            }
        }
    }
}
```

There's a trade-off here: now all code inside the spec acts as if it were in a `beforeEach`, meaning it's not currently possible to nest something inside the Spec and only have it called once. Arguably, such things should be lifted to stored properties above the `spec()` func, anyway.

What do you guys think?

Related: #908