### PR TITLE
Update Nimble to 11.2.1, remove now-unnecessary usage of awaits in tests. Drop support for swift 5.6/Xcode 13.3.1

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1", "14.0.1"]
+        xcode: ["14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         container:
-          - swift:5.6
           - swift:5.7
       fail-fast: false
     container: ${{ matrix.container }}

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1", "14.0.1"]
+        xcode: ["14.0.1"]
         platform: ["macos", "ios", "tvos"]
       fail-fast: false
     env:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,34 +1,32 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "d258c638d9ef214723a857a23f4113773aad28fb",
-          "version": "9.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "f809deb30dc5c9d9b78c872e553261a61177721a",
+        "version" : "2.0.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "b7f6c49acdb247e3158198c5448b38c3cc595533",
+        "version" : "11.2.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Quick", targets: ["Quick"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble.git", from: "11.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "11.2.0"),
     ],
     targets: {
         var targets: [Target] = [

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -125,7 +125,7 @@ public class Example: _ExampleBase {
     static internal let recordSkipSelector = NSSelectorFromString("recordSkipWithDescription:sourceCodeContext:")
     #endif
 
-    internal func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) { // swiftlint:disable:this function_body_length
+    internal func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) {
         #if !canImport(Darwin)
             return // This functionality is only supported by Apple's proprietary XCTest, not by swift-corelibs-xctest
         #else // `NSSelectorFromString` requires the Objective-C runtime, which is not available on Linux.

--- a/Sources/Quick/QuickMain.swift
+++ b/Sources/Quick/QuickMain.swift
@@ -15,7 +15,7 @@ import XCTest
 ///
 /// - parameter specs: An array of QuickSpec subclasses to run
 /// - parameter configurations: An array QuickConfiguration subclasses for setting up
-//                              global suite configuration (optional)
+///                              global suite configuration (optional)
 /// - parameter testCases: An array of XCTestCase test cases, just as would be passed
 ///                        info `XCTMain` if you were using swift-corelibs-xctest directly.
 ///                        This allows for mixing Quick specs and XCTestCase tests in one run.

--- a/Sources/Quick/QuickTestObservation.swift
+++ b/Sources/Quick/QuickTestObservation.swift
@@ -5,7 +5,7 @@ import XCTest
 
 /// A dummy protocol for calling the internal `+[QuickSpec buildExamplesIfNeeded]` method
 /// which is defined in Objective-C from Swift.
-@objc internal protocol _QuickSpecInternal {
+@objc internal protocol _QuickSpecInternal { // swiftlint:disable:this type_name
     static func buildExamplesIfNeeded()
 }
 

--- a/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_BehaviorTests_Behaviors.swift
+++ b/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_BehaviorTests_Behaviors.swift
@@ -6,7 +6,7 @@ class FunctionalTests_BehaviorTests_Behavior: Behavior<String> {
     override static func spec(_ aContext: @escaping () -> String) {
         it("passed the correct parameters via the context") {
             let callsite = aContext()
-            await expect(callsite).to(equal("BehaviorSpec"))
+            expect(callsite).to(equal("BehaviorSpec"))
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_SharedExamplesTests_SharedExamples.swift
+++ b/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_SharedExamplesTests_SharedExamples.swift
@@ -13,7 +13,7 @@ class FunctionalTests_SharedExamplesTests_SharedExamples: QuickConfiguration {
         sharedExamples("shared examples that take a context") { (sharedExampleContext: @escaping SharedExampleContext) in
             it("is passed the correct parameters via the context") {
                 let callsite = sharedExampleContext()["callsite"] as? String
-                await expect(callsite).to(equal("SharedExamplesSpec"))
+                expect(callsite).to(equal("SharedExamplesSpec"))
             }
         }
     }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AroundEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AroundEachTests.swift
@@ -59,16 +59,16 @@ class FunctionalTests_AroundEachSpec: QuickSpec {
                 }
 
                 it("executes the outer and inner aroundEach closures, but not before this closure [2]") {
-                    await expect(aroundEachOrder).to(contain(.innerAroundPrefix, .innerBefore))
-                    await expect(aroundEachOrder).notTo(contain(.innerAroundSuffix))
-                    await expect(aroundEachOrder).notTo(contain(.innerAfter))
+                    expect(aroundEachOrder).to(contain(.innerAroundPrefix, .innerBefore))
+                    expect(aroundEachOrder).notTo(contain(.innerAroundSuffix))
+                    expect(aroundEachOrder).notTo(contain(.innerAfter))
                 }
             }
         }
 
         describe("execution threads") {
             aroundEach { run in
-                await expect(Thread.isMainThread).to(beFalse())
+                expect(Thread.isMainThread).to(beFalse())
                 await run()
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
@@ -10,7 +10,7 @@ class BundleModuleNameSpecs: QuickSpec {
             it("should repalce invalid characters with underscores") {
                 let bundle = Bundle.currentTestBundle
                 let moduleName = bundle?.moduleName
-                await expect(moduleName?.contains("Quick_")).to(beTrue())
+                expect(moduleName?.contains("Quick_")).to(beTrue())
             }
 
             it("should be the correct module name to be able to retreive classes") {
@@ -21,7 +21,7 @@ class BundleModuleNameSpecs: QuickSpec {
 
                 let moduleName = bundle.moduleName
                 let className: AnyClass? = NSClassFromString("\(moduleName).BundleModuleNameSpecs")
-                await expect(className).to(be(BundleModuleNameSpecs.self))
+                expect(className).to(be(BundleModuleNameSpecs.self))
             }
         }
     }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
@@ -13,7 +13,7 @@ class CurrentSpecTests: QuickSpec {
                 return result
                 #endif
             }()
-            await expect(name).to(match("returns the currently executing spec"))
+            expect(name).to(match("returns the currently executing spec"))
         }
 
         let currentSpecDuringSpecSetup = QuickSpec.current

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -13,7 +13,7 @@ class FunctionalTests_ItSpec: QuickSpec {
 
         it("has a description with セレクター名に使えない文字が入っている 👊💥") {
             let name = "has a description with セレクター名に使えない文字が入っている 👊💥"
-            await expect(exampleMetadata?.example.name).to(equal(name))
+            expect(exampleMetadata?.example.name).to(equal(name))
         }
 
 #if canImport(Darwin)
@@ -84,8 +84,8 @@ class FunctionalTests_ItSpec: QuickSpec {
                 }
 
                 it("should have thrown an exception with the correct error message") {
-                    await expect(exception).toNot(beNil())
-                    await expect(exception?.reason).to(equal("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'."))
+                    expect(exception).toNot(beNil())
+                    expect(exception?.reason).to(equal("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'."))
                 }
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
@@ -20,18 +20,18 @@ final class SubclassDetectionSpec: QuickSpec {
             }
 
             it("returns false when a class is not at all related to the superclass") {
-                await expect(isClass(D.self, aSubclassOf: A.self)).to(beFalse())
-                await expect(isClass(D.self, aSubclassOf: B.self)).to(beFalse())
-                await expect(isClass(D.self, aSubclassOf: C.self)).to(beFalse())
+                expect(isClass(D.self, aSubclassOf: A.self)).to(beFalse())
+                expect(isClass(D.self, aSubclassOf: B.self)).to(beFalse())
+                expect(isClass(D.self, aSubclassOf: C.self)).to(beFalse())
             }
         }
 
         describe("finding all subclasses of a given type") {
             it("finds only subclasses, but not the actual class, of the desired type") {
                 let foundSubclasses: [A.Type] = allSubclasses(ofType: A.self)
-                await expect(foundSubclasses).to(haveCount(2))
-                await expect(foundSubclasses.first).to(be(B.self) || be(C.self))
-                await expect(foundSubclasses.last).to(be(B.self) || be(C.self))
+                expect(foundSubclasses).to(haveCount(2))
+                expect(foundSubclasses.first).to(be(B.self) || be(C.self))
+                expect(foundSubclasses.last).to(be(B.self) || be(C.self))
             }
         }
     }


### PR DESCRIPTION
[Nimble 11.2.0](https://github.com/Quick/Nimble/releases/tag/v11.2.0) fixed the issue where any usage of async behavior in a test would cause the compiler to think that any usage of `expect` was taking in an async closure. This PR pulls in the now-current [11.2.1 version of Nimble](https://github.com/Quick/Nimble/releases/tag/v11.2.1), and sets the Package.swift to require at least 11.2.0.

This should make life significantly easier for those contributing to Quick.