### PR TITLE
Fix tests broken by Nimble 10 update

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -17,7 +17,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v4.0.0
         with:
-          paths: '[".github/workflows/ci-swiftpm.yml", "Sources/**", "Tests/**", "Package.*"]'
+          paths: '[".github/workflows/ci-swiftpm.yml", "Sources/**", "Tests/**", "Package.*", "Externals"]'
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 
   swiftpm_darwin:

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -17,7 +17,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v4.0.0
         with:
-          paths: '[".github/workflows/ci-xcode.yml", "Externals", "Quick.xc*", "Sources/**", "Tests/**", "Rakefile"]'
+          paths: '[".github/workflows/ci-xcode.yml", "Externals", "Quick.xc*", "Sources/**", "Tests/**", "Rakefile", "Externals"]'
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 
   xcode:

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -60,7 +60,7 @@ class QuickSpec_SelectedTests: XCTestCase {
 
         let suite = XCTestSuite(forTestCaseWithName: "SimulateSelectedTests_TestCase/example1")
         expect(suite.tests).to(haveCount(1))
-        expect(suite.tests).to(allPass { $0?.name.contains("example1") == true })
+        expect(suite.tests).to(allPass { $0.name.contains("example1") == true })
     }
 }
 


### PR DESCRIPTION
The Sequence assertion API was changed (simplified) in the Nimble v9 -> v10 update. This updates the test we had that used it and was broken by it.

This PR also updates the github workflows to ensure that tests run when we update the Nimble submodule in a PR. So that we don't do this again.