### PR TITLE
Fix sporadic crashes caused by finding classes that don't play well with isSubclass(of:)

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -131,6 +131,12 @@
 		8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
+		89D2C671284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
+		89D2C672284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
+		89D2C673284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
+		89D2C675284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
+		89D2C676284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
+		89D2C677284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
 		8D010A571C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A581C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
 		8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D010A561C11726F00633E2B /* DescribeTests.swift */; };
@@ -377,6 +383,8 @@
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SelectedTests+ObjC.m"; sourceTree = "<group>"; };
+		89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetectionSpec.swift; sourceTree = "<group>"; };
+		89D2C674284DA77D004B108C /* SubclassDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetection.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrossReferencingSpecs.swift; sourceTree = "<group>"; };
 		CD1F6502226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestObservationCenter+QCKSuspendObservation.swift"; sourceTree = "<group>"; };
@@ -695,6 +703,7 @@
 				DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */,
 				DA8F91AA19F3299E006F6675 /* SharedExamplesTests.swift */,
 				DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */,
+				89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */,
 				7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */,
 				AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */,
 				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
@@ -796,6 +805,7 @@
 				CD3451461E4703D4000C8633 /* QuickMain.swift */,
 				CD3451471E4703D4000C8633 /* QuickSpec.swift */,
 				CD21A025247C1385002C4762 /* QuickTestObservation.swift */,
+				89D2C674284DA77D004B108C /* SubclassDetection.swift */,
 				34F375A619515CA700CE1B99 /* World.swift */,
 				34F3759E19515CA700CE1B99 /* Example.swift */,
 				DA02C91819A8073100093156 /* ExampleMetadata.swift */,
@@ -1344,6 +1354,7 @@
 				34C5860A1C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				1F118D041BDCA536005013A2 /* Example.swift in Sources */,
 				1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */,
+				89D2C677284DA77D004B108C /* SubclassDetection.swift in Sources */,
 				DED3036D1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				CE590E211C431FE400253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				1F118D071BDCA536005013A2 /* Callsite.swift in Sources */,
@@ -1397,6 +1408,7 @@
 				8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D712264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
+				89D2C673284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
 				CD582D772264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */,
@@ -1435,6 +1447,7 @@
 				DA408BE719FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				34F375BA19515CA700CE1B99 /* QuickSpec.m in Sources */,
 				DED3036C1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
+				89D2C676284DA77D004B108C /* SubclassDetection.swift in Sources */,
 				CE590E1C1C431FE300253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				DAE7150119FF6A62005905B8 /* QuickConfiguration.m in Sources */,
 				CE590E1E1C431FE300253D19 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1488,6 +1501,7 @@
 				8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D702264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
+				89D2C672284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D752264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586031C4ABD4000D4F057 /* XCTestCaseProvider.swift in Sources */,
@@ -1574,6 +1588,7 @@
 				CE57CEDF1C430BD200D63004 /* QuickTestSuite.swift in Sources */,
 				34C586081C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				DED3036B1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
+				89D2C675284DA77D004B108C /* SubclassDetection.swift in Sources */,
 				DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				34F375B919515CA700CE1B99 /* QuickSpec.m in Sources */,
 				CE57CEE11C430BD200D63004 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1627,6 +1642,7 @@
 				8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */,
 				CD582D6F2264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
+				89D2C671284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D732264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586011C4ABD3F00D4F057 /* XCTestCaseProvider.swift in Sources */,

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -23,7 +23,7 @@ extension QuickConfiguration {
         #if canImport(Darwin)
         // See https://developer.apple.com/forums/thread/700770.
         var classesCount: UInt32 = 0
-        let classList = objc_copyClassList(&classesCount)
+        guard let classList = objc_copyClassList(&classesCount) else { return }
         defer { free(UnsafeMutableRawPointer(classList)) }
         let classes = UnsafeBufferPointer(start: classList, count: Int(classesCount))
 

--- a/Sources/Quick/Configuration/QuickConfiguration.swift
+++ b/Sources/Quick/Configuration/QuickConfiguration.swift
@@ -10,9 +10,7 @@ open class QuickConfiguration: NSObject {
 #endif
 
 extension QuickConfiguration {
-    #if !canImport(Darwin)
     private static var configurationSubclasses: [QuickConfiguration.Type] = []
-    #endif
 
     #if canImport(Darwin)
     @objc
@@ -35,11 +33,10 @@ extension QuickConfiguration {
 
         // Perform all configurations (ensures that shared examples have been discovered)
         world.configure { configuration in
-            #if canImport(Darwin)
-            enumerateSubclasses { (configurationClass: QuickConfiguration.Type) in
+            (allSubclasses(ofType: QuickConfiguration.self) + configurationSubclasses)
+                .forEach { (configurationClass: QuickConfiguration.Type) in
                 configurationClass.configure(configuration)
             }
-            #endif
         }
         world.finalizeConfiguration()
     }

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -27,46 +27,10 @@ import XCTest
         guard !didBuildAllExamples else { return }
         didBuildAllExamples = true
 
-        QuickSpec.enumerateSubclasses { specClass in
+        enumerateSubclasses { (specClass: QuickSpec.Type) in
             // This relies on `_QuickSpecInternal`.
             (specClass as AnyClass).buildExamplesIfNeeded()
         }
-    }
-}
-
-// swiftlint:disable:next todo
-// TODO: Unify this with QuickConfiguration's equivalent
-extension QuickSpec {
-    internal static func enumerateSubclasses(
-        subclasses: [QuickSpec.Type]? = nil,
-        _ block: (QuickSpec.Type) -> Void
-    ) {
-        let subjects: [QuickSpec.Type]
-        if let subclasses = subclasses {
-            subjects = subclasses
-        } else {
-            // See https://developer.apple.com/forums/thread/700770.
-            var classesCount: UInt32 = 0
-            guard let classList = objc_copyClassList(&classesCount) else { return }
-            defer { free(UnsafeMutableRawPointer(classList)) }
-            let classes = UnsafeBufferPointer(start: classList, count: Int(classesCount))
-
-            guard classesCount > 0 else { return }
-
-            var specSubclasses: [QuickSpec.Type] = []
-            for subclass in classes {
-                guard
-                    isClass(subclass, aSubclassOf: QuickSpec.self)
-                    else { continue }
-
-                // swiftlint:disable:next force_cast
-                specSubclasses.append(subclass as! QuickSpec.Type)
-            }
-
-            subjects = specSubclasses
-        }
-
-        subjects.forEach(block)
     }
 }
 

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -27,10 +27,11 @@ import XCTest
         guard !didBuildAllExamples else { return }
         didBuildAllExamples = true
 
-        enumerateSubclasses { (specClass: QuickSpec.Type) in
-            // This relies on `_QuickSpecInternal`.
-            (specClass as AnyClass).buildExamplesIfNeeded()
-        }
+        allSubclasses(ofType: QuickSpec.self)
+            .forEach { (specClass: QuickSpec.Type) in
+                // This relies on `_QuickSpecInternal`.
+                (specClass as AnyClass).buildExamplesIfNeeded()
+            }
     }
 }
 

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -47,7 +47,7 @@ extension QuickSpec {
         } else {
             // See https://developer.apple.com/forums/thread/700770.
             var classesCount: UInt32 = 0
-            let classList = objc_copyClassList(&classesCount)
+            guard let classList = objc_copyClassList(&classesCount) else { return }
             defer { free(UnsafeMutableRawPointer(classList)) }
             let classes = UnsafeBufferPointer(start: classList, count: Int(classesCount))
 

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -45,24 +45,18 @@ extension QuickSpec {
         if let subclasses = subclasses {
             subjects = subclasses
         } else {
-            let classesCount = objc_getClassList(nil, 0)
+            // See https://developer.apple.com/forums/thread/700770.
+            var classesCount: UInt32 = 0
+            let classList = objc_copyClassList(&classesCount)
+            defer { free(UnsafeMutableRawPointer(classList)) }
+            let classes = UnsafeBufferPointer(start: classList, count: Int(classesCount))
 
-            guard classesCount > 0 else {
-                return
-            }
-
-            let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(classesCount))
-            defer { free(classes) }
-
-            let autoreleasingClasses = AutoreleasingUnsafeMutablePointer<AnyClass>(classes)
-            objc_getClassList(autoreleasingClasses, classesCount)
+            guard classesCount > 0 else { return }
 
             var specSubclasses: [QuickSpec.Type] = []
-            for index in 0..<classesCount {
+            for subclass in classes {
                 guard
-                    let subclass = classes[Int(index)],
-                    let superclass = class_getSuperclass(subclass),
-                    superclass.isSubclass(of: QuickSpec.self)
+                    isClass(subclass, aSubclassOf: QuickSpec.self)
                     else { continue }
 
                 // swiftlint:disable:next force_cast

--- a/Sources/Quick/SubclassDetection.swift
+++ b/Sources/Quick/SubclassDetection.swift
@@ -1,3 +1,5 @@
+#if canImport(Darwin)
+
 import Foundation
 
 /// Determines if a class is a subclass of another by looping over the superclasses of the given class.
@@ -12,3 +14,5 @@ func isClass(_ klass: AnyClass, aSubclassOf targetClass: AnyClass) -> Bool {
     }
     return false
 }
+
+#endif

--- a/Sources/Quick/SubclassDetection.swift
+++ b/Sources/Quick/SubclassDetection.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Determines if a class is a subclass of another by looping over the superclasses of the given class.
+/// Apparently, `isSubclass(of:)` uses a different method to check this, which can cause exceptions to
+/// be raised under certain circumstances when used in conjuction with `objc_getClassList`.
+/// See https://github.com/Quick/Quick/issues/1155, and https://openradar.appspot.com/FB9854851.
+func isClass(_ klass: AnyClass, aSubclassOf targetClass: AnyClass) -> Bool {
+    var superclass: AnyClass? = klass
+    while superclass != nil {
+        superclass = class_getSuperclass(superclass)
+        if superclass == targetClass { return true }
+    }
+    return false
+}

--- a/Sources/Quick/SubclassDetection.swift
+++ b/Sources/Quick/SubclassDetection.swift
@@ -15,4 +15,33 @@ func isClass(_ klass: AnyClass, aSubclassOf targetClass: AnyClass) -> Bool {
     return false
 }
 
+/// Retrieves the current list of all known classes that are a subtype of the desired type.
+/// This uses `objc_copyClassList` instead of `objc_getClassList` because the get function
+/// is subject to race conditions and buffer overflow issues. The copy function handles all of that for us.
+private func allSubclasses<T: AnyObject>(ofType targetType: T.Type) -> [T.Type] {
+    // See https://developer.apple.com/forums/thread/700770.
+    var classesCount: UInt32 = 0
+    guard let classList = objc_copyClassList(&classesCount) else { return [] }
+    defer { free(UnsafeMutableRawPointer(classList)) }
+    let classes = UnsafeBufferPointer(start: classList, count: Int(classesCount))
+
+    guard classesCount > 0 else {
+        return []
+    }
+
+    return classes.filter { isClass($0, aSubclassOf: targetType) }
+        .compactMap { $0 as? T.Type }
+}
+
+/// Detects all subclasses of the given type, and calls the given block with each of them.
+/// The classes are iterated over in the order that `objc_copyClassList` returns them.
+///
+/// - parameter givenSubclasses: A list of given subclasses. If non-nil, these will be iterated over instead of the given subclasses.
+/// - parameter block: A block that takes the given type.
+///                    This block will be executed once for each subclass of that type.
+func enumerateSubclasses<T: AnyObject>(givenSubclasses: [T.Type]? = nil, _ block: (T.Type) -> Void) {
+    (givenSubclasses ?? allSubclasses(ofType: T.self))
+        .forEach(block)
+}
+
 #endif

--- a/Sources/Quick/SubclassDetection.swift
+++ b/Sources/Quick/SubclassDetection.swift
@@ -14,11 +14,14 @@ func isClass(_ klass: AnyClass, aSubclassOf targetClass: AnyClass) -> Bool {
     }
     return false
 }
+#endif
 
 /// Retrieves the current list of all known classes that are a subtype of the desired type.
 /// This uses `objc_copyClassList` instead of `objc_getClassList` because the get function
 /// is subject to race conditions and buffer overflow issues. The copy function handles all of that for us.
-private func allSubclasses<T: AnyObject>(ofType targetType: T.Type) -> [T.Type] {
+/// Note: On non-Apple platforms, this will return an empty array.
+func allSubclasses<T: AnyObject>(ofType targetType: T.Type) -> [T.Type] {
+    #if canImport(Darwin)
     // See https://developer.apple.com/forums/thread/700770.
     var classesCount: UInt32 = 0
     guard let classList = objc_copyClassList(&classesCount) else { return [] }
@@ -30,18 +33,9 @@ private func allSubclasses<T: AnyObject>(ofType targetType: T.Type) -> [T.Type] 
     }
 
     return classes.filter { isClass($0, aSubclassOf: targetType) }
-        .compactMap { $0 as? T.Type }
+        // swiftlint:disable:next force_cast
+        .map { $0 as! T.Type }
+    #else
+    return []
+    #endif
 }
-
-/// Detects all subclasses of the given type, and calls the given block with each of them.
-/// The classes are iterated over in the order that `objc_copyClassList` returns them.
-///
-/// - parameter givenSubclasses: A list of given subclasses. If non-nil, these will be iterated over instead of the given subclasses.
-/// - parameter block: A block that takes the given type.
-///                    This block will be executed once for each subclass of that type.
-func enumerateSubclasses<T: AnyObject>(givenSubclasses: [T.Type]? = nil, _ block: (T.Type) -> Void) {
-    (givenSubclasses ?? allSubclasses(ofType: T.self))
-        .forEach(block)
-}
-
-#endif

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
@@ -1,0 +1,25 @@
+@testable import Quick
+import Nimble
+
+private class A {}
+private class B: A {}
+private class C: B {}
+private class D {}
+
+final class SubclassDetectionSpec: QuickSpec {
+    override func spec() {
+        it("detects when a class is an immediate subclass of another") {
+            expect(isClass(B.self, aSubclassOf: A.self)).to(beTrue())
+        }
+
+        it("detects when a class is an indirect subclass of another") {
+            expect(isClass(C.self, aSubclassOf: A.self)).to(beTrue())
+        }
+
+        it("returns false when a class is not at all related to the superclass") {
+            expect(isClass(D.self, aSubclassOf: A.self)).to(beFalse())
+            expect(isClass(D.self, aSubclassOf: B.self)).to(beFalse())
+            expect(isClass(D.self, aSubclassOf: C.self)).to(beFalse())
+        }
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
@@ -1,3 +1,5 @@
+#if canImport(Darwin)
+
 @testable import Quick
 import Nimble
 
@@ -23,3 +25,5 @@ final class SubclassDetectionSpec: QuickSpec {
         }
     }
 }
+
+#endif

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
@@ -10,18 +10,29 @@ private class D {}
 
 final class SubclassDetectionSpec: QuickSpec {
     override func spec() {
-        it("detects when a class is an immediate subclass of another") {
-            expect(isClass(B.self, aSubclassOf: A.self)).to(beTrue())
+        describe("detecting if a given class is a subclass of another") {
+            it("detects when a class is an immediate subclass of another") {
+                expect(isClass(B.self, aSubclassOf: A.self)).to(beTrue())
+            }
+
+            it("detects when a class is an indirect subclass of another") {
+                expect(isClass(C.self, aSubclassOf: A.self)).to(beTrue())
+            }
+
+            it("returns false when a class is not at all related to the superclass") {
+                expect(isClass(D.self, aSubclassOf: A.self)).to(beFalse())
+                expect(isClass(D.self, aSubclassOf: B.self)).to(beFalse())
+                expect(isClass(D.self, aSubclassOf: C.self)).to(beFalse())
+            }
         }
 
-        it("detects when a class is an indirect subclass of another") {
-            expect(isClass(C.self, aSubclassOf: A.self)).to(beTrue())
-        }
-
-        it("returns false when a class is not at all related to the superclass") {
-            expect(isClass(D.self, aSubclassOf: A.self)).to(beFalse())
-            expect(isClass(D.self, aSubclassOf: B.self)).to(beFalse())
-            expect(isClass(D.self, aSubclassOf: C.self)).to(beFalse())
+        describe("finding all subclasses of a given type") {
+            it("finds only subclasses, but not the actual class, of the desired type") {
+                let foundSubclasses: [A.Type] = allSubclasses(ofType: A.self)
+                expect(foundSubclasses).to(haveCount(2))
+                expect(foundSubclasses.first).to(be(B.self) || be(C.self))
+                expect(foundSubclasses.last).to(be(B.self) || be(C.self))
+            }
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
@@ -62,7 +62,7 @@ func qck_runSpecs(_ specClasses: [QuickSpec.Type]) -> XCTestRun? {
 
         #if !SWIFT_PACKAGE
         // Gather examples first
-        QuickSpec.enumerateSubclasses(subclasses: specClasses) { specClass in
+        enumerateSubclasses(givenSubclasses: specClasses) { specClass in
             // This relies on `_QuickSpecInternal`.
             (specClass as AnyClass).buildExamplesIfNeeded()
         }

--- a/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/QuickSpecRunner.swift
@@ -62,7 +62,7 @@ func qck_runSpecs(_ specClasses: [QuickSpec.Type]) -> XCTestRun? {
 
         #if !SWIFT_PACKAGE
         // Gather examples first
-        enumerateSubclasses(givenSubclasses: specClasses) { specClass in
+        specClasses.forEach { specClass in
             // This relies on `_QuickSpecInternal`.
             (specClass as AnyClass).buildExamplesIfNeeded()
         }


### PR DESCRIPTION
Also grabs the list of objc classes in a much more thread-safe way.

Fixes #1155

---

This changes how we determine if a given class is a subclass of QuickSpec or QuickConfiguration. This is likely slower than using `isSubclass(of:)`. However, according to the radar @tiarnann filed, this should eliminate the sporadic crashes in subclass detection that keep coming up. So that's definitely worth fixing the issue.

Additionally, this replaces usage of `objc_getClassList` with `objc_copyClassList`. Apparently the get method has potential race conditions that can cause crashes, while the copy method does not.