### PR TITLE
Support async in fit

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -292,16 +292,6 @@ public func xit(_ description: String, file: FileString = #file, line: UInt = #l
 }
 
 /**
-    Use this to quickly mark an `it` closure as pending.
-    This disables the example and ensures the code within the closure is never run.
-
-    Note: This is a synchronous version.
-*/
-public func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
-    World.sharedWorld.xit(description, file: file, line: line, closure: closure)
-}
-
-/**
     Use this to quickly mark an `itBehavesLike` closure as pending.
     This disables the example group defined by this behavior and ensures the code within is never run.
 */
@@ -331,16 +321,6 @@ public func fcontext(_ description: String, closure: () -> Void) {
     If any examples in the test suite are focused, only those examples are executed.
 */
 public func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) {
-    World.sharedWorld.fit(description, file: file, line: line, closure: closure)
-}
-
-/**
-    Use this to quickly focus an `it` closure, focusing the example.
-    If any examples in the test suite are focused, only those examples are executed.
-
-    Note: This is a synchronous version.
-*/
-public func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
     World.sharedWorld.fit(description, file: file, line: line, closure: closure)
 }
 

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -179,7 +179,7 @@ public func aroundEach(_ closure: @escaping AroundExampleWithMetadataAsyncClosur
     - parameter closure: The closure to be run prior to each example and after any beforeEach blocks
 */
 
-public func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+public func justBeforeEach(_ closure: @escaping BeforeExampleAsyncClosure) {
     World.sharedWorld.justBeforeEach(closure)
 }
 
@@ -244,17 +244,6 @@ public func itBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #f
 }
 
 // MARK: - Pending
-/**
-    Defines an example or example group that should not be executed. Use `pending` to temporarily disable
-    examples or groups that should not be run yet.
-
-    - parameter description: An arbitrary string describing the example or example group.
-    - parameter closure: A closure that will not be evaluated.
-*/
-public func pending(_ description: String, closure: () -> Void) {
-    World.sharedWorld.pending(description, closure: closure)
-}
-
 /**
     Defines an example or example group that should not be executed. Use `pending` to temporarily disable
     examples or groups that should not be run yet.

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -61,12 +61,15 @@ extension World {
     }
 
     // MARK: - Just Before Each
-    internal func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+#if canImport(Darwin)
+    @objc(justBeforeEach:)
+    internal func objc_justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'justBeforeEach' cannot be used inside '\(currentPhase)', 'justBeforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendJustBeforeEach(closure)
     }
+#endif
 
     @nonobjc
     internal func justBeforeEach(_ closure: @escaping BeforeExampleAsyncClosure) {

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -35,6 +35,10 @@ class _FunctionalTests_FocusedSpec_Focused: QuickSpec {
             fit("has a focused example that passes (3)") {}
         }
 
+        fit("focused tests can run on the main thread") { @MainActor in
+            expect(Thread.isMainThread).to(beTrue())
+        }
+
         fitBehavesLike("two passing shared examples")
         fitBehavesLike(FunctionalTests_FocusedSpec_Behavior.self) { () -> Void in }
     }
@@ -74,6 +78,6 @@ final class FocusedTests: XCTestCase, XCTestCaseProvider {
             _FunctionalTests_FocusedSpec_Focused.self,
         ])
         #endif
-        XCTAssertEqual(result?.executionCount, 8)
+        XCTAssertEqual(result?.executionCount, 9)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Quick/Quick/issues/1181

If you have two functions that take a closure - one takes an async closure, and the other takes a sync closure - unless you specifically make an async call, swift will pick the sync version of the function. Because we had both sync and async versions of `fit` available, Swift would default to the sync version.

I noticed similar issues in `xit`, `pending` and `justBeforeEach`. This PR fixes those as well.
