### PR TITLE
Introduce an `assignBefore` operator

### DIFF
--- a/Documentation/en-us/QuickExamplesAndGroups.md
+++ b/Documentation/en-us/QuickExamplesAndGroups.md
@@ -221,10 +221,6 @@ In some cases you will want to have a group of tests with a common test setup bu
 ```swift
 // Swift
 
-enum ClickError: Error {
-  case dolphinIsSleeping
-}
-
 describe("a sleeping dolphin") {
     var sleeping: Bool!
     var click: Click!

--- a/Documentation/en-us/QuickExamplesAndGroups.md
+++ b/Documentation/en-us/QuickExamplesAndGroups.md
@@ -214,6 +214,49 @@ of typing!
 
 To execute code *after* each example, use `afterEach`.
 
+### Sharing Setup/Teardown Code Using `justBeforeEach`
+
+In some cases you will want to have a group of tests with a common test setup but different configuration of that setup code in the individual tests. This makes the most sense when you have an API that you are mocking, and logic on top of that API that will make different decisions based on the result.
+
+```swift
+// Swift
+
+enum ClickError: Error {
+  case dolphinIsSleeping
+}
+
+describe("a sleeping dolphin") {
+    var sleeping: Bool!
+    var click: Click!
+
+    justBeforeEach {
+        dolphin = Dolphin(sleeping: sleeping)
+        click = dolphin.click()
+    }
+
+    context("not sleeping") {
+        beforeEach {
+            sleeping = false
+        }
+
+        it("then it makes clicks that are loud") {
+            expect(click.isLoud).to(beTrue())
+        }
+    }
+
+    context("sleeping") {
+        beforeEach {
+            sleeping = true
+        }
+
+        it("then it does not make clicks that are loud") {
+            expect(click.isLoud).to(beFalse())
+        }
+    }
+}
+```
+In this example, a sleeping dolphin will not make Clicks. We wish to build our tests so that we only construct one Dolphin object, and only invoke the `.click()` method once. This requires the use of `justBeforeEach`, which invokes our constructor and method after the two `beforeEach` blocks have been invoked. Without `justBeforeEach`, we would have to trigger the API call twice in our tests, with a different argument each time. For tests that have a lot of boilerplate or setup required, this can significantly reduce lines of code and complexity.
+
 ### Specifying Conditional Behavior Using `context`
 
 Dolphins use clicks for echolocation. When they approach something
@@ -299,7 +342,7 @@ describe(@"a dolphin", ^{
 QuickSpecEnd
 ```
 
-Strictly speaking, the `context` keyword is a synonym for `describe`, 
+Strictly speaking, the `context` keyword is a synonym for `describe`,
 but thoughtful use will make your spec easier to understand.
 
 ### Test Readability: Quick and XCTest

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -108,6 +108,9 @@
 		47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
 		5A5D118719473F2100F6D13D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61E9B99628C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
+		61E9B99728C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
+		61E9B99828C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
 		64076CEF1D6D7C2000E2B499 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAEB6B8E1943873100289F44 /* Quick.framework */; };
 		64076CF01D6D7C2000E2B499 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8100E901A1E4447007595ED /* Nimble.framework */; };
 		64076D021D6D7CD600E2B499 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
@@ -377,6 +380,7 @@
 		47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BeforeEachTests+ObjC.m"; sourceTree = "<group>"; };
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick - iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick - iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustBeforeEachTests.swift; sourceTree = "<group>"; };
 		64076CF51D6D7C2000E2B499 /* QuickAfterSuite - macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64076D081D6D7CD600E2B499 /* QuickAfterSuite - iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64076D1A1D6D7CEA00E2B499 /* QuickAfterSuite - tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -698,24 +702,25 @@
 		DA8F919B19F3189D006F6675 /* FunctionalTests */ = {
 			isa = PBXGroup;
 			children = (
-				DAE714E919FF65A6005905B8 /* Configuration */,
-				CDB2AA5E1D6C84CF005600C3 /* ObjC */,
-				DA7AE6F019FC493F000AFDCE /* ItTests.swift */,
-				8D010A561C11726F00633E2B /* DescribeTests.swift */,
-				DA87078219F48775008C04AC /* BeforeEachTests.swift */,
 				DA05D60F19F73A3800771050 /* AfterEachTests.swift */,
 				DA3E1685243F8C23001F7CCA /* AroundEachTests.swift */,
-				DAA63EA219F7637300CD0A3B /* PendingTests.swift */,
+				DA87078219F48775008C04AC /* BeforeEachTests.swift */,
 				DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */,
-				DA8F91AA19F3299E006F6675 /* SharedExamplesTests.swift */,
-				DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */,
-				89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */,
+				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
+				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
+				DAE714E919FF65A6005905B8 /* Configuration */,
 				7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */,
 				AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */,
-				DED3037C1DF6CF140041394E /* BundleModuleNameTests.swift */,
-				CE4A57891EA5DC270063C0D4 /* BehaviorTests.swift */,
 				DA5CBB471EAFA55800297C9E /* CurrentSpecTests.swift */,
+				8D010A561C11726F00633E2B /* DescribeTests.swift */,
+				DA7AE6F019FC493F000AFDCE /* ItTests.swift */,
+				61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */,
+				CDB2AA5E1D6C84CF005600C3 /* ObjC */,
+				DAA63EA219F7637300CD0A3B /* PendingTests.swift */,
 				79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */,
+				DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */,
+				DA8F91AA19F3299E006F6675 /* SharedExamplesTests.swift */,
+				89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1429,6 +1434,7 @@
 				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
 				DA5CBB4B1EAFA61D00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */,
+				61E9B99828C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1523,6 +1529,7 @@
 				47876F7E1A49AD71002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB4A1EAFA61C00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */,
+				61E9B99728C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1665,6 +1672,7 @@
 				47876F7D1A49AD63002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB491EAFA61A00297C9E /* CurrentSpecTests.swift in Sources */,
 				7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */,
+				61E9B99628C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -108,6 +108,9 @@
 		47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
 		5A5D118719473F2100F6D13D /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5D117C19473F2100F6D13D /* Quick.framework */; };
 		5A5D11A7194740E000F6D13D /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61572A8E28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */ = {isa = PBXBuildFile; fileRef = 61572A8D28E3959D00C5A80D /* JustBeforeEachTests+Objc.m */; };
+		61572A8F28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */ = {isa = PBXBuildFile; fileRef = 61572A8D28E3959D00C5A80D /* JustBeforeEachTests+Objc.m */; };
+		61572A9028E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */ = {isa = PBXBuildFile; fileRef = 61572A8D28E3959D00C5A80D /* JustBeforeEachTests+Objc.m */; };
 		61E9B99628C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
 		61E9B99728C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
 		61E9B99828C6FD0E00CA9AAC /* JustBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */; };
@@ -380,6 +383,7 @@
 		47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BeforeEachTests+ObjC.m"; sourceTree = "<group>"; };
 		5A5D117C19473F2100F6D13D /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5D118619473F2100F6D13D /* Quick - iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick - iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		61572A8D28E3959D00C5A80D /* JustBeforeEachTests+Objc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "JustBeforeEachTests+Objc.m"; sourceTree = "<group>"; };
 		61E9B99528C6FD0E00CA9AAC /* JustBeforeEachTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustBeforeEachTests.swift; sourceTree = "<group>"; };
 		64076CF51D6D7C2000E2B499 /* QuickAfterSuite - macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		64076D081D6D7CD600E2B499 /* QuickAfterSuite - iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickAfterSuite - iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -648,6 +652,7 @@
 				DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */,
 				DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */,
 				479C31E11A36156E00DA8718 /* ItTests+ObjC.m */,
+				61572A8D28E3959D00C5A80D /* JustBeforeEachTests+Objc.m */,
 				8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */,
 				4715903F1A488F3F00FBA644 /* PendingTests+ObjC.m */,
 				4748E8931A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m */,
@@ -1424,6 +1429,7 @@
 				CD582D712264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C673284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				61572A9028E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
 				CD582D772264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */,
@@ -1519,6 +1525,7 @@
 				CD582D702264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C672284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				61572A8F28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D752264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586031C4ABD4000D4F057 /* XCTestCaseProvider.swift in Sources */,
@@ -1662,6 +1669,7 @@
 				CD582D6F2264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C671284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				61572A8E28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D732264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
 				34C586011C4ABD3F00D4F057 /* XCTestCaseProvider.swift in Sources */,

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -163,6 +163,19 @@ public func aroundEach(_ closure: @escaping AroundExampleWithMetadataClosure) {
 }
 
 /**
+     Defines a closure to be run prior to each example but after any beforeEach blocks.
+     This closure is not run for pending or otherwise disabled examples.
+     An example group may contain an unlimited number of justBeforeEach. They'll be
+     run in the order they're defined, but you shouldn't rely on that behavior.
+
+    - parameter closure: The closure to be run prior to each example and after any beforeEach blocks
+*/
+
+public func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+    World.sharedWorld.justBeforeEach(closure)
+}
+
+/**
     Defines an example. Examples use assertions to demonstrate how code should
     behave. These are like "tests" in XCTest.
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -46,6 +46,13 @@ extension World {
         self.describe(description, flags: [Filter.pending: true], closure: closure)
     }
 
+    internal func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'justBeforeEach' cannot be used inside '\(currentPhase)', 'justBeforeEach' may only be used inside 'context' or 'describe'.")
+        }
+        currentExampleGroup.hooks.appendJustBeforeEach(closure)
+    }
+
     internal func beforeEach(_ closure: @escaping BeforeExampleClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -95,8 +95,13 @@ final public class Example: _ExampleBase {
             self.group!.phase = .aftersExecuting
         }
 
+        let allJustBeforeEachStatements = group!.justBeforeEachStatements + world.exampleHooks.justBeforeEachStatements
+        let justBeforeEachExample = allJustBeforeEachStatements.reduce(runExample) { closure, wrapper in
+            return { wrapper(exampleMetadata, closure) }
+        }
+
         let allWrappers = group!.wrappers + world.exampleHooks.wrappers
-        let wrappedExample = allWrappers.reduce(runExample) { closure, wrapper in
+        let wrappedExample = allWrappers.reduce(justBeforeEachExample) { closure, wrapper in
             return { wrapper(exampleMetadata, closure) }
         }
         wrappedExample()

--- a/Sources/Quick/ExampleGroup.swift
+++ b/Sources/Quick/ExampleGroup.swift
@@ -61,6 +61,14 @@ final public class ExampleGroup: NSObject {
         return aggregateFlags
     }
 
+    internal var justBeforeEachStatements: [AroundExampleWithMetadataClosure] {
+        var closures = Array(hooks.justBeforeEachStatements.reversed())
+        walkUp { group in
+            closures.append(contentsOf: group.hooks.justBeforeEachStatements.reversed())
+        }
+        return closures
+    }
+
     internal var wrappers: [AroundExampleWithMetadataClosure] {
         var closures = Array(hooks.wrappers.reversed())
         walkUp { group in

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -2,8 +2,16 @@
     A container for closures to be executed before and after each example.
 */
 final internal class ExampleHooks {
+    internal var justBeforeEachStatements: [AroundExampleWithMetadataClosure] = []
     internal var wrappers: [AroundExampleWithMetadataClosure] = []
     internal var phase: HooksPhase = .nothingExecuted
+
+    internal func appendJustBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+        justBeforeEachStatements.append { _, runExample in
+            closure()
+            runExample()
+        }
+    }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         wrappers.append { exampleMetadata, runExample in

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -65,6 +65,7 @@ QUICK_EXPORT void qck_afterEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure);
 QUICK_EXPORT void qck_aroundEach(QCKDSLAroundExampleBlock closure);
 QUICK_EXPORT void qck_aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure);
+QUICK_EXPORT void qck_justBeforeEach(QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
 QUICK_EXPORT void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
@@ -216,6 +217,18 @@ static inline void aroundEach(QCKDSLAroundExampleBlock closure) {
  */
 static inline void aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure) {
     qck_aroundEachWithMetadata(closure);
+}
+
+/**
+    Defines a closure to be run prior to each example but after any beforeEach blocks.
+    This closure is not run for pending or otherwise disabled examples.
+    An example group may contain an unlimited number of justBeforeEach. They'll be
+    run in the order they're defined, but you shouldn't rely on that behavior.
+
+    @param closure The closure to be run prior to each example but before any beforeEach blocks in the test suite.
+ */
+static inline void justBeforeEach(QCKDSLEmptyBlock closure) {
+    qck_justBeforeEach(closure);
 }
 
 /**

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -50,6 +50,10 @@ void qck_aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure) {
     [[World sharedWorld] aroundEachWithMetadata:closure];
 }
 
+void qck_justBeforeEach(QCKDSLEmptyBlock closure) {
+    [[World sharedWorld] justBeforeEach:closure];
+}
+
 QCKItBlock qck_it_builder(NSString *file, NSUInteger line) {
     return ^(NSString *description, QCKDSLEmptyBlock closure) {
         [[World sharedWorld] itWithDescription:description

--- a/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Quick
+import Nimble
+
+class FunctionalTests_AssignBeforeSpec: QuickSpec {
+
+    enum ApiResponse {
+        case Success
+        case Failure
+    }
+
+    func apiCall(someArgument: Bool) -> ApiResponse {
+        return someArgument ? ApiResponse.Success : ApiResponse.Failure
+    }
+
+    override func spec() {
+        describe("justBeforeEach") {
+            var someArgument: Bool!
+            var apiResponse: ApiResponse!
+
+            justBeforeEach {
+                apiResponse = self.apiCall(someArgument: someArgument)
+            }
+
+            context("success") {
+                beforeEach {
+                    someArgument = true
+                }
+
+                it("then it response with Success") {
+                    expect(apiResponse).to(equal(ApiResponse.Success))
+                }
+            }
+
+            context("failure") {
+                beforeEach {
+                    someArgument = false
+                }
+
+                it("then it responds with failure") {
+                    expect(apiResponse).to(equal(ApiResponse.Failure))
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
@@ -2,8 +2,7 @@ import XCTest
 @testable import Quick
 import Nimble
 
-class FunctionalTests_AssignBeforeSpec: QuickSpec {
-
+class FunctionalTests_JustBeforeEachSpec: QuickSpec {
     enum ApiResponse {
         case Success
         case Failure

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/JustBeforeEachTests+Objc.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/JustBeforeEachTests+Objc.m
@@ -1,0 +1,66 @@
+@import XCTest;
+@import Quick;
+@import Nimble;
+
+#import "QCKSpecRunner.h"
+
+typedef NS_ENUM(NSUInteger, ApiResponseType) {
+    Success,
+    Failure
+};
+
+@interface SomeApiClass_Objc : XCTestCase; @end
+
+@implementation SomeApiClass_Objc
+
++ (ApiResponseType)apiCall:(BOOL)someArgument {
+    if (someArgument) {
+        return Success;
+    } else {
+        return Failure;
+    }
+}
+@end
+
+static ApiResponseType apiResponse;
+static BOOL apiClassArgument = NO;
+
+QuickSpecBegin(FunctionalTests_JustBeforeEachSpec_ObjC)
+
+justBeforeEach(^{
+    apiResponse = [SomeApiClass_Objc apiCall:apiClassArgument];
+});
+
+context(@"success", ^{
+    beforeEach(^{
+        apiClassArgument = YES;
+    });
+
+    it(@"then it responds with Success", ^{
+        expect((NSInteger)apiResponse).to(equal(Success));
+    });
+});
+
+context(@"failure", ^{
+    beforeEach(^{
+        apiClassArgument = NO;
+    });
+
+    it(@"then it responds with Failure", ^{
+        expect((NSInteger)apiResponse).to(equal(Failure));
+    });
+});
+
+QuickSpecEnd
+
+@interface JustBeforeEachTests_ObjC : XCTestCase; @end
+
+@implementation JustBeforeEachTests_ObjC
+
+- (void)testJustBeforeEachExecuted {
+    XCTestRun *result = qck_runSpec([FunctionalTests_JustBeforeEachSpec_ObjC class]);
+    XCTAssertEqual(result.executionCount, 2);
+    XCTAssertTrue(result.hasSucceeded);
+}
+
+@end


### PR DESCRIPTION
**Overview**
Quick is missing the ability to assign values to variables in interior blocks, but read those variables in a common exterior block. This is similar to the lazy evaluation of the `let` operation in rspec. This change introduces the ability to assign variable values prior to the execution of the `beforeEach` blocks.

**What behavior was changed?**
A new operator, `assignBefore`, was added to the DSL and logic of the `Example` class

**What code was refactored / updated to support this change?**
I have amended the core logic of the `Example` class, added `assignBefore` to the DSL, and added a new array of closures stored by the `ExampleHooks` class.

**What issues are related to this PR? Or why was this change introduced?**
I have written a blog post describing my rationale. See [this link](https://medium.com/perry-street-software-engineering/making-quickspec-lazier-proposing-the-assignbefore-operator-2abc9df47b8d).

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?

If this is a direction you guys want to move in, I am happy to cleanup and do this additional work! If not, no worries, will keep as a fork. Lastly, if you have a better solution in Swift than this modification, I am all ears!
