### PR TITLE
Drop support for xcode 13.

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1"]
+        xcode: ["14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         container:
-          - swift:5.6
+          - swift:5.7
       fail-fast: false
     container: ${{ matrix.container }}
     steps:

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1"]
+        xcode: ["14.0.1"]
         platform: ["macos", "ios", "tvos"]
       fail-fast: false
     env:

--- a/Documentation/en-us/InstallingQuick.md
+++ b/Documentation/en-us/InstallingQuick.md
@@ -153,7 +153,7 @@ To install Quick via XCode's Swift Package Manager integration, select your .xco
 Add Quick's github url as a dependency of your package, then as a dependency of your test target, like so:
 
 ```swift
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 


### PR DESCRIPTION
It's for async/await reasons.

**This drops support for compiling with Swift 5.6 and earlier (Xcode 13.x and earlier). OS Support is unchanged.**

Todo (After merge):

- [ ] Update branch protection rules for the new required swift/Xcode versions.
