### PR TITLE
Add async resultbuilder-based support

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -131,6 +131,33 @@
 		7B5358CE1C3D4FBC00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358CF1C3D4FBE00A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
 		7B5358D01C3D4FC000A23FAA /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */; };
+		895A7180296D4F7D00AE392D /* AsyncSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A717F296D4F7D00AE392D /* AsyncSpec.swift */; };
+		895A7181296D4F7D00AE392D /* AsyncSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A717F296D4F7D00AE392D /* AsyncSpec.swift */; };
+		895A7182296D4F7D00AE392D /* AsyncSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A717F296D4F7D00AE392D /* AsyncSpec.swift */; };
+		895A7184296D4F8D00AE392D /* AsyncExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A7183296D4F8D00AE392D /* AsyncExample.swift */; };
+		895A7185296D4F8D00AE392D /* AsyncExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A7183296D4F8D00AE392D /* AsyncExample.swift */; };
+		895A7186296D4F8D00AE392D /* AsyncExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A7183296D4F8D00AE392D /* AsyncExample.swift */; };
+		895A718F296D527900AE392D /* AsyncItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A718B296D524400AE392D /* AsyncItTests.swift */; };
+		895A7190296D527A00AE392D /* AsyncItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A718B296D524400AE392D /* AsyncItTests.swift */; };
+		895A7191296D527B00AE392D /* AsyncItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A718B296D524400AE392D /* AsyncItTests.swift */; };
+		895A719B296FB88100AE392D /* ExampleBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719A296FB88100AE392D /* ExampleBase.swift */; };
+		895A719C296FB88100AE392D /* ExampleBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719A296FB88100AE392D /* ExampleBase.swift */; };
+		895A719D296FB88100AE392D /* ExampleBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719A296FB88100AE392D /* ExampleBase.swift */; };
+		895A719F296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A0296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A1296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A2296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A3296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A4296FE01400AE392D /* AsyncSpecRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A719E296FE01400AE392D /* AsyncSpecRunner.swift */; };
+		895A71A6296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A5296FE42000AE392D /* AsyncBeforeEachTests.swift */; };
+		895A71A7296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A5296FE42000AE392D /* AsyncBeforeEachTests.swift */; };
+		895A71A8296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A5296FE42000AE392D /* AsyncBeforeEachTests.swift */; };
+		895A71AA296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A9296FE55300AE392D /* AsyncSpec+DSL.swift */; };
+		895A71AB296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A9296FE55300AE392D /* AsyncSpec+DSL.swift */; };
+		895A71AC296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71A9296FE55300AE392D /* AsyncSpec+DSL.swift */; };
+		895A71AE296FE7AB00AE392D /* AsyncAfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71AD296FE7AB00AE392D /* AsyncAfterEachTests.swift */; };
+		895A71AF296FE7AB00AE392D /* AsyncAfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71AD296FE7AB00AE392D /* AsyncAfterEachTests.swift */; };
+		895A71B0296FE7AC00AE392D /* AsyncAfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895A71AD296FE7AB00AE392D /* AsyncAfterEachTests.swift */; };
 		8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
@@ -395,6 +422,14 @@
 		79FE27DE22DC955400BA013D /* QuickSpec_SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSpec_SelectedTests.swift; sourceTree = "<group>"; };
 		7B44ADBD1C5444940007AF2E /* HooksPhase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HooksPhase.swift; sourceTree = "<group>"; };
 		7B5358CA1C3D4E2A00A23FAA /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
+		895A717F296D4F7D00AE392D /* AsyncSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncSpec.swift; sourceTree = "<group>"; };
+		895A7183296D4F8D00AE392D /* AsyncExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExample.swift; sourceTree = "<group>"; };
+		895A718B296D524400AE392D /* AsyncItTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncItTests.swift; sourceTree = "<group>"; };
+		895A719A296FB88100AE392D /* ExampleBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleBase.swift; sourceTree = "<group>"; };
+		895A719E296FE01400AE392D /* AsyncSpecRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncSpecRunner.swift; sourceTree = "<group>"; };
+		895A71A5296FE42000AE392D /* AsyncBeforeEachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncBeforeEachTests.swift; sourceTree = "<group>"; };
+		895A71A9296FE55300AE392D /* AsyncSpec+DSL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AsyncSpec+DSL.swift"; sourceTree = "<group>"; };
+		895A71AD296FE7AB00AE392D /* AsyncAfterEachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAfterEachTests.swift; sourceTree = "<group>"; };
 		8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SelectedTests+ObjC.m"; sourceTree = "<group>"; };
 		89A7919C28139D0900D99622 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		89A7919D28139D0900D99622 /* Quick.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Quick.podspec; sourceTree = "<group>"; };
@@ -637,11 +672,23 @@
 			path = DSL;
 			sourceTree = "<group>";
 		};
+		895A718A296D523900AE392D /* Async */ = {
+			isa = PBXGroup;
+			children = (
+				895A71AD296FE7AB00AE392D /* AsyncAfterEachTests.swift */,
+				895A71A5296FE42000AE392D /* AsyncBeforeEachTests.swift */,
+				895A718B296D524400AE392D /* AsyncItTests.swift */,
+			);
+			path = Async;
+			sourceTree = "<group>";
+		};
 		89E8E595290044B2003B08F0 /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				895A7183296D4F8D00AE392D /* AsyncExample.swift */,
 				DA02C91819A8073100093156 /* ExampleMetadata.swift */,
 				89E8E59A290045AE003B08F0 /* Example.swift */,
+				895A719A296FB88100AE392D /* ExampleBase.swift */,
 			);
 			path = Examples;
 			sourceTree = "<group>";
@@ -685,6 +732,7 @@
 		DA3124E119FCAEE8002858A7 /* DSL */ = {
 			isa = PBXGroup;
 			children = (
+				895A71A9296FE55300AE392D /* AsyncSpec+DSL.swift */,
 				DA3124E519FCAEE8002858A7 /* World+DSL.swift */,
 				DA3124E219FCAEE8002858A7 /* DSL.swift */,
 			);
@@ -709,6 +757,7 @@
 				DA8F919519F31680006F6675 /* QCKSpecRunner.h */,
 				DA8F919619F31680006F6675 /* QCKSpecRunner.m */,
 				CD582D722264C137008F7CE6 /* QuickSpecRunner.swift */,
+				895A719E296FE01400AE392D /* AsyncSpecRunner.swift */,
 				CD582D6E2264B371008F7CE6 /* QuickSpec+MethodList.swift */,
 				34ACFB7B1C34859300942064 /* XCTestCaseProvider.swift */,
 				CD1F6502226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift */,
@@ -719,6 +768,7 @@
 		DA8F919B19F3189D006F6675 /* FunctionalTests */ = {
 			isa = PBXGroup;
 			children = (
+				895A718A296D523900AE392D /* Async */,
 				DA05D60F19F73A3800771050 /* AfterEachTests.swift */,
 				DA3E1685243F8C23001F7CCA /* AroundEachTests.swift */,
 				DA87078219F48775008C04AC /* BeforeEachTests.swift */,
@@ -835,6 +885,7 @@
 				89E8E595290044B2003B08F0 /* Examples */,
 				DA408BDE19FF5599005DF92A /* Hooks */,
 				CD3451461E4703D4000C8633 /* QuickMain.swift */,
+				895A717F296D4F7D00AE392D /* AsyncSpec.swift */,
 				CD3451471E4703D4000C8633 /* QuickSpec.swift */,
 				34F3759F19515CA700CE1B99 /* ExampleGroup.swift */,
 				CD21A025247C1385002C4762 /* QuickTestObservation.swift */,
@@ -1388,6 +1439,7 @@
 				1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */,
 				89D2C677284DA77D004B108C /* SubclassDetection.swift in Sources */,
 				DED3036D1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
+				895A7186296D4F8D00AE392D /* AsyncExample.swift in Sources */,
 				CE590E211C431FE400253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				1F118D071BDCA536005013A2 /* Callsite.swift in Sources */,
 				CE590E231C431FE400253D19 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1396,6 +1448,7 @@
 				CE590E221C431FE400253D19 /* URL+FileName.swift in Sources */,
 				1F118CFE1BDCA536005013A2 /* DSL.swift in Sources */,
 				7B44ADC01C5444940007AF2E /* HooksPhase.swift in Sources */,
+				895A719D296FB88100AE392D /* ExampleBase.swift in Sources */,
 				1F118D001BDCA536005013A2 /* Closures.swift in Sources */,
 				1F118D051BDCA536005013A2 /* ExampleMetadata.swift in Sources */,
 				1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */,
@@ -1403,10 +1456,12 @@
 				CE590E1F1C431FE400253D19 /* QuickTestSuite.swift in Sources */,
 				1F118D091BDCA536005013A2 /* QuickSpec.m in Sources */,
 				B5F43E5C29301E9200468BCC /* TestState.swift in Sources */,
+				895A7182296D4F7D00AE392D /* AsyncSpec.swift in Sources */,
 				CD21A028247C1385002C4762 /* QuickTestObservation.swift in Sources */,
 				CDE5BDFF2268CE97006E2F66 /* QuickConfiguration.swift in Sources */,
 				1F118D011BDCA536005013A2 /* ExampleHooks.swift in Sources */,
 				89E8E59D290045AE003B08F0 /* Example.swift in Sources */,
+				895A71AC296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1419,8 +1474,10 @@
 				79FE27E122DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				1F118D1C1BDCA556005013A2 /* BeforeSuiteTests.swift in Sources */,
 				1F118D1D1BDCA556005013A2 /* BeforeSuiteTests+ObjC.m in Sources */,
+				895A71B0296FE7AC00AE392D /* AsyncAfterEachTests.swift in Sources */,
 				1F118D0E1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
 				CE4A57931EA725420063C0D4 /* BehaviorTests.swift in Sources */,
+				895A7191296D527B00AE392D /* AsyncItTests.swift in Sources */,
 				1F118D141BDCA556005013A2 /* FailureTests+ObjC.m in Sources */,
 				CE4A57911EA7252E0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DED3037F1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */,
@@ -1435,6 +1492,7 @@
 				1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */,
 				1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */,
 				AED9C8651CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
+				895A71A8296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */,
 				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
 				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
 				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
@@ -1442,6 +1500,7 @@
 				CD582D712264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C673284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				895A71A3296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				61572A9028E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
 				CD582D772264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
@@ -1463,6 +1522,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD582D782264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
+				895A71A4296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				CD1F6508226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				1F118D0D1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
 				34C586061C4ABD4100D4F057 /* XCTestCaseProvider.swift in Sources */,
@@ -1485,6 +1545,7 @@
 				34F375BA19515CA700CE1B99 /* QuickSpec.m in Sources */,
 				DED3036C1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				89D2C676284DA77D004B108C /* SubclassDetection.swift in Sources */,
+				895A7185296D4F8D00AE392D /* AsyncExample.swift in Sources */,
 				CE590E1C1C431FE300253D19 /* NSBundle+CurrentTestBundle.swift in Sources */,
 				DAE7150119FF6A62005905B8 /* QuickConfiguration.m in Sources */,
 				CE590E1E1C431FE300253D19 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1493,6 +1554,7 @@
 				CE590E1D1C431FE300253D19 /* URL+FileName.swift in Sources */,
 				34F375BC19515CA700CE1B99 /* World.swift in Sources */,
 				DA169E4919FF5DF100619816 /* QCKConfiguration.swift in Sources */,
+				895A719C296FB88100AE392D /* ExampleBase.swift in Sources */,
 				7B44ADBF1C5444940007AF2E /* HooksPhase.swift in Sources */,
 				DA3124ED19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */,
@@ -1500,10 +1562,12 @@
 				CE590E1A1C431FE300253D19 /* QuickTestSuite.swift in Sources */,
 				DA3124E719FCAEE8002858A7 /* DSL.swift in Sources */,
 				B5F43E5B29301E9200468BCC /* TestState.swift in Sources */,
+				895A7181296D4F7D00AE392D /* AsyncSpec.swift in Sources */,
 				CD21A027247C1385002C4762 /* QuickTestObservation.swift in Sources */,
 				CDE5BDFE2268CE96006E2F66 /* QuickConfiguration.swift in Sources */,
 				DA6B30191A4DB0D500FFB148 /* Filter.swift in Sources */,
 				89E8E59C290045AE003B08F0 /* Example.swift in Sources */,
+				895A71AB296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1516,8 +1580,10 @@
 				79FE27E022DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				DA8F919A19F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F11B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
+				895A71AF296FE7AB00AE392D /* AsyncAfterEachTests.swift in Sources */,
 				4728253C1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				DAE714F119FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
+				895A7190296D527A00AE392D /* AsyncItTests.swift in Sources */,
 				DED3037E1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */,
 				DA05D61119F73A3800771050 /* AfterEachTests.swift in Sources */,
 				DAB0137019FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
@@ -1532,6 +1598,7 @@
 				CE4A578E1EA7251C0063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DA8F91AF19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FB19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
+				895A71A7296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */,
 				AED9C8641CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590411A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919E19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
@@ -1539,6 +1606,7 @@
 				CD582D702264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F419FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C672284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				895A71A1296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				61572A8F28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				479C31E41A36172700DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D752264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
@@ -1595,6 +1663,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD582D742264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
+				895A71A0296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				CD1F6504226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				DA07722E1A4E5B7B0098839D /* QCKSpecRunner.m in Sources */,
 				34C586021C4ABD3F00D4F057 /* XCTestCaseProvider.swift in Sources */,
@@ -1608,6 +1677,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD582D762264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,
+				895A71A2296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				CD1F6506226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
 				DA07722F1A4E5B7C0098839D /* QCKSpecRunner.m in Sources */,
 				34C586041C4ABD4000D4F057 /* XCTestCaseProvider.swift in Sources */,
@@ -1630,6 +1700,7 @@
 				34C586081C4AC5E500D4F057 /* ErrorUtility.swift in Sources */,
 				DED3036B1DF6C66B0041394E /* String+C99ExtendedIdentifier.swift in Sources */,
 				89D2C675284DA77D004B108C /* SubclassDetection.swift in Sources */,
+				895A7184296D4F8D00AE392D /* AsyncExample.swift in Sources */,
 				DA408BE619FF5599005DF92A /* SuiteHooks.swift in Sources */,
 				34F375B919515CA700CE1B99 /* QuickSpec.m in Sources */,
 				CE57CEE11C430BD200D63004 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
@@ -1638,6 +1709,7 @@
 				CE57CEE01C430BD200D63004 /* URL+FileName.swift in Sources */,
 				34F375AD19515CA700CE1B99 /* ExampleGroup.swift in Sources */,
 				34F375BB19515CA700CE1B99 /* World.swift in Sources */,
+				895A719B296FB88100AE392D /* ExampleBase.swift in Sources */,
 				DA169E4819FF5DF100619816 /* QCKConfiguration.swift in Sources */,
 				7B44ADBE1C5444940007AF2E /* HooksPhase.swift in Sources */,
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,
@@ -1645,10 +1717,12 @@
 				CE175D4E1E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				DA3124E619FCAEE8002858A7 /* DSL.swift in Sources */,
 				B5F43E5A29301E9200468BCC /* TestState.swift in Sources */,
+				895A7180296D4F7D00AE392D /* AsyncSpec.swift in Sources */,
 				CD21A026247C1385002C4762 /* QuickTestObservation.swift in Sources */,
 				CDE5BDFD2268CE95006E2F66 /* QuickConfiguration.swift in Sources */,
 				DA6B30181A4DB0D500FFB148 /* Filter.swift in Sources */,
 				89E8E59B290045AE003B08F0 /* Example.swift in Sources */,
+				895A71AA296FE55300AE392D /* AsyncSpec+DSL.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1661,8 +1735,10 @@
 				79FE27DF22DC955400BA013D /* QuickSpec_SelectedTests.swift in Sources */,
 				DA8F919919F31680006F6675 /* QCKSpecRunner.m in Sources */,
 				DA8940F01B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
+				895A71AE296FE7AB00AE392D /* AsyncAfterEachTests.swift in Sources */,
 				4728253B1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m in Sources */,
 				CE4A57941EA725440063C0D4 /* BehaviorTests.swift in Sources */,
+				895A718F296D527900AE392D /* AsyncItTests.swift in Sources */,
 				DAE714F019FF65D3005905B8 /* Configuration+BeforeEachTests.swift in Sources */,
 				CE4A57921EA725300063C0D4 /* FunctionalTests_BehaviorTests_Behaviors.swift in Sources */,
 				DED3037D1DF6CF140041394E /* BundleModuleNameTests.swift in Sources */,
@@ -1677,6 +1753,7 @@
 				4748E8941A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
 				DA8F91AE19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				DAE714FA19FF682A005905B8 /* Configuration+AfterEachTests.swift in Sources */,
+				895A71A6296FE42000AE392D /* AsyncBeforeEachTests.swift in Sources */,
 				AED9C8631CC8A7BD00432F62 /* CrossReferencingSpecs.swift in Sources */,
 				471590401A488F3F00FBA644 /* PendingTests+ObjC.m in Sources */,
 				DA8F919D19F31921006F6675 /* FailureTests+ObjC.m in Sources */,
@@ -1684,6 +1761,7 @@
 				CD582D6F2264B371008F7CE6 /* QuickSpec+MethodList.swift in Sources */,
 				DAE714F319FF65E7005905B8 /* Configuration+BeforeEach.swift in Sources */,
 				89D2C671284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */,
+				895A719F296FE01400AE392D /* AsyncSpecRunner.swift in Sources */,
 				61572A8E28E3959D00C5A80D /* JustBeforeEachTests+Objc.m in Sources */,
 				479C31E31A36171B00DA8718 /* ItTests+ObjC.m in Sources */,
 				CD582D732264C137008F7CE6 /* QuickSpecRunner.swift in Sources */,

--- a/Sources/Quick/DSL/AsyncSpec+DSL.swift
+++ b/Sources/Quick/DSL/AsyncSpec+DSL.swift
@@ -1,0 +1,21 @@
+extension AsyncSpec {
+    public class func describe(_ description: String, @AsyncGroupBuilder children: () -> [QuickAsync]) -> AsyncExampleGroup {
+        AsyncExampleGroup(description, children: children)
+    }
+
+    public class func context(_ description: String, @AsyncGroupBuilder children: () -> [QuickAsync]) -> AsyncExampleGroup {
+        AsyncExampleGroup(description, children: children)
+    }
+
+    public class func beforeEach(closure: @escaping () async throws -> Void) -> BeforeEach {
+        BeforeEach(closure: closure)
+    }
+
+    public class func afterEach(closure: @escaping () async throws -> Void) -> AfterEach {
+        AfterEach(closure: closure)
+    }
+
+    public class func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) -> It {
+        It(description, file: file, line: line, closure: closure)
+    }
+}

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -23,7 +23,7 @@ extension World {
 
     // MARK: - Example groups.
     internal func describe(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'describe' cannot be used inside '\(currentPhase)', 'describe' may only be used inside 'context' or 'describe'.")
         }
         guard currentExampleGroup != nil else {
@@ -36,7 +36,7 @@ extension World {
     }
 
     internal func context(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'context' cannot be used inside '\(currentPhase)', 'context' may only be used inside 'context' or 'describe'.")
         }
         self.describe(description, flags: flags, closure: closure)
@@ -54,7 +54,7 @@ extension World {
 #if canImport(Darwin)
     @objc(justBeforeEach:)
     internal func objc_justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'justBeforeEach' cannot be used inside '\(currentPhase)', 'justBeforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendJustBeforeEach(closure)
@@ -63,7 +63,7 @@ extension World {
 
     @nonobjc
     internal func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'justBeforeEach' cannot be used inside '\(currentPhase)', 'justBeforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendJustBeforeEach(closure)
@@ -73,7 +73,7 @@ extension World {
 #if canImport(Darwin)
     @objc(beforeEachWithMetadata:)
     internal func objc_beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendBefore(closure)
@@ -81,14 +81,14 @@ extension World {
 #endif
     @nonobjc
     internal func beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendBefore(closure)
     }
 
     internal func beforeEach(_ closure: @escaping BeforeExampleClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendBefore(closure)
@@ -98,7 +98,7 @@ extension World {
 #if canImport(Darwin)
     @objc(afterEachWithMetadata:)
     internal func objc_afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendAfter(closure)
@@ -106,14 +106,14 @@ extension World {
 #endif
     @nonobjc
     internal func afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendAfter(closure)
     }
 
     internal func afterEach(_ closure: @escaping AfterExampleClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
         }
         currentExampleGroup.hooks.appendAfter(closure)
@@ -122,7 +122,7 @@ extension World {
     // MARK: - Around Each
     @nonobjc
     internal func aroundEach(_ closure: @escaping AroundExampleClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'aroundEach' cannot be used inside '\(currentPhase)', 'aroundEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendAround(closure)
@@ -130,7 +130,7 @@ extension World {
 
     @nonobjc
     internal func aroundEach(_ closure: @escaping AroundExampleWithMetadataClosure) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'aroundEach' cannot be used inside '\(currentPhase)', 'aroundEach' may only be used inside 'context' or 'describe'. ")
         }
         currentExampleGroup.hooks.appendAround(closure)
@@ -145,7 +145,7 @@ extension World {
         if aftersCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'.")
         }
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'.")
         }
         let callsite = Callsite(file: file, line: line)
@@ -166,7 +166,7 @@ extension World {
     // MARK: - Shared Behavior
     @nonobjc
     internal func itBehavesLike(_ name: String, sharedExampleContext: @escaping SharedExampleContext, flags: FilterFlags = [:], file: FileString, line: UInt) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'itBehavesLike' cannot be used inside '\(currentPhase)', 'itBehavesLike' may only be used inside 'context' or 'describe'.")
         }
         let callsite = Callsite(file: file, line: line)
@@ -195,7 +195,7 @@ extension World {
     }
 
     internal func itBehavesLike<C>(_ behavior: Behavior<C>.Type, context: @escaping () -> C, flags: FilterFlags = [:], file: FileString, line: UInt) {
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'itBehavesLike' cannot be used inside '\(currentPhase)', 'itBehavesLike' may only be used inside 'context' or 'describe'.")
         }
         let callsite = Callsite(file: file, line: line)
@@ -230,7 +230,7 @@ extension World {
         if aftersCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'afterEach', 'it' may only be used inside 'context' or 'describe'.")
         }
-        guard currentExampleMetadata == nil else {
+        guard currentSpec == nil else {
             raiseError("'it' cannot be used inside 'it', 'it' may only be used inside 'context' or 'describe'.")
         }
         let callsite = Callsite(file: file, line: line)

--- a/Sources/Quick/Examples/AsyncExample.swift
+++ b/Sources/Quick/Examples/AsyncExample.swift
@@ -1,0 +1,167 @@
+@resultBuilder
+public struct AsyncSpecBuilder {
+    typealias FinalResult = [AsyncExample]
+    public static func buildBlock(_ components: QuickAsync...) -> QuickAsync {
+        Describe(description: "", flags: [:], isInternalRootExampleGroup: true, children: components)
+    }
+
+    public static func buildFinalResult(_ component: QuickAsync) -> [AsyncExample] {
+        component.component.group()
+            .map { (name, callsite, closure) in
+            return AsyncExample(name: name, callsite: callsite, closure: closure)
+        }
+    }
+}
+
+@resultBuilder
+public struct AsyncGroupBuilder {
+    public static func buildBlock(_ components: QuickAsync...) -> [QuickAsync] {
+        components
+    }
+
+    public static func buildArray(_ components: [[QuickAsync]]) -> [QuickAsync] {
+        components.flatMap { $0 }
+    }
+}
+
+public final class AsyncExample: ExampleBase {
+    fileprivate let closure: () async throws -> Void
+
+    internal init(name: String, callsite: Callsite, closure: @escaping () async throws -> Void) {
+        self.closure = closure
+        super.init(name: name, callsite: callsite)
+    }
+
+    internal func run() async {
+        do {
+            try await closure()
+        } catch {
+            self.handleThrownErrorFromTest(error: error)
+        }
+    }
+}
+
+public indirect enum AsyncComponent {
+    case beforeEach(closure: () async throws -> Void)
+    case example(name: String, callsite: Callsite, closure: () async throws -> Void)
+    case afterEach(closure: () async throws -> Void)
+    case describe(AsyncExampleGroup)
+
+    func group() -> [(name: String, callsite: Callsite, closure: () async throws -> Void)] { // swiftlint:disable:this large_tuple
+        switch self {
+        case .beforeEach, .afterEach: return []
+        case let .example(name: name, callsite: callsite, closure: closure):
+            return [(name, callsite, closure)]
+        case let .describe(exampleGroup):
+            let components = exampleGroup.children.map { $0.component }
+            let beforeEachs = components.compactMap { $0.beforeEach }
+            let afterEachs = components.compactMap { $0.afterEach }
+
+            return components.flatMap { subComponent in
+                return subComponent.group().map { (subname, callsite, closure) in
+                    var exampleName: String
+                    if exampleGroup.isInternalRootExampleGroup {
+                        exampleName = subname
+                    } else {
+                        exampleName = "\(exampleGroup.description) \(subname)"
+                    }
+                    return (exampleName, callsite, {
+                        for beforeEach in beforeEachs {
+                            try await beforeEach()
+                        }
+
+                        try await closure()
+
+                        for afterEach in afterEachs {
+                            try await afterEach()
+                        }
+                    })
+                }
+            }
+        }
+    }
+
+    private var beforeEach: (() async throws -> Void)? {
+        guard case let .beforeEach(closure) = self else {
+            return nil
+        }
+        return closure
+    }
+
+    private var afterEach: (() async throws -> Void)? {
+        guard case let .afterEach(closure) = self else {
+            return nil
+        }
+        return closure
+    }
+}
+
+public protocol QuickAsync {
+//    var exampleGroup: AsyncExampleGroup { get }
+    var component: AsyncComponent { get }
+}
+
+public struct It: QuickAsync { // swiftlint:disable:this type_name
+    let name: String
+    let callsite: Callsite
+    let closure: () async throws -> Void
+
+    public var component: AsyncComponent {
+        .example(name: name, callsite: callsite, closure: closure)
+    }
+    public init(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) {
+        name = description
+        callsite = Callsite(file: file, line: line)
+        self.closure = closure
+    }
+}
+
+public struct BeforeEach: QuickAsync {
+    internal let closure: () async throws -> Void
+
+    public var component: AsyncComponent { .beforeEach(closure: closure) }
+
+    public init(closure: @escaping () async throws -> Void) {
+        self.closure = closure
+    }
+}
+
+public struct AfterEach: QuickAsync {
+    internal let closure: () async throws -> Void
+
+    public var component: AsyncComponent { .afterEach(closure: closure) }
+
+    public init(closure: @escaping () async throws -> Void) {
+        self.closure = closure
+    }
+}
+
+public struct AsyncExampleGroup {
+    let description: String
+    let flags: FilterFlags
+    let isInternalRootExampleGroup: Bool
+    let children: [QuickAsync]
+
+    internal init(description: String, flags: FilterFlags, isInternalRootExampleGroup: Bool, children: [QuickAsync]) {
+        self.description = description
+        self.flags = flags
+        self.isInternalRootExampleGroup = isInternalRootExampleGroup
+        self.children = children
+    }
+
+    public init(_ description: String, @AsyncGroupBuilder children: () -> [QuickAsync]) {
+        self.description = description
+        self.flags = [:]
+        self.isInternalRootExampleGroup = false
+        self.children = children()
+    }
+}
+
+public typealias Describe = AsyncExampleGroup
+public typealias Context = AsyncExampleGroup
+
+extension AsyncExampleGroup: QuickAsync {
+    public var component: AsyncComponent {
+        .describe(self)
+    }
+}

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -1,30 +1,18 @@
 import Foundation
 import XCTest
 
-#if canImport(Darwin)
-// swiftlint:disable type_name
-@objcMembers
-public class _ExampleBase: NSObject {}
-#else
-public class _ExampleBase: NSObject {}
-// swiftlint:enable type_name
-#endif
-
-public class Example: _ExampleBase {
+public final class Example: ExampleBase {
     /**
         A boolean indicating whether the example is a shared example;
         i.e.: whether it is an example defined with `itBehavesLike`.
     */
     public var isSharedExample = false
 
-    /**
-        The site at which the example is defined.
-        This must be set correctly in order for Xcode to highlight
-        the correct line in red when reporting a failure.
-    */
-    public var callsite: Callsite
-
-    weak internal var group: ExampleGroup?
+    weak internal var group: ExampleGroup? {
+        didSet {
+            resetName()
+        }
+    }
 
     private let internalDescription: String
     private let flags: FilterFlags
@@ -32,9 +20,11 @@ public class Example: _ExampleBase {
 
     internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () throws -> Void) {
         self.internalDescription = description
-        self.callsite = callsite
         self.flags = flags
         self.closure = closure
+        super.init(name: internalDescription, callsite: callsite)
+
+        resetName()
     }
 
     public override var description: String {
@@ -49,9 +39,11 @@ public class Example: _ExampleBase {
         The example name is used to generate a test method selector
         to be displayed in Xcode's test navigator.
     */
-    public var name: String {
-        guard let groupName = group?.name else { return description }
-        return "\(groupName), \(description)"
+    private func resetName() {
+        name = {
+            guard let groupName = group?.name else { return description }
+            return "\(groupName), \(description)"
+        }()
     }
 
     public func run() {
@@ -69,19 +61,13 @@ public class Example: _ExampleBase {
 
         group!.phase = .beforesExecuting
 
-        let runExample: () -> Void = { [closure, name, callsite] in
+        let runExample: () -> Void = { [closure] in
             self.group!.phase = .beforesFinished
 
             do {
                 try closure()
             } catch {
-                if let stopTestError = error as? StopTest {
-                    self.reportStoppedTest(stopTestError)
-                } else if let testSkippedError = error as? XCTSkip {
-                    self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
-                } else {
-                    self.reportFailedTest(error, name: name, callsite: callsite)
-                }
+                self.handleThrownErrorFromTest(error: error)
             }
 
             self.group!.phase = .aftersExecuting
@@ -119,135 +105,6 @@ public class Example: _ExampleBase {
             aggregateFlags[key] = value
         }
         return aggregateFlags
-    }
-
-    #if canImport(Darwin)
-    static internal let recordSkipSelector = NSSelectorFromString("recordSkipWithDescription:sourceCodeContext:")
-    #endif
-
-    internal func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) {
-        #if !canImport(Darwin)
-            return // This functionality is only supported by Apple's proprietary XCTest, not by swift-corelibs-xctest
-        #else // `NSSelectorFromString` requires the Objective-C runtime, which is not available on Linux.
-
-            let messageSuffix = """
-                \n
-                If nobody else has done so yet, please submit an issue to https://github.com/Quick/Quick/issues
-
-                For now, we'll just benignly ignore skipped tests.
-            """
-
-            guard let testRun = QuickSpec.current.testRun else {
-                print("""
-                     [Quick Warning]: `QuickSpec.current.testRun` was unexpectededly `nil`.
-                """ + messageSuffix)
-                return
-            }
-
-            guard let skippedTestContextAny = testSkippedError.errorUserInfo["XCTestErrorUserInfoKeySkippedTestContext"] else {
-                print("""
-                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
-                    We expected the `errorUserInfo` dictionary of the XCTSKip error to contain a value for the key
-                    "XCTestErrorUserInfoKeySkippedTestContext", but it didn't.
-                """ + messageSuffix)
-                return
-            }
-
-            // Uses an internal type "XCTSkippedTestContext", but "NSObject" will be sufficient for `perform(_:with:_with:)`.
-            guard let skippedTestContext = skippedTestContextAny as? NSObject else {
-                print("""
-                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
-                    We expected `skippedTestContextAny` to have type `NSObject`,
-                    but we got an object of type \(type(of: skippedTestContextAny))
-                """ + messageSuffix)
-                return
-            }
-
-            guard let sourceCodeContextAny = skippedTestContext.value(forKey: "sourceCodeContext") else {
-                print("""
-                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
-                    We expected `XCTSkippedTestContext` to have a `sourceCodeContext` property, but it did not.
-                """ + messageSuffix)
-                return
-            }
-
-            guard let sourceCodeContext = sourceCodeContextAny as? XCTSourceCodeContext else {
-                print("""
-                    [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
-                    We expected `XCTSkippedTestContext.sourceCodeContext` to have type `XCTSourceCodeContext`,
-                    but we got an object of type \(type(of: sourceCodeContextAny)).
-                """ + messageSuffix)
-                return
-            }
-
-            guard testRun.responds(to: Self.recordSkipSelector) else {
-                print("""
-                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed, as it no longer responds to
-                    the -[XCTSkip \(NSStringFromSelector(Self.recordSkipSelector))] message necessary to report skipped tests to Xcode.
-                """ + messageSuffix)
-               return
-            }
-
-            testRun.perform(Self.recordSkipSelector, with: testSkippedError.message, with: sourceCodeContext)
-        #endif
-    }
-
-    internal func reportFailedTest(_ error: Error, name: String, callsite: Callsite) {
-        let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
-
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
-            let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
-            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
-            let sourceCodeContext = XCTSourceCodeContext(location: location)
-            let issue = XCTIssue(
-                type: .thrownError,
-                compactDescription: description,
-                sourceCodeContext: sourceCodeContext
-            )
-            QuickSpec.current.record(issue)
-        #else
-            QuickSpec.current.recordFailure(
-                withDescription: description,
-                inFile: file,
-                atLine: Int(callsite.line),
-                expected: false
-            )
-        #endif
-    }
-
-    internal func reportStoppedTest(_ stopTestError: StopTest) {
-        guard stopTestError.reportError else { return }
-
-        let callsite = stopTestError.callsite
-
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
-            let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
-            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
-            let sourceCodeContext = XCTSourceCodeContext(location: location)
-            let issue = XCTIssue(
-                type: .assertionFailure,
-                compactDescription: stopTestError.failureDescription,
-                sourceCodeContext: sourceCodeContext
-            )
-            QuickSpec.current.record(issue)
-        #else
-            QuickSpec.current.recordFailure(
-                withDescription: stopTestError.failureDescription,
-                inFile: file,
-                atLine: Int(callsite.line),
-                expected: true
-            )
-        #endif
     }
 }
 

--- a/Sources/Quick/Examples/ExampleBase.swift
+++ b/Sources/Quick/Examples/ExampleBase.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+// swiftlint:disable type_name
+@objcMembers
+public class _ExampleBase: NSObject {}
+#else
+public class _ExampleBase: NSObject {}
+// swiftlint:enable type_name
+#endif
+
+public class ExampleBase: _ExampleBase {
+    /// The example name.
+    var name: String
+
+    /**
+        The site at which the example is defined.
+        This must be set correctly in order for Xcode to highlight
+        the correct line in red when reporting a failure.
+    */
+    public var callsite: Callsite
+
+    internal init(name: String, callsite: Callsite) {
+        self.name = name
+        self.callsite = callsite
+    }
+
+    internal func handleThrownErrorFromTest(error: Error) {
+        if let stopTestError = error as? StopTest {
+            self.reportStoppedTest(stopTestError)
+        } else if let testSkippedError = error as? XCTSkip {
+            self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
+        } else {
+            self.reportFailedTest(error, name: name, callsite: callsite)
+        }
+    }
+
+#if canImport(Darwin)
+    static internal let recordSkipSelector = NSSelectorFromString("recordSkipWithDescription:sourceCodeContext:")
+#endif
+
+    internal func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) {
+        #if !canImport(Darwin)
+            return // This functionality is only supported by Apple's proprietary XCTest, not by swift-corelibs-xctest
+        #else // `NSSelectorFromString` requires the Objective-C runtime, which is not available on Linux.
+
+            let messageSuffix = """
+                \n
+                If nobody else has done so yet, please submit an issue to https://github.com/Quick/Quick/issues
+
+                For now, we'll just benignly ignore skipped tests.
+            """
+
+            guard let testRun = currentSpec.testRun else {
+                print("""
+                     [Quick Warning]: `AsyncSpec.current.testRun` and `QuickSpec.current.testRun` were unexpectededly `nil`.
+                """ + messageSuffix)
+                return
+            }
+
+            guard let skippedTestContextAny = testSkippedError.errorUserInfo["XCTestErrorUserInfoKeySkippedTestContext"] else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected the `errorUserInfo` dictionary of the XCTSKip error to contain a value for the key
+                    "XCTestErrorUserInfoKeySkippedTestContext", but it didn't.
+                """ + messageSuffix)
+                return
+            }
+
+            // Uses an internal type "XCTSkippedTestContext", but "NSObject" will be sufficient for `perform(_:with:_with:)`.
+            guard let skippedTestContext = skippedTestContextAny as? NSObject else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `skippedTestContextAny` to have type `NSObject`,
+                    but we got an object of type \(type(of: skippedTestContextAny))
+                """ + messageSuffix)
+                return
+            }
+
+            guard let sourceCodeContextAny = skippedTestContext.value(forKey: "sourceCodeContext") else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `XCTSkippedTestContext` to have a `sourceCodeContext` property, but it did not.
+                """ + messageSuffix)
+                return
+            }
+
+            guard let sourceCodeContext = sourceCodeContextAny as? XCTSourceCodeContext else {
+                print("""
+                    [Quick Warning]: The internals of Apple's XCTestCaseRun have changed.
+                    We expected `XCTSkippedTestContext.sourceCodeContext` to have type `XCTSourceCodeContext`,
+                    but we got an object of type \(type(of: sourceCodeContextAny)).
+                """ + messageSuffix)
+                return
+            }
+
+            guard testRun.responds(to: Self.recordSkipSelector) else {
+                print("""
+                [Quick Warning]: The internals of Apple's XCTestCaseRun have changed, as it no longer responds to
+                    the -[XCTSkip \(NSStringFromSelector(Self.recordSkipSelector))] message necessary to report skipped tests to Xcode.
+                """ + messageSuffix)
+               return
+            }
+
+            testRun.perform(Self.recordSkipSelector, with: testSkippedError.message, with: sourceCodeContext)
+        #endif
+    }
+
+    internal func reportFailedTest(_ error: Error, name: String, callsite: Callsite) {
+        let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
+
+        #if SWIFT_PACKAGE
+            let file = callsite.file.description
+        #else
+            let file = callsite.file
+        #endif
+
+        #if !SWIFT_PACKAGE
+            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
+            let sourceCodeContext = XCTSourceCodeContext(location: location)
+            let issue = XCTIssue(
+                type: .thrownError,
+                compactDescription: description,
+                sourceCodeContext: sourceCodeContext
+            )
+            currentSpec.record(issue)
+        #else
+            currentSpec.recordFailure(
+                withDescription: description,
+                inFile: file,
+                atLine: Int(callsite.line),
+                expected: false
+            )
+        #endif
+    }
+
+    internal func reportStoppedTest(_ stopTestError: StopTest) {
+        guard stopTestError.reportError else { return }
+
+        let callsite = stopTestError.callsite
+
+        #if SWIFT_PACKAGE
+            let file = callsite.file.description
+        #else
+            let file = callsite.file
+        #endif
+
+        #if !SWIFT_PACKAGE
+            let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
+            let sourceCodeContext = XCTSourceCodeContext(location: location)
+            let issue = XCTIssue(
+                type: .assertionFailure,
+                compactDescription: stopTestError.failureDescription,
+                sourceCodeContext: sourceCodeContext
+            )
+            currentSpec.record(issue)
+        #else
+            currentSpec.recordFailure(
+                withDescription: stopTestError.failureDescription,
+                inFile: file,
+                atLine: Int(callsite.line),
+                expected: true
+            )
+        #endif
+    }
+
+    private var currentSpec: XCTestCase {
+        AsyncSpec.current ?? QuickSpec.current
+    }
+}

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 /**
     A closure that, when evaluated, returns a dictionary of key-value
@@ -47,6 +48,12 @@ final internal class World: _WorldBase {
     */
 
     internal var currentExampleMetadata: ExampleMetadata?
+
+    /**
+        The current running ``AsyncSpec`` or ``QuickSpec``.
+        Warning: Don't be confused by the return type. This only returns either the current AsyncSpec or QuickSpec.
+     */
+    internal var currentSpec: XCTestCase? { AsyncSpec.current ?? QuickSpec.current }
 
     internal var numberOfExamplesRun = 0
 

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -133,6 +133,7 @@ static QuickSpec *currentSpec = nil;
         self.example = example;
         currentSpec = self;
         [example run];
+        currentSpec = nil;
     });
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncAfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncAfterEachTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Quick
+import Nimble
+
+private enum AfterEachType {
+    case outerOne
+    case outerTwo
+    case outerThree
+    case innerOne
+    case innerTwo
+    case noExamples
+}
+
+private var afterEachOrder = [AfterEachType]()
+
+class FunctionalTests_AsyncAfterEachSpec: AsyncSpec {
+    @AsyncSpecBuilder
+    override class func spec() -> [AsyncExample] {
+        describe("afterEach ordering") {
+            afterEach { afterEachOrder.append(.outerOne) }
+            afterEach { afterEachOrder.append(.outerTwo) }
+            afterEach { afterEachOrder.append(.outerThree) }
+
+            it("1 executes the outer afterEach closures once, but not before this closure") {
+                // No examples have been run, so no afterEach will have been run either.
+                // The list should be empty.
+                expect(afterEachOrder).to(beEmpty())
+            }
+
+            it("2 executes the outer afterEach closures a second time, but not before this closure") {
+                // The afterEach for the previous example should have been run.
+                // The list should contain the afterEach for that example, executed from top to bottom.
+                expect(afterEachOrder).to(equal([.outerOne, .outerTwo, .outerThree]))
+            }
+
+            context("when there are nested afterEach") {
+                afterEach { afterEachOrder.append(.innerOne) }
+                afterEach { afterEachOrder.append(.innerTwo) }
+
+                it("3 executes the outer and inner afterEach closures, but not before this closure") {
+                    // The afterEach for the previous two examples should have been run.
+                    // The list should contain the afterEach for those example, executed from top to bottom.
+                    expect(afterEachOrder).to(equal([
+                        .outerOne, .outerTwo, .outerThree,
+                        .outerOne, .outerTwo, .outerThree,
+                    ]))
+                }
+            }
+
+            context("when there are nested afterEach without examples") {
+                afterEach { afterEachOrder.append(.noExamples) }
+            }
+        }
+    }
+}
+
+final class AsyncAfterEachTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (AsyncAfterEachTests) -> () throws -> Void)] {
+        return [
+            ("testAfterEachIsExecutedInTheCorrectOrder", testAfterEachIsExecutedInTheCorrectOrder),
+        ]
+    }
+
+    func testAfterEachIsExecutedInTheCorrectOrder() {
+        afterEachOrder = []
+
+        runAsyncSpec(FunctionalTests_AsyncAfterEachSpec.self)
+        let expectedOrder: [AfterEachType] = [
+            // [1] The outer afterEach closures are executed from top to bottom.
+            .outerOne, .outerTwo, .outerThree,
+            // [2] The outer afterEach closures are executed from top to bottom.
+            .outerOne, .outerTwo, .outerThree,
+            // [3] The inner afterEach closures are executed from top to bottom,
+            //     then the outer afterEach closures are executed from top to bottom.
+            .innerOne, .innerTwo, .outerOne, .outerTwo, .outerThree,
+        ]
+        XCTAssertEqual(afterEachOrder, expectedOrder)
+
+        afterEachOrder = []
+    }
+}
+

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncBeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncBeforeEachTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import Quick
+import Nimble
+
+private enum BeforeEachType {
+    case outerOne
+    case outerTwo
+    case innerOne
+    case innerTwo
+    case innerThree
+    case noExamples
+}
+
+private var beforeEachOrder = [BeforeEachType]()
+
+class FunctionalTests_AsyncBeforeEachSpec: AsyncSpec {
+    @AsyncSpecBuilder
+    override class func spec() -> [AsyncExample] {
+        describe("beforeEach ordering") {
+            beforeEach { beforeEachOrder.append(.outerOne) }
+            beforeEach { beforeEachOrder.append(.outerTwo) }
+
+            it("executes the outer beforeEach closures once [1]") {}
+            it("executes the outer beforeEach closures a second time [2]") {}
+
+            context("when there are nested beforeEach") {
+                beforeEach { beforeEachOrder.append(.innerOne) }
+                beforeEach { beforeEachOrder.append(.innerTwo) }
+                beforeEach { beforeEachOrder.append(.innerThree) }
+
+                it("executes the outer and inner beforeEach closures [3]") {}
+            }
+
+            context("when there are nested beforeEach without examples") {
+                beforeEach { beforeEachOrder.append(.noExamples) }
+            }
+        }
+    }
+}
+
+class FunctionalTests_AsyncBeforeEach_WithoutOuterDescribe_Spec: AsyncSpec {
+    @AsyncSpecBuilder
+    override class func spec() -> [AsyncExample] {
+        beforeEach { beforeEachOrder.append(.outerOne) }
+        beforeEach { beforeEachOrder.append(.outerTwo) }
+
+        it("executes the outer beforeEach closures once [1]") {}
+        it("executes the outer beforeEach closures a second time [2]") {}
+
+        context("when there are nested beforeEach") {
+            beforeEach { beforeEachOrder.append(.innerOne) }
+            beforeEach { beforeEachOrder.append(.innerTwo) }
+            beforeEach { beforeEachOrder.append(.innerThree) }
+
+            it("executes the outer and inner beforeEach closures [3]") {}
+        }
+
+        context("when there are nested beforeEach without examples") {
+            beforeEach { beforeEachOrder.append(.noExamples) }
+        }
+    }
+}
+
+final class AsyncBeforeEachTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (AsyncBeforeEachTests) -> () throws -> Void)] {
+        return [
+            ("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
+            ("testBeforeEachWithoutOuterDescribeExecutedInTheCorrectOrder", testBeforeEachWithoutOuterDescribeExecutedInTheCorrectOrder),
+        ]
+    }
+
+    func testBeforeEachIsExecutedInTheCorrectOrder() {
+        beforeEachOrder = []
+
+        runAsyncSpec(FunctionalTests_AsyncBeforeEachSpec.self)
+        let expectedOrder: [BeforeEachType] = [
+            // [1] The outer beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo,
+            // [2] The outer beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo,
+            // [3] The outer beforeEach closures are executed from top to bottom,
+            //     then the inner beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo, .innerOne, .innerTwo, .innerThree,
+        ]
+        XCTAssertEqual(beforeEachOrder, expectedOrder)
+    }
+
+    func testBeforeEachWithoutOuterDescribeExecutedInTheCorrectOrder() {
+        beforeEachOrder = []
+
+        runAsyncSpec(FunctionalTests_AsyncBeforeEach_WithoutOuterDescribe_Spec.self)
+        let expectedOrder: [BeforeEachType] = [
+            // [1] The outer beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo,
+            // [2] The outer beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo,
+            // [3] The outer beforeEach closures are executed from top to bottom,
+            //     then the inner beforeEach closures are executed from top to bottom.
+            .outerOne, .outerTwo, .innerOne, .innerTwo, .innerThree,
+        ]
+        XCTAssertEqual(beforeEachOrder, expectedOrder)
+    }
+}
+

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncItTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Nimble
+@testable import Quick
+
+private var isRunningFunctionalTests = false
+
+enum ExampleError: Error {
+    case error
+}
+
+func asyncFunction() async {}
+
+func asyncNonThrowingFunction() async throws {}
+
+func asyncThrowingFunction(shouldThrow: Bool) async throws {
+    if shouldThrow {
+        throw ExampleError.error
+    }
+}
+
+final class FunctionalTests_AsyncItSpec: AsyncSpec {
+    @AsyncSpecBuilder
+    override class func spec() -> [AsyncExample] {
+        describe("async handling") {
+            var beforeEachSet: Bool = false
+            beforeEach {
+                beforeEachSet = true
+            }
+
+            it("listens to beforeEachs") {
+                expect(beforeEachSet).to(beTrue())
+            }
+
+            it("supports calling async, non-throwing functions") {
+                await asyncFunction()
+            }
+
+            it("supports calling async functions marked as throws") {
+                try await asyncNonThrowingFunction()
+            }
+
+            it("supports calling async functions that actually throw") {
+                try await asyncThrowingFunction(shouldThrow: isRunningFunctionalTests)
+            }
+
+            it("defaults to running async tests off of main") {
+                expect(Thread.isMainThread).to(beFalse())
+            }
+
+            it("supports running async tests on main, ish") { @MainActor in
+                expect(Thread.isMainThread).to(beTrue())
+            }
+        }
+    }
+}
+
+final class AsyncItTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (AsyncItTests) -> () throws -> Void)] {
+        return [
+            ("testAsyncExamples", testAsyncExamples),
+        ]
+    }
+
+    override func setUp() {
+        super.setUp()
+        isRunningFunctionalTests = true
+    }
+
+    override func tearDown() {
+        isRunningFunctionalTests = false
+        super.tearDown()
+    }
+
+    func testAsyncExamples() {
+        let result = runAsyncSpec(FunctionalTests_AsyncItSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 6)
+        XCTAssertEqual(result.failureCount, 0)
+        XCTAssertEqual(result.unexpectedExceptionCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 1)
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -158,7 +158,6 @@ final class FunctionalTests_StoppingTestsSpec: QuickSpec {
     }
 }
 
-
 final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [

--- a/Tests/QuickTests/QuickTests/Helpers/AsyncSpecRunner.swift
+++ b/Tests/QuickTests/QuickTests/Helpers/AsyncSpecRunner.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Quick
+
+@discardableResult
+func runAsyncSpec(_ specClass: AsyncSpec.Type) -> XCTestRun? {
+    let suite = XCTestSuite(name: "Testing AsyncSpec")
+    suite.addTest(specClass.defaultTestSuite)
+    return XCTestObservationCenter.shared.qck_suspendObservation {
+        suite.run()
+        return suite.testRun
+    }
+}


### PR DESCRIPTION
This basically serves to reimplement Quick using a ResultBuilder approach. It doesn't integrate with anything else in Quick, and I only provide basic BeforeEach, It (the actual test), AfterEach, as well as example groups.

This should serve as a proof of concept for this approach. I want to test out how this scales before fully committing to it.

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
 - What code was refactored / updated to support this change?
 - What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

