### PR TITLE
Transition QuickSpec.spec to be a static method.

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -1,337 +1,347 @@
 // swiftlint:disable line_length
 
-// MARK: - beforeSuite
-/**
-    Defines a closure to be run prior to any examples in the test suite.
-    You may define an unlimited number of these closures, but there is no
-    guarantee as to the order in which they're run.
+/// A protocol for defining the synchronous DSL usable from Quick synchronous specs.
+public protocol SyncDSLUser {}
 
-    If the test suite crashes before the first example is run, this closure
-    will not be executed.
+extension QuickSpec: SyncDSLUser {}
+extension Behavior: SyncDSLUser {}
+extension QuickConfiguration: SyncDSLUser {}
 
-    - parameter closure: The closure to be run prior to any examples in the test suite.
-*/
-public func beforeSuite(_ closure: @escaping BeforeSuiteClosure) {
-    World.sharedWorld.beforeSuite(closure)
-}
+extension SyncDSLUser {
 
-// MARK: - afterSuite
-/**
-    Defines a closure to be run after all of the examples in the test suite.
-    You may define an unlimited number of these closures, but there is no
-    guarantee as to the order in which they're run.
+    // MARK: - beforeSuite
+    /**
+     Defines a closure to be run prior to any examples in the test suite.
+     You may define an unlimited number of these closures, but there is no
+     guarantee as to the order in which they're run.
 
-    If the test suite crashes before all examples are run, this closure
-    will not be executed.
+     If the test suite crashes before the first example is run, this closure
+     will not be executed.
 
-    - parameter closure: The closure to be run after all of the examples in the test suite.
-*/
-public func afterSuite(_ closure: @escaping AfterSuiteClosure) {
-    World.sharedWorld.afterSuite(closure)
-}
+     - parameter closure: The closure to be run prior to any examples in the test suite.
+     */
+    public static func beforeSuite(_ closure: @escaping BeforeSuiteClosure) {
+        World.sharedWorld.beforeSuite(closure)
+    }
 
-// MARK: - sharedExamples
-/**
-    Defines a group of shared examples. These examples can be re-used in several locations
-    by using the `itBehavesLike` function.
+    // MARK: - afterSuite
+    /**
+     Defines a closure to be run after all of the examples in the test suite.
+     You may define an unlimited number of these closures, but there is no
+     guarantee as to the order in which they're run.
 
-    - parameter name: The name of the shared example group. This must be unique across all shared example
-                 groups defined in a test suite.
-    - parameter closure: A closure containing the examples. This behaves just like an example group defined
-                    using `describe` or `context`--the closure may contain any number of `beforeEach`
-                    and `afterEach` closures, as well as any number of examples (defined using `it`).
-*/
-public func sharedExamples(_ name: String, closure: @escaping () -> Void) {
-    World.sharedWorld.sharedExamples(name) { _ in closure() }
-}
+     If the test suite crashes before all examples are run, this closure
+     will not be executed.
 
-/**
-    Defines a group of shared examples. These examples can be re-used in several locations
-    by using the `itBehavesLike` function.
+     - parameter closure: The closure to be run after all of the examples in the test suite.
+     */
+    public static func afterSuite(_ closure: @escaping AfterSuiteClosure) {
+        World.sharedWorld.afterSuite(closure)
+    }
 
-    - parameter name: The name of the shared example group. This must be unique across all shared example
-                 groups defined in a test suite.
-    - parameter closure: A closure containing the examples. This behaves just like an example group defined
-                    using `describe` or `context`--the closure may contain any number of `beforeEach`
-                    and `afterEach` closures, as well as any number of examples (defined using `it`).
+    // MARK: - sharedExamples
+    /**
+     Defines a group of shared examples. These examples can be re-used in several locations
+     by using the `itBehavesLike` function.
 
-                    The closure takes a SharedExampleContext as an argument. This context is a function
-                    that can be executed to retrieve parameters passed in via an `itBehavesLike` function.
-*/
-public func sharedExamples(_ name: String, closure: @escaping SharedExampleClosure) {
-    World.sharedWorld.sharedExamples(name, closure: closure)
-}
+     - parameter name: The name of the shared example group. This must be unique across all shared example
+     groups defined in a test suite.
+     - parameter closure: A closure containing the examples. This behaves just like an example group defined
+     using `describe` or `context`--the closure may contain any number of `beforeEach`
+     and `afterEach` closures, as well as any number of examples (defined using `it`).
+     */
+    public static func sharedExamples(_ name: String, closure: @escaping () -> Void) {
+        World.sharedWorld.sharedExamples(name) { _ in closure() }
+    }
 
-// MARK: - Example groups
-/**
-    Defines an example group. Example groups are logical groupings of examples.
-    Example groups can share setup and teardown code.
+    /**
+     Defines a group of shared examples. These examples can be re-used in several locations
+     by using the `itBehavesLike` function.
 
-    - parameter description: An arbitrary string describing the example group.
-    - parameter closure: A closure that can contain other examples.
-*/
-public func describe(_ description: String, closure: () -> Void) {
-    World.sharedWorld.describe(description, closure: closure)
-}
+     - parameter name: The name of the shared example group. This must be unique across all shared example
+     groups defined in a test suite.
+     - parameter closure: A closure containing the examples. This behaves just like an example group defined
+     using `describe` or `context`--the closure may contain any number of `beforeEach`
+     and `afterEach` closures, as well as any number of examples (defined using `it`).
 
-/**
-    Defines an example group. Equivalent to `describe`.
-*/
-public func context(_ description: String, closure: () -> Void) {
-    World.sharedWorld.context(description, closure: closure)
-}
+     The closure takes a SharedExampleContext as an argument. This context is a function
+     that can be executed to retrieve parameters passed in via an `itBehavesLike` function.
+     */
+    public static func sharedExamples(_ name: String, closure: @escaping SharedExampleClosure) {
+        World.sharedWorld.sharedExamples(name, closure: closure)
+    }
 
-// MARK: - beforeEach
-/**
-    Defines a closure to be run prior to each example in the current example
-    group. This closure is not run for pending or otherwise disabled examples.
-    An example group may contain an unlimited number of beforeEach. They'll be
-    run in the order they're defined, but you shouldn't rely on that behavior.
+    // MARK: - Example groups
+    /**
+     Defines an example group. Example groups are logical groupings of examples.
+     Example groups can share setup and teardown code.
 
-    - parameter closure: The closure to be run prior to each example.
-*/
-public func beforeEach(_ closure: @escaping BeforeExampleClosure) {
-    World.sharedWorld.beforeEach(closure)
-}
+     - parameter description: An arbitrary string describing the example group.
+     - parameter closure: A closure that can contain other examples.
+     */
+    public static func describe(_ description: String, closure: () -> Void) {
+        World.sharedWorld.describe(description, closure: closure)
+    }
 
-/**
-    Identical to Quick.DSL.beforeEach, except the closure is provided with
-    metadata on the example that the closure is being run prior to.
-*/
-public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
-    World.sharedWorld.beforeEach(closure: closure)
-}
+    /**
+     Defines an example group. Equivalent to `describe`.
+     */
+    public static func context(_ description: String, closure: () -> Void) {
+        World.sharedWorld.context(description, closure: closure)
+    }
 
-// MARK: - AfterEach
-/**
-    Defines a closure to be run after each example in the current example
-    group. This closure is not run for pending or otherwise disabled examples.
-    An example group may contain an unlimited number of afterEach. They'll be
-    run in the order they're defined, but you shouldn't rely on that behavior.
+    // MARK: - beforeEach
+    /**
+     Defines a closure to be run prior to each example in the current example
+     group. This closure is not run for pending or otherwise disabled examples.
+     An example group may contain an unlimited number of beforeEach. They'll be
+     run in the order they're defined, but you shouldn't rely on that behavior.
 
-    - parameter closure: The closure to be run after each example.
-*/
-public func afterEach(_ closure: @escaping AfterExampleClosure) {
-    World.sharedWorld.afterEach(closure)
-}
+     - parameter closure: The closure to be run prior to each example.
+     */
+    public static func beforeEach(_ closure: @escaping BeforeExampleClosure) {
+        World.sharedWorld.beforeEach(closure)
+    }
 
-/**
-    Identical to Quick.DSL.afterEach, except the closure is provided with
-    metadata on the example that the closure is being run after.
-*/
-public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
-    World.sharedWorld.afterEach(closure: closure)
-}
+    /**
+     Identical to Quick.DSL.beforeEach, except the closure is provided with
+     metadata on the example that the closure is being run prior to.
+     */
+    public static func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
+        World.sharedWorld.beforeEach(closure: closure)
+    }
 
-// MARK: - aroundEach
-/**
-    Defines a closure to that wraps each example in the current example
-    group. This closure is not run for pending or otherwise disabled examples.
+    // MARK: - AfterEach
+    /**
+     Defines a closure to be run after each example in the current example
+     group. This closure is not run for pending or otherwise disabled examples.
+     An example group may contain an unlimited number of afterEach. They'll be
+     run in the order they're defined, but you shouldn't rely on that behavior.
 
-    The closure you pass to aroundEach receives a callback as its argument, which
-    it MUST call exactly one for the example to run properly:
+     - parameter closure: The closure to be run after each example.
+     */
+    public static func afterEach(_ closure: @escaping AfterExampleClosure) {
+        World.sharedWorld.afterEach(closure)
+    }
 
-        aroundEach { runExample in
-            doSomeSetup()
-            runExample()
-            doSomeCleanup()
-        }
+    /**
+     Identical to Quick.DSL.afterEach, except the closure is provided with
+     metadata on the example that the closure is being run after.
+     */
+    public static func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
+        World.sharedWorld.afterEach(closure: closure)
+    }
 
-    This callback is particularly useful for test decartions that can’t split
-    into a separate beforeEach and afterEach. For example, running each example
-    in its own autorelease pool (provided by Task) requires aroundEach:
+    // MARK: - aroundEach
+    /**
+     Defines a closure to that wraps each example in the current example
+     group. This closure is not run for pending or otherwise disabled examples.
 
-        aroundEach { runExample in
-            autoreleasepool {
-                runExample()
-            }
-            checkObjectsNoLongerRetained()
-        }
+     The closure you pass to aroundEach receives a callback as its argument, which
+     it MUST call exactly one for the example to run properly:
 
-    You can also use aroundEach to guarantee proper nesting of setup and cleanup
-    operations in situations where their relative order matters.
+     aroundEach { runExample in
+     doSomeSetup()
+     runExample()
+     doSomeCleanup()
+     }
 
-    An example group may contain an unlimited number of aroundEach callbacks.
-    They will nest inside each other, with the first declared in the group
-    nested at the outermost level.
+     This callback is particularly useful for test decartions that can’t split
+     into a separate beforeEach and afterEach. For example, running each example
+     in its own autorelease pool (provided by Task) requires aroundEach:
 
-    - parameter closure: The closure that wraps around each example.
-*/
-public func aroundEach(_ closure: @escaping AroundExampleClosure) {
-    World.sharedWorld.aroundEach(closure)
-}
+     aroundEach { runExample in
+     autoreleasepool {
+     runExample()
+     }
+     checkObjectsNoLongerRetained()
+     }
 
-/**
-    Identical to Quick.DSL.aroundEach, except the closure receives metadata
-    about the example that the closure wraps.
-*/
-public func aroundEach(_ closure: @escaping AroundExampleWithMetadataClosure) {
-    World.sharedWorld.aroundEach(closure)
-}
+     You can also use aroundEach to guarantee proper nesting of setup and cleanup
+     operations in situations where their relative order matters.
 
-// MARK: - Examples
-/**
+     An example group may contain an unlimited number of aroundEach callbacks.
+     They will nest inside each other, with the first declared in the group
+     nested at the outermost level.
+
+     - parameter closure: The closure that wraps around each example.
+     */
+    public static func aroundEach(_ closure: @escaping AroundExampleClosure) {
+        World.sharedWorld.aroundEach(closure)
+    }
+
+    /**
+     Identical to Quick.DSL.aroundEach, except the closure receives metadata
+     about the example that the closure wraps.
+     */
+    public static func aroundEach(_ closure: @escaping AroundExampleWithMetadataClosure) {
+        World.sharedWorld.aroundEach(closure)
+    }
+
+    // MARK: - Examples
+    /**
      Defines a closure to be run prior to each example but after any beforeEach blocks.
      This closure is not run for pending or otherwise disabled examples.
      An example group may contain an unlimited number of justBeforeEach. They'll be
      run in the order they're defined, but you shouldn't rely on that behavior.
 
-    - parameter closure: The closure to be run prior to each example and after any beforeEach blocks
-*/
+     - parameter closure: The closure to be run prior to each example and after any beforeEach blocks
+     */
 
-public func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
-    World.sharedWorld.justBeforeEach(closure)
-}
+    public static func justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+        World.sharedWorld.justBeforeEach(closure)
+    }
 
-/**
-    Defines an example. Examples use assertions to demonstrate how code should
-    behave. These are like "tests" in XCTest.
+    /**
+     Defines an example. Examples use assertions to demonstrate how code should
+     behave. These are like "tests" in XCTest.
 
-    - parameter description: An arbitrary string describing what the example is meant to specify.
-    - parameter closure: A closure that can contain assertions.
-    - parameter file: The absolute path to the file containing the example. A sensible default is provided.
-    - parameter line: The line containing the example. A sensible default is provided.
-*/
-public func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
-    World.sharedWorld.it(description, file: file, line: line, closure: closure)
-}
+     - parameter description: An arbitrary string describing what the example is meant to specify.
+     - parameter closure: A closure that can contain assertions.
+     - parameter file: The absolute path to the file containing the example. A sensible default is provided.
+     - parameter line: The line containing the example. A sensible default is provided.
+     */
+    public static func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+        World.sharedWorld.it(description, file: file, line: line, closure: closure)
+    }
 
-// MARK: - Shared Examples
-/**
-    Inserts the examples defined using a `sharedExamples` function into the current example group.
-    The shared examples are executed at this location, as if they were written out manually.
+    // MARK: - Shared Examples
+    /**
+     Inserts the examples defined using a `sharedExamples` function into the current example group.
+     The shared examples are executed at this location, as if they were written out manually.
 
-    - parameter name: The name of the shared examples group to be executed. This must be identical to the
-                 name of a shared examples group defined using `sharedExamples`. If there are no shared
-                 examples that match the name given, an exception is thrown and the test suite will crash.
-    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
-    - parameter line: The line containing the current example group. A sensible default is provided.
-*/
-public func itBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line) {
-    itBehavesLike(name, file: file, line: line, sharedExampleContext: { return [:] })
-}
+     - parameter name: The name of the shared examples group to be executed. This must be identical to the
+     name of a shared examples group defined using `sharedExamples`. If there are no shared
+     examples that match the name given, an exception is thrown and the test suite will crash.
+     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+     - parameter line: The line containing the current example group. A sensible default is provided.
+     */
+    public static func itBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line) {
+        itBehavesLike(name, file: file, line: line, sharedExampleContext: { return [:] })
+    }
 
-/**
-    Inserts the examples defined using a `sharedExamples` function into the current example group.
-    The shared examples are executed at this location, as if they were written out manually.
-    This function also passes those shared examples a context that can be evaluated to give the shared
-    examples extra information on the subject of the example.
+    /**
+     Inserts the examples defined using a `sharedExamples` function into the current example group.
+     The shared examples are executed at this location, as if they were written out manually.
+     This function also passes those shared examples a context that can be evaluated to give the shared
+     examples extra information on the subject of the example.
 
-    - parameter name: The name of the shared examples group to be executed. This must be identical to the
-                 name of a shared examples group defined using `sharedExamples`. If there are no shared
-                 examples that match the name given, an exception is thrown and the test suite will crash.
-    - parameter sharedExampleContext: A closure that, when evaluated, returns key-value pairs that provide the
-                                 shared examples with extra information on the subject of the example.
-    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
-    - parameter line: The line containing the current example group. A sensible default is provided.
-*/
-public func itBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line, sharedExampleContext: @escaping SharedExampleContext) {
-    World.sharedWorld.itBehavesLike(name, sharedExampleContext: sharedExampleContext, file: file, line: line)
-}
+     - parameter name: The name of the shared examples group to be executed. This must be identical to the
+     name of a shared examples group defined using `sharedExamples`. If there are no shared
+     examples that match the name given, an exception is thrown and the test suite will crash.
+     - parameter sharedExampleContext: A closure that, when evaluated, returns key-value pairs that provide the
+     shared examples with extra information on the subject of the example.
+     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+     - parameter line: The line containing the current example group. A sensible default is provided.
+     */
+    public static func itBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line, sharedExampleContext: @escaping SharedExampleContext) {
+        World.sharedWorld.itBehavesLike(name, sharedExampleContext: sharedExampleContext, file: file, line: line)
+    }
 
-/**
-    Inserts the examples defined using a `Behavior` into the current example group.
-    The shared examples are executed at this location, as if they were written out manually.
-    This function also passes a strongly-typed context that can be evaluated to give the shared examples extra information on the subject of the example.
+    /**
+     Inserts the examples defined using a `Behavior` into the current example group.
+     The shared examples are executed at this location, as if they were written out manually.
+     This function also passes a strongly-typed context that can be evaluated to give the shared examples extra information on the subject of the example.
 
-    - parameter behavior: The type of `Behavior` class defining the example group to be executed.
-    - parameter context: A closure that, when evaluated, returns an instance of `Behavior`'s context type to provide its example group with extra information on the subject of the example.
-    - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
-    - parameter line: The line containing the current example group. A sensible default is provided.
- */
-public func itBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
-    World.sharedWorld.itBehavesLike(behavior, context: context, file: file, line: line)
-}
+     - parameter behavior: The type of `Behavior` class defining the example group to be executed.
+     - parameter context: A closure that, when evaluated, returns an instance of `Behavior`'s context type to provide its example group with extra information on the subject of the example.
+     - parameter file: The absolute path to the file containing the current example group. A sensible default is provided.
+     - parameter line: The line containing the current example group. A sensible default is provided.
+     */
+    public static func itBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+        World.sharedWorld.itBehavesLike(behavior, context: context, file: file, line: line)
+    }
 
-// MARK: - Pending
-/**
-    Defines an example or example group that should not be executed. Use `pending` to temporarily disable
-    examples or groups that should not be run yet.
+    // MARK: - Pending
+    /**
+     Defines an example or example group that should not be executed. Use `pending` to temporarily disable
+     examples or groups that should not be run yet.
 
-    - parameter description: An arbitrary string describing the example or example group.
-    - parameter closure: A closure that will not be evaluated.
-*/
-public func pending(_ description: String, closure: () throws -> Void) {
-    World.sharedWorld.pending(description, closure: closure)
-}
+     - parameter description: An arbitrary string describing the example or example group.
+     - parameter closure: A closure that will not be evaluated.
+     */
+    public static func pending(_ description: String, closure: () throws -> Void) {
+        World.sharedWorld.pending(description, closure: closure)
+    }
 
-// MARK: - Defocused
-/**
-    Use this to quickly mark a `describe` closure as pending.
-    This disables all examples within the closure.
-*/
-public func xdescribe(_ description: String, closure: () -> Void) {
-    World.sharedWorld.xdescribe(description, closure: closure)
-}
+    // MARK: - Defocused
+    /**
+     Use this to quickly mark a `describe` closure as pending.
+     This disables all examples within the closure.
+     */
+    public static func xdescribe(_ description: String, closure: () -> Void) {
+        World.sharedWorld.xdescribe(description, closure: closure)
+    }
 
-/**
-    Use this to quickly mark a `context` closure as pending.
-    This disables all examples within the closure.
-*/
-public func xcontext(_ description: String, closure: () -> Void) {
-    xdescribe(description, closure: closure)
-}
+    /**
+     Use this to quickly mark a `context` closure as pending.
+     This disables all examples within the closure.
+     */
+    public static func xcontext(_ description: String, closure: () -> Void) {
+        xdescribe(description, closure: closure)
+    }
 
-/**
-    Use this to quickly mark an `it` closure as pending.
-    This disables the example and ensures the code within the closure is never run.
-*/
-public func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
-    World.sharedWorld.xit(description, file: file, line: line, closure: closure)
-}
+    /**
+     Use this to quickly mark an `it` closure as pending.
+     This disables the example and ensures the code within the closure is never run.
+     */
+    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+        World.sharedWorld.xit(description, file: file, line: line, closure: closure)
+    }
 
-/**
-    Use this to quickly mark an `itBehavesLike` closure as pending.
-    This disables the example group defined by this behavior and ensures the code within is never run.
-*/
-public func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
-    World.sharedWorld.xitBehavesLike(behavior, context: context, file: file, line: line)
-}
+    /**
+     Use this to quickly mark an `itBehavesLike` closure as pending.
+     This disables the example group defined by this behavior and ensures the code within is never run.
+     */
+    public static func xitBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+        World.sharedWorld.xitBehavesLike(behavior, context: context, file: file, line: line)
+    }
 
-// MARK: - Focused
-/**
-    Use this to quickly focus a `describe` closure, focusing the examples in the closure.
-    If any examples in the test suite are focused, only those examples are executed.
-    This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
-*/
-public func fdescribe(_ description: String, closure: () -> Void) {
-    World.sharedWorld.fdescribe(description, closure: closure)
-}
+    // MARK: - Focused
+    /**
+     Use this to quickly focus a `describe` closure, focusing the examples in the closure.
+     If any examples in the test suite are focused, only those examples are executed.
+     This trumps any explicitly focused or unfocused examples within the closure--they are all treated as focused.
+     */
+    public static func fdescribe(_ description: String, closure: () -> Void) {
+        World.sharedWorld.fdescribe(description, closure: closure)
+    }
 
-/**
-    Use this to quickly focus a `context` closure. Equivalent to `fdescribe`.
-*/
-public func fcontext(_ description: String, closure: () -> Void) {
-    fdescribe(description, closure: closure)
-}
+    /**
+     Use this to quickly focus a `context` closure. Equivalent to `fdescribe`.
+     */
+    public static func fcontext(_ description: String, closure: () -> Void) {
+        fdescribe(description, closure: closure)
+    }
 
-/**
-    Use this to quickly focus an `it` closure, focusing the example.
-    If any examples in the test suite are focused, only those examples are executed.
-*/
-public func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
-    World.sharedWorld.fit(description, file: file, line: line, closure: closure)
-}
+    /**
+     Use this to quickly focus an `it` closure, focusing the example.
+     If any examples in the test suite are focused, only those examples are executed.
+     */
+    public static func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+        World.sharedWorld.fit(description, file: file, line: line, closure: closure)
+    }
 
-/**
-    Use this to quickly focus an `itBehavesLike` closure.
-*/
-public func fitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line) {
-    fitBehavesLike(name, file: file, line: line, sharedExampleContext: { return [:] })
-}
+    /**
+     Use this to quickly focus an `itBehavesLike` closure.
+     */
+    public static func fitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line) {
+        fitBehavesLike(name, file: file, line: line, sharedExampleContext: { return [:] })
+    }
 
-/**
-    Use this to quickly focus an `itBehavesLike` closure.
-*/
-public func fitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line, sharedExampleContext: @escaping SharedExampleContext) {
-    World.sharedWorld.fitBehavesLike(name, sharedExampleContext: sharedExampleContext, file: file, line: line)
-}
+    /**
+     Use this to quickly focus an `itBehavesLike` closure.
+     */
+    public static func fitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line, sharedExampleContext: @escaping SharedExampleContext) {
+        World.sharedWorld.fitBehavesLike(name, sharedExampleContext: sharedExampleContext, file: file, line: line)
+    }
 
-/**
- Use this to quickly focus on `itBehavesLike` closure.
- */
-public func fitBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
-    World.sharedWorld.fitBehavesLike(behavior, context: context, file: file, line: line)
+    /**
+     Use this to quickly focus on `itBehavesLike` closure.
+     */
+    public static func fitBehavesLike<C>(_ behavior: Behavior<C>.Type, file: FileString = #file, line: UInt = #line, context: @escaping () -> C) {
+        World.sharedWorld.fitBehavesLike(behavior, context: context, file: file, line: line)
+    }
 }
 
 // swiftlint:enable line_length

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -24,20 +24,9 @@ open class QuickSpec: QuickSpecBase {
         }
     }
 
-    open func spec() {}
+    open class func spec() {}
 
-#if !canImport(Darwin)
-    public required init() {
-        super.init(name: "", testClosure: { _ in })
-    }
-    public required init(name: String, testClosure: @escaping (XCTestCase) throws -> Swift.Void) {
-        super.init(name: name, testClosure: testClosure)
-    }
-#else
-    public required override init() {
-        super.init()
-    }
-
+#if canImport(Darwin)
     /// This method is used as a hook for the following two purposes
     ///
     /// 1. Performing all configurations
@@ -109,6 +98,14 @@ open class QuickSpec: QuickSpecBase {
 #endif
 
 #if !canImport(Darwin)
+    public required init() {
+        super.init(name: "", testClosure: { _ in })
+    }
+
+    public required init(name: String, testClosure: @escaping (XCTestCase) throws -> Swift.Void) {
+        super.init(name: name, testClosure: testClosure)
+    }
+
     public class var allTests: [(String, (QuickSpec) -> () throws -> Void)] {
         gatherExamplesIfNeeded()
 
@@ -133,7 +130,7 @@ open class QuickSpec: QuickSpecBase {
         }
 
         world.performWithCurrentExampleGroup(rootExampleGroup) {
-            self.init().spec()
+            self.spec()
         }
     }
 

--- a/Sources/Quick/TestState.swift
+++ b/Sources/Quick/TestState.swift
@@ -14,7 +14,7 @@ public struct TestState<T> {
 
     /// Resets the property to nil after each test.
     public init() {
-        afterEach { [container] in
+        QuickSpec.afterEach { [container] in
             container.value = nil
         }
     }
@@ -22,7 +22,7 @@ public struct TestState<T> {
     /// Sets the property to an initial value before each test and resets it to nil after each test.
     /// - Parameter initialValue: An autoclosure to return the initial value to use before the test.
     public init(_ initialValue: @escaping @autoclosure () -> T) {
-        aroundEach { [container] runExample in
+        QuickSpec.aroundEach { [container] runExample in
             container.value = initialValue()
             runExample()
             container.value = nil

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -134,7 +134,7 @@ final internal class World: _WorldBase {
         top level of a -[QuickSpec spec] method--it's thanks to this group that
         users can define beforeEach and it closures at the top level, like so:
 
-            override func spec() {
+            override class func spec() {
                 // These belong to the root example group
                 beforeEach {}
                 it("is at the top level") {}

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -35,7 +35,7 @@
 #define QuickSpecBegin(name) \
     @interface name : QuickSpec; @end \
     @implementation name \
-    - (void)spec { \
+    + (void)spec { \
 
 
 /**

--- a/Sources/QuickObjectiveC/QuickSpec.h
+++ b/Sources/QuickObjectiveC/QuickSpec.h
@@ -34,7 +34,7 @@
  and examples.
 
  @code
- override func spec() {
+ override class func spec() {
      describe("winter") {
          it("is coming") {
              // ...
@@ -45,7 +45,7 @@
 
  See DSL.swift for more information on what syntax is available.
  */
-- (void)spec;
++ (void)spec;
 
 /**
  Returns the currently executing spec. Use in specs that require XCTestCase

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -66,7 +66,7 @@ static QuickSpec *currentSpec = nil;
 
 #pragma mark - Public Interface
 
-- (void)spec { }
++ (void)spec { }
 
 + (QuickSpec*) current {
     return currentSpec;
@@ -91,10 +91,8 @@ static QuickSpec *currentSpec = nil;
 
     ExampleGroup *rootExampleGroup = [world rootExampleGroupForSpecClass:[self class]];
     [world performWithCurrentExampleGroup:rootExampleGroup closure:^{
-        QuickSpec *spec = [self new];
-
         @try {
-            [spec spec];
+            [self spec];
         }
         @catch (NSException *exception) {
             [NSException raise:NSInternalInconsistencyException

--- a/Tests/QuickIssue853RegressionTests/SubclassOfSubclassWithStructPropertyTests.swift
+++ b/Tests/QuickIssue853RegressionTests/SubclassOfSubclassWithStructPropertyTests.swift
@@ -8,13 +8,13 @@ import Quick
 class SubclassOfSubclassWithStructPropertySpec: SubclassSpec {
     let date = Date()
 
-    override func spec() {
+    override class func spec() {
         it("should not crash") {}
     }
 }
 
 class SubclassSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("should not crash") {}
     }
 }

--- a/Tests/QuickTests/QuickAfterSuiteTests/AfterSuiteTests.swift
+++ b/Tests/QuickTests/QuickAfterSuiteTests/AfterSuiteTests.swift
@@ -6,7 +6,7 @@ var afterSuiteFirstTestExecuted = false
 var afterSuiteTestsWasExecuted = false
 
 class AfterSuiteTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         afterSuite {
             afterSuiteTestsWasExecuted = true
         }

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -26,7 +26,7 @@ class FunctionalTests_FocusedSpec_Behavior: Behavior<Void> {
 // `specs` array).
 
 class _FunctionalTests_FocusedSpec_Focused: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("has an unfocused example that fails, but is never run") { fail() }
         fit("has a focused example that passes (1)") {}
 
@@ -41,7 +41,7 @@ class _FunctionalTests_FocusedSpec_Focused: QuickSpec {
 }
 
 class _FunctionalTests_FocusedSpec_Unfocused: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("has an unfocused example that fails, but is never run") { fail() }
 
         describe("an unfocused example group that is never run") {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -14,7 +14,7 @@ private enum AfterEachType {
 private var afterEachOrder = [AfterEachType]()
 
 class FunctionalTests_AfterEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("afterEach ordering") {
             afterEach { afterEachOrder.append(.outerOne) }
             afterEach { afterEachOrder.append(.outerTwo) }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AroundEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AroundEachTests.swift
@@ -22,7 +22,7 @@ private enum AroundEachType {
 private var aroundEachOrder = [AroundEachType]()
 
 class FunctionalTests_AroundEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("aroundEach ordering") {
             beforeEach { aroundEachOrder.append(.before0) }
             afterEach { aroundEachOrder.append(.after0) }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -14,7 +14,7 @@ private enum BeforeEachType {
 private var beforeEachOrder = [BeforeEachType]()
 
 class FunctionalTests_BeforeEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("beforeEach ordering") {
             beforeEach { beforeEachOrder.append(.outerOne) }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeSuiteTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeSuiteTests.swift
@@ -5,7 +5,7 @@ import Nimble
 var beforeSuiteWasExecuted = false
 
 class FunctionalTests_BeforeSuite_BeforeSuiteSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         beforeSuite {
             beforeSuiteWasExecuted = true
         }
@@ -13,7 +13,7 @@ class FunctionalTests_BeforeSuite_BeforeSuiteSpec: QuickSpec {
 }
 
 class FunctionalTests_BeforeSuite_Spec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("is executed after beforeSuite") {
             expect(beforeSuiteWasExecuted).to(beTruthy())
         }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BehaviorTests.swift
@@ -4,13 +4,13 @@ import Nimble
 import XCTest
 
 class FunctionalTests_BehaviorTests_Spec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         itBehavesLike(FunctionalTests_BehaviorTests_Behavior2.self) { () -> Void in }
     }
 }
 
 class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         itBehavesLike(FunctionalTests_BehaviorTests_Behavior.self) {
             "BehaviorSpec"
         }
@@ -19,7 +19,7 @@ class FunctionalTests_BehaviorTests_ContextSpec: QuickSpec {
 
 #if canImport(Darwin) && !SWIFT_PACKAGE
 class FunctionalTests_BehaviorTests_ErrorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("error handling when misusing ordering") {
             it("should throw an exception when including itBehavesLike in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Nimble
 
 class BundleModuleNameSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Bundle module name") {
             it("should repalce invalid characters with underscores") {
                 let bundle = Bundle.currentTestBundle

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachTests.swift
@@ -3,7 +3,7 @@ import Quick
 import Nimble
 
 class Configuration_AfterEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         beforeEach {
             FunctionalTests_Configuration_AfterEachWasExecuted = false
         }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachTests.swift
@@ -3,7 +3,7 @@ import Quick
 import Nimble
 
 class Configuration_BeforeEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("is executed after the configuration beforeEach") {
             expect(FunctionalTests_Configuration_BeforeEachWasExecuted).to(beTruthy())
         }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ContextTests.swift
@@ -4,7 +4,7 @@ import Nimble
 
 #if canImport(Darwin) && !SWIFT_PACKAGE
 class QuickContextTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Context") {
             it("should throw an exception if used in an it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/CrossReferencingSpecs.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/CrossReferencingSpecs.swift
@@ -5,14 +5,14 @@ import Nimble
 // references another spec class during its spec setup.
 
 class FunctionalTests_CrossReferencingSpecA: QuickSpec {
-    override func spec() {
+    override class func spec() {
         _ = FunctionalTests_CrossReferencingSpecB()
         it("does not crash") {}
     }
 }
 
 class FunctionalTests_CrossReferencingSpecB: QuickSpec {
-    override func spec() {
+    override class func spec() {
         _ = FunctionalTests_CrossReferencingSpecA()
         it("does not crash") {}
     }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/CurrentSpecTests.swift
@@ -3,7 +3,7 @@ import Nimble
 import Dispatch
 
 class CurrentSpecTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("returns the currently executing spec") {
             let name: String = {
                 let result = QuickSpec.current.name

--- a/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/DescribeTests.swift
@@ -12,12 +12,12 @@ final class DescribeTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testDescribeThrowsIfUsedOutsideOfQuickSpec() {
-        expect { describe("this should throw an exception", closure: {}) }.to(raiseException())
+        expect { QuickSpec.describe("this should throw an exception", closure: {}) }.to(raiseException())
     }
 }
 
 class QuickDescribeTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Describe") {
             it("should throw an exception if used in an it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class FunctionalTests_ItSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var exampleMetadata: ExampleMetadata?
         beforeEach { metadata in exampleMetadata = metadata }
 
@@ -114,7 +114,7 @@ class FunctionalTests_ItSpec: QuickSpec {
 private var isRunningFunctionalTests = false
 
 class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("implicit error handling") {
             enum ExampleError: Error {
                 case error
@@ -140,14 +140,14 @@ class FunctionalTests_ImplicitErrorItSpec: QuickSpec {
 }
 
 final class FunctionalTests_SkippingTestsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("supports skipping tests") { throw XCTSkip("This test is intentionally skipped") }
         it("supports not skipping tests") { }
     }
 }
 
 final class FunctionalTests_StoppingTestsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("supports silently stopping tests") { throw StopTest.silently }
         it("supports stopping tests with expected errors") {
             if isRunningFunctionalTests {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/JustBeforeEachTests.swift
@@ -8,11 +8,11 @@ class FunctionalTests_JustBeforeEachSpec: QuickSpec {
         case Failure
     }
 
-    func apiCall(someArgument: Bool) -> ApiResponse {
+    class func apiCall(someArgument: Bool) -> ApiResponse {
         return someArgument ? ApiResponse.Success : ApiResponse.Failure
     }
 
-    override func spec() {
+    override class func spec() {
         describe("justBeforeEach") {
             var someArgument: Bool!
             var apiResponse: ApiResponse!

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -13,7 +13,7 @@ class FunctionalTests_PendingSpec_Behavior: Behavior<Void> {
     }
 }
 class FunctionalTests_PendingSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         xit("an example that will not run") {
             expect(true).to(beFalsy())
         }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/QuickSpec_SelectedTests.swift
@@ -13,7 +13,7 @@ class SimulateSelectedTests_TestCase: QuickSpec {
         return .init(name: "Selected tests")
     }
 
-    override func spec() {
+    override class func spec() {
         it("example1") { }
         it("example2") { }
         it("example3") { }
@@ -21,7 +21,7 @@ class SimulateSelectedTests_TestCase: QuickSpec {
 }
 
 class SimulateAllTests_TestCase: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("example1") { }
         it("example2") { }
         it("example3") { }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamples+BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamples+BeforeEachTests.swift
@@ -17,7 +17,7 @@ class FunctionalTests_SharedExamples_BeforeEachTests_SharedExamples: QuickConfig
 }
 
 class FunctionalTests_SharedExamples_BeforeEachSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         beforeEach { specBeforeEachExecutedCount += 1 }
         it("executes the spec beforeEach once") {}
         itBehavesLike("a group of three shared examples with a beforeEach")

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SharedExamplesTests.swift
@@ -4,20 +4,20 @@ import Quick
 import Nimble
 
 class FunctionalTests_SharedExamples_Spec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         itBehavesLike("a group of three shared examples")
     }
 }
 
 class FunctionalTests_SharedExamples_ContextSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         itBehavesLike("shared examples that take a context") { ["callsite": "SharedExamplesSpec"] }
     }
 }
 
 #if canImport(Darwin) && !SWIFT_PACKAGE
 class FunctionalTests_SharedExamples_ErrorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("error handling when misusing ordering") {
             it("should throw an exception when including itBehavesLike in it block") {
                 expect {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/SubclassDetectionSpec.swift
@@ -9,7 +9,7 @@ private class C: B {}
 private class D {}
 
 final class SubclassDetectionSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("detecting if a given class is a subclass of another") {
             it("detects when a class is an immediate subclass of another") {
                 expect(isClass(B.self, aSubclassOf: A.self)).to(beTrue())

--- a/Tests/QuickTests/QuickTests/FunctionalTests/TestStateSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/TestStateSpec.swift
@@ -2,7 +2,7 @@ import Quick
 import Nimble
 
 class FunctionalTests_TestStateSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("testState without initial value") {
             @TestState var testState: Int!
 


### PR DESCRIPTION
Cherry-Picked out of https://github.com/Quick/Quick/pull/1199. That PR still needs more work, but I think making QuickSpec.spec be a static method would be a good idea.

This is definitely related to seeing the [new changes to ResultBuilder](https://forums.swift.org/t/improved-result-builder-implementation-in-swift-5-8/63192) getting publicized and wanting to see if having AsyncSpec be based on ResultBuilder is actually worthwhile now.

> Objective-C users (particularly those who use the QuickSpecBegin/QuickSpecEnd macros) have the easiest migration path: they don't have to do anything. Others will need to apply a regex (swift: s/override func spec/override class func spec/; Obj-c: s/- spec/+ spec/). Assuming this approach survives a more thorough investigation, future work would be to provide an easy way to make this migration in as few steps as possible. Unfortunately, any instance methods spec helpers that people use will need to be migrated to be class methods, and I don't think we'll be able to catch any of these.

---

Migrate the DSL to be static methods on a protocol implemented by QuickSpec & related. This should make the future AsyncSpec changes much better.

