### PR TITLE
Allow throwing in a test without producing an unexpected error

### DIFF
--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -10,6 +10,11 @@ public class _ExampleBase: NSObject {}
 // swiftlint:enable type_name
 #endif
 
+public enum QuickError: Error {
+    case stopSilently
+    case stop(_ description: String, file: FileString = #file, line: UInt = #line)
+}
+
 /**
     Examples, defined with the `it` function, use assertions to
     demonstrate how code should behave. These are like "tests" in XCTest.
@@ -83,7 +88,12 @@ final public class Example: _ExampleBase {
             do {
                 try closure()
             } catch {
-                if let testSkippedError = error as? XCTSkip {
+                if case QuickError.stopSilently = error {
+                    // Do nothing.
+                } else if case QuickError.stop(let description, let file, let line) = error {
+                    let errorCallsite = Callsite(file: file, line: line)
+                    self.reportStoppedTest(description, callsite: errorCallsite)
+                } else if let testSkippedError = error as? XCTSkip {
                     self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
                 } else {
                     self.reportFailedTest(error, name: name, callsite: callsite)
@@ -217,6 +227,33 @@ final public class Example: _ExampleBase {
                 inFile: file,
                 atLine: Int(callsite.line),
                 expected: false
+            )
+        #endif
+    }
+    
+    private func reportStoppedTest(_ description: String, callsite: Callsite) {
+
+        #if SWIFT_PACKAGE
+            let file = callsite.file.description
+        #else
+            let file = callsite.file
+        #endif
+
+        #if !SWIFT_PACKAGE
+            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
+            let sourceCodeContext = XCTSourceCodeContext(location: location)
+            let issue = XCTIssue(
+                type: .assertionFailure,
+                compactDescription: description,
+                sourceCodeContext: sourceCodeContext
+            )
+            QuickSpec.current.record(issue)
+        #else
+            QuickSpec.current.recordFailure(
+                withDescription: description,
+                inFile: file,
+                atLine: Int(callsite.line),
+                expected: true
             )
         #endif
     }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -140,12 +140,25 @@ final class FunctionalTests_SkippingTestsSpec: QuickSpec {
     }
 }
 
+final class FunctionalTests_StoppingTestsSpec: QuickSpec {
+    override func spec() {
+        it("supports silently stopping tests") { throw QuickError.stopSilently }
+        it("supports stopping tests with expected errors") {
+            if isRunningFunctionalTests {
+                throw QuickError.stop("Test stopped due to expected error")
+            }
+        }
+        it("supports not stopping tests") { }
+    }
+}
+
 final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [
             ("testAllExamplesAreExecuted", testAllExamplesAreExecuted),
             ("testImplicitErrorHandling", testImplicitErrorHandling),
             ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
+            ("testStoppingExamplesAreCorrectlyReported", testStoppingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -187,5 +200,14 @@ final class ItTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(result.executionCount, 2)
         XCTAssertEqual(result.skipCount, 1)
         XCTAssertEqual(result.totalFailureCount, 0)
+    }
+    
+    func testStoppingExamplesAreCorrectlyReported() {
+        let result = qck_runSpec(FunctionalTests_StoppingTestsSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 3)
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.unexpectedExceptionCount, 0)
+        XCTAssertEqual(result.totalFailureCount, 1)
     }
 }


### PR DESCRIPTION
# Problem statement

Often times in testing, I have assertions that render the rest of the test moot or dangerous.

For example:

```
it("creates three good objects") {
    expect(array).to(haveCount(3))
    expect(array[0]).to(lookLikeBaz())
    expect(array[1]).to(lookLikeBaz())
    expect(array[2]).to(lookLikeBaz())
}
```

This test will crash if `array` has a count less than 3, because it accesses elements that are out of range.

A workaround is something like the following, but these require boilerplate that either repeats the test logic or loses the error message.

```
it("creates three good objects") {
    expect(array).to(haveCount(3))
    guard array.count == 3 else { return }
    expect(array[0]).to(lookLikeBaz())
    expect(array[1]).to(lookLikeBaz())
    expect(array[2]).to(lookLikeBaz())
}

it("creates three good objects") {
    guard array.count == 3 else {
        XCTFail("Count was off, expected 3, got \(array.count)")
        return
    }
    expect(array[0]).to(lookLikeBaz())
    expect(array[1]).to(lookLikeBaz())
    expect(array[2]).to(lookLikeBaz())
}
```

What I typically end up doing is writing custom test assertions that throw on failure, which minimizes boilerplate in the test and prevents crashing:

```
it("creates three good objects") {
    try assertThat(array, hasCount: 3)
    expect(array[0]).to(lookLikeBaz())
    expect(array[1]).to(lookLikeBaz())
    expect(array[2]).to(lookLikeBaz())
}
```

_Unfortunately_, as Quick functions today, this test fails with an error message on the `it` line, records it as an unexpected failure, and includes a bunch of details about the error.

A workaround I use locally is a custom subclass of Spec that silences expected errors:

```
class MySpec: QuickSpec {
    override func record(_ issue: XCTIssue) {
        if issue.compactDescription.contains("MY_SPEC_RECORDED") { return }
        super.record(issue)
    }
}

func TestFailure(_ message: String, file: StaticString = #file, line: UInt = #line) -> NSError {
    if let spec = QuickSpec.current as? HeapSpec {
        let location = XCTSourceCodeLocation(filePath: file, lineNumber: line)
        let issue = XCTIssue(type: .assertionFailure, compactDescription: message, sourceCodeContext: XCTSourceCodeContext(location: location))
        spec.record(issue)
        return NSError(domain: "bnickel.TestFailure", code: 1, userInfo: [NSLocalizedDescriptionKey: "MY_SPEC_RECORDED: " + message])
    } else {
        return NSError(domain: "bnickel.TestFailure", code: 2, userInfo: [NSLocalizedDescriptionKey: message])
    }
}

func TestEnded() -> NSError {
    if QuickSpec.current is HeapSpec {
        return NSError(domain: "bnickel.TestEnded", code: 1, userInfo: [NSLocalizedDescriptionKey: "MY_SPEC_RECORDED"])
    } else {
        return NSError(domain: "bnickel.TestEnded", code: 2, userInfo: [:])
    }
}
```

These functions allow me to stop a test with an error message using `throw TestFailure("Something broke in a big way")`, or if I know errors have already been logged by another function, stop the test silently with `TestEnded()`

# Solution

This PR takes my strategy of having test stopping functions and bakes them into Quick so they produce appropriate error messaging.

For example:

```
func assertWorldExists(file: FileString = #file, line: UInt = #line) throws -> World {
    guard let world = world else { throw QuickError.stop("The world has ended", file: file, line: line) }
    return world
}

extension World {
    func expectToBeValid() -> Bool {
        // Log a bunch of errors
    }

    func assertValid() throws {
        guard self.expectToBeValid() else { throw QuickError.stopSilently }
    }
}

it("has a valid world") {
    let world = try assertWorldExists()
    world.expectToBeValid()
    // additional conditions on world that don't require it to be valid
}

it("can do something with a valid world") {
    let world = try assertWorldExists()
    try world.assertValid()
    // additional conditions that require world to be valid
}
```

Generally speaking, `QuickError.stop` would be appropriate for most tests, but `QuickError.stopSilently` is useful for cases where you already have a function logging a bunch of issues.

Checklist - While not every PR needs it, new features should consider this list:

 - [X] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [X] Is this a new feature (Requires minor version bump)?

