### PR TITLE
Demangle QuickSpec test names as much as possible

### DIFF
--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -209,6 +209,9 @@
 		89D2C675284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
 		89D2C676284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
 		89D2C677284DA77D004B108C /* SubclassDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C674284DA77D004B108C /* SubclassDetection.swift */; };
+		89E3F80E29F5AA8A00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */; };
+		89E3F80F29F5AA8B00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */; };
+		89E3F81029F5AA8C00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */; };
 		89E8E59B290045AE003B08F0 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8E59A290045AE003B08F0 /* Example.swift */; };
 		89E8E59C290045AE003B08F0 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8E59A290045AE003B08F0 /* Example.swift */; };
 		89E8E59D290045AE003B08F0 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8E59A290045AE003B08F0 /* Example.swift */; };
@@ -482,6 +485,7 @@
 		89A7919D28139D0900D99622 /* Quick.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Quick.podspec; sourceTree = "<group>"; };
 		89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetectionSpec.swift; sourceTree = "<group>"; };
 		89D2C674284DA77D004B108C /* SubclassDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetection.swift; sourceTree = "<group>"; };
+		89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AsyncSpec+testMethodSelectors.m"; sourceTree = "<group>"; };
 		89E8E59A290045AE003B08F0 /* Example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example.swift; sourceTree = "<group>"; };
 		8D010A561C11726F00633E2B /* DescribeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DescribeTests.swift; sourceTree = "<group>"; };
 		AED9C8621CC8A7BD00432F62 /* CrossReferencingSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrossReferencingSpecs.swift; sourceTree = "<group>"; };
@@ -722,6 +726,7 @@
 				34F375A419515CA700CE1B99 /* QuickSpec.h */,
 				34F375A519515CA700CE1B99 /* QuickSpec.m */,
 				CE57CEDC1C430BD200D63004 /* XCTestSuite+QuickTestSuiteBuilder.m */,
+				89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */,
 			);
 			name = QuickObjectiveC;
 			path = Sources/QuickObjectiveC;
@@ -1521,6 +1526,7 @@
 				1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */,
 				CE175D501E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				CE590E1F1C431FE400253D19 /* QuickTestSuite.swift in Sources */,
+				89E3F81029F5AA8C00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */,
 				1F118D091BDCA536005013A2 /* QuickSpec.m in Sources */,
 				1E4441CE2988A418009AE584 /* AsyncExampleHooks.swift in Sources */,
 				1E4441DC2988A422009AE584 /* AsyncSpec.swift in Sources */,
@@ -1638,6 +1644,7 @@
 				DA408BE519FF5599005DF92A /* ExampleHooks.swift in Sources */,
 				CE175D4F1E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				CE590E1A1C431FE300253D19 /* QuickTestSuite.swift in Sources */,
+				89E3F80F29F5AA8B00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */,
 				DA3124E719FCAEE8002858A7 /* DSL.swift in Sources */,
 				1E4441CD2988A417009AE584 /* AsyncExampleHooks.swift in Sources */,
 				1E4441D52988A421009AE584 /* AsyncSpec.swift in Sources */,
@@ -1805,6 +1812,7 @@
 				DA3124EC19FCAEE8002858A7 /* World+DSL.swift in Sources */,
 				1E4441822988A36D009AE584 /* AsyncWorld+DSL.swift in Sources */,
 				DA408BE419FF5599005DF92A /* ExampleHooks.swift in Sources */,
+				89E3F80E29F5AA8A00EA7370 /* AsyncSpec+testMethodSelectors.m in Sources */,
 				1E4441862988A3A4009AE584 /* AsyncExampleHooks.swift in Sources */,
 				CE175D4E1E8D6B4900EB5E84 /* Behavior.swift in Sources */,
 				DA3124E619FCAEE8002858A7 /* DSL.swift in Sources */,

--- a/Sources/Quick/Async/AsyncExampleGroup.swift
+++ b/Sources/Quick/Async/AsyncExampleGroup.swift
@@ -97,4 +97,3 @@ final public class AsyncExampleGroup: CustomStringConvertible {
         }
     }
 }
-

--- a/Sources/Quick/Async/AsyncSpec.swift
+++ b/Sources/Quick/Async/AsyncSpec.swift
@@ -76,6 +76,9 @@ open class AsyncSpec: XCTestCase {
         }
         let implementation = imp_implementationWithBlock(block as Any)
 
+        // The Objc version of QuickSpec can override `testInvocations`, allowing it to
+        // omit the leading "test ". Unfortunately, there's not a similar API available
+        // to Swift. So the compromise is this.
         let originalName = "test \(example.name)"
         var selectorName = originalName
         var index: UInt = 2
@@ -93,6 +96,7 @@ open class AsyncSpec: XCTestCase {
         return selector
     }
 #endif // canImport(Darwin)
+
 #if !canImport(Darwin)
     public required init() {
         super.init(name: "", testClosure: { _ in })

--- a/Sources/Quick/Async/AsyncWorld.swift
+++ b/Sources/Quick/Async/AsyncWorld.swift
@@ -219,4 +219,3 @@ final internal class AsyncWorld: _WorldBase {
         }
     }
 }
-

--- a/Sources/Quick/DSL/AsyncDSL.swift
+++ b/Sources/Quick/DSL/AsyncDSL.swift
@@ -269,4 +269,3 @@ extension AsyncDSLUser {
 }
 
 // swiftlint:enable line_length
-

--- a/Sources/Quick/DSL/AsyncWorld+DSL.swift
+++ b/Sources/Quick/DSL/AsyncWorld+DSL.swift
@@ -157,4 +157,3 @@ extension AsyncWorld {
         return "it"
     }
 }
-

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -11,7 +11,9 @@ public class _ExampleBase: NSObject {}
 #endif
 
 /**
-    The common superclass of both Example and AsyncExample. This is mostly used for determining filtering (focusing or pending) and other cases where we want to apply something to any kind of example.
+    The common superclass of both Example and AsyncExample. This is mostly used for
+    determining filtering (focusing or pending) and other cases where we want to apply
+    something to any kind of example.
  */
 public class ExampleBase: _ExampleBase {
     /**

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -163,4 +163,3 @@ open class QuickSpec: QuickSpecBase {
 }
 
 #endif
-

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -80,12 +80,15 @@ open class QuickSpec: QuickSpecBase {
         }
         let implementation = imp_implementationWithBlock(block as Any)
 
-        let originalName = example.name.c99ExtendedIdentifier
+        // The Objc version of QuickSpec can override `testInvocations`, allowing it to
+        // omit the leading "test ". Unfortunately, there's not a similar API available
+        // to Swift. So the compromise is this.
+        let originalName = "test \(example.name)"
         var selectorName = originalName
         var index: UInt = 2
 
         while selectorNames.contains(selectorName) {
-            selectorName = String(format: "%@_%tu", originalName, index)
+            selectorName = String(format: "%@ (%tu)", originalName, index)
             index += 1
         }
 
@@ -96,7 +99,7 @@ open class QuickSpec: QuickSpecBase {
 
         return selector
     }
-#endif
+#endif // canImport(Darwin)
 
 #if !canImport(Darwin)
     public required init() {

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -80,10 +80,7 @@ open class QuickSpec: QuickSpecBase {
         }
         let implementation = imp_implementationWithBlock(block as Any)
 
-        // The Objc version of QuickSpec can override `testInvocations`, allowing it to
-        // omit the leading "test ". Unfortunately, there's not a similar API available
-        // to Swift. So the compromise is this.
-        let originalName = "test \(example.name)"
+        let originalName = example.name
         var selectorName = originalName
         var index: UInt = 2
 

--- a/Sources/QuickObjectiveC/AsyncSpec+testMethodSelectors.m
+++ b/Sources/QuickObjectiveC/AsyncSpec+testMethodSelectors.m
@@ -1,0 +1,28 @@
+#if __has_include("Quick-Swift.h")
+#import "Quick-Swift.h"
+#else
+#import <Quick/Quick-Swift.h>
+#endif
+
+@interface AsyncSpec (testMethodSelectors)
+@end
+
+@implementation AsyncSpec (testMethodSelectors)
+
++ (NSArray<NSInvocation *> *)testInvocations {
+    NSArray<NSString *> *selectors = [self darwinXCTestMethodSelectors];
+    NSMutableArray<NSInvocation *> *invocations = [NSMutableArray arrayWithCapacity:selectors.count];
+
+    for (NSString *selectorString in selectors) {
+        SEL selector = NSSelectorFromString(selectorString);
+        NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.selector = selector;
+
+        [invocations addObject:invocation];
+    }
+
+    return invocations;
+}
+
+@end

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -108,8 +108,6 @@ static QuickSpec *currentSpec = nil;
     }];
 }
 
-- (void)example_thing:(void (^)(void))completionHandler {}
-
 /**
  QuickSpec uses this method to dynamically define a new instance method for the
  given example. The instance method runs the example, catching any exceptions.
@@ -136,12 +134,20 @@ static QuickSpec *currentSpec = nil;
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];
 
-    NSString *originalName = [QCKObjCStringUtils c99ExtendedIdentifierFrom:example.name];
+    // Unlike the Swift version of QuickSpec (and AsyncSpec), because the Objc version
+    // of QuickSpec can override `testInvocations`, we don't need to rely on XCTest
+    // using the "all methods that start with 'test'" heuristic to determine which
+    // methods to call when running a test.
+    // Meaning that cocoapods, carthage, et. al. get a slightly cleaner test list
+    // while SPM has to prepend 'test' to all the created tests.
+    // This is only a thing on apple platforms - platforms using the open source
+    // version of XCTest don't have this issue.
+    NSString *originalName = example.name;
     NSString *selectorName = originalName;
     NSUInteger i = 2;
 
     while ([selectorNames containsObject:selectorName]) {
-        selectorName = [NSString stringWithFormat:@"%@_%tu", originalName, i++];
+        selectorName = [NSString stringWithFormat:@"%@ (%tu)", originalName, i++];
     }
 
     [selectorNames addObject:selectorName];

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -134,14 +134,6 @@ static QuickSpec *currentSpec = nil;
 
     const char *types = [[NSString stringWithFormat:@"%s%s%s", @encode(void), @encode(id), @encode(SEL)] UTF8String];
 
-    // Unlike the Swift version of QuickSpec (and AsyncSpec), because the Objc version
-    // of QuickSpec can override `testInvocations`, we don't need to rely on XCTest
-    // using the "all methods that start with 'test'" heuristic to determine which
-    // methods to call when running a test.
-    // Meaning that cocoapods, carthage, et. al. get a slightly cleaner test list
-    // while SPM has to prepend 'test' to all the created tests.
-    // This is only a thing on apple platforms - platforms using the open source
-    // version of XCTest don't have this issue.
     NSString *originalName = example.name;
     NSString *selectorName = originalName;
     NSUInteger i = 2;

--- a/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_AsyncBehaviorTests_AsyncBehaviors.swift
+++ b/Tests/QuickTests/QuickTests/Fixtures/FunctionalTests_AsyncBehaviorTests_AsyncBehaviors.swift
@@ -18,4 +18,3 @@ class FunctionalTests_AsyncBehaviorTests_AsyncBehavior2: AsyncBehavior<Void> {
         it("passes three times") { expect(true).to(beTruthy()) }
     }
 }
-

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/ItAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/ItAsyncTests.swift
@@ -22,7 +22,7 @@ class FunctionalTests_AsyncItSpec: AsyncSpec {
 
             beforeEach {
                 allSelectors = FunctionalTests_AsyncItSpec.allSelectors()
-                    .filter { $0.hasPrefix("test when an example has a unique name, ") }
+                    .filter { $0.hasPrefix("when an example has a unique name, ") }
                     .sorted(by: <)
             }
 
@@ -30,8 +30,8 @@ class FunctionalTests_AsyncItSpec: AsyncSpec {
 
             it("doesn't add multiple selectors for it") {
                 expect(allSelectors) == [
-                    "test when an example has a unique name, doesn't add multiple selectors for it",
-                    "test when an example has a unique name, has a unique name",
+                    "when an example has a unique name, doesn't add multiple selectors for it",
+                    "when an example has a unique name, has a unique name",
                 ]
             }
         }
@@ -41,7 +41,7 @@ class FunctionalTests_AsyncItSpec: AsyncSpec {
 
             beforeEach {
                 allSelectors = FunctionalTests_AsyncItSpec.allSelectors()
-                    .filter { $0.hasPrefix("test when two examples have the exact name, ") }
+                    .filter { $0.hasPrefix("when two examples have the exact name, ") }
                     .sorted(by: <)
             }
 
@@ -50,9 +50,9 @@ class FunctionalTests_AsyncItSpec: AsyncSpec {
 
             it("makes a unique name for each of the above") {
                 expect(allSelectors) == [
-                    "test when two examples have the exact name, has exactly the same name",
-                    "test when two examples have the exact name, has exactly the same name (2)",
-                    "test when two examples have the exact name, makes a unique name for each of the above",
+                    "when two examples have the exact name, has exactly the same name",
+                    "when two examples have the exact name, has exactly the same name (2)",
+                    "when two examples have the exact name, makes a unique name for each of the above",
                 ]
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/ItAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/ItAsyncTests.swift
@@ -158,7 +158,6 @@ final class FunctionalTests_StoppingTestsAsyncSpec: AsyncSpec {
     }
 }
 
-
 final class AsyncItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (AsyncItTests) -> () throws -> Void)] {
         return [

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -23,15 +23,6 @@ class FunctionalTests_ItSpec: QuickSpec {
             beforeEach {
                 allSelectors = FunctionalTests_ItSpec.allSelectors()
                     .filter { $0.contains("when an example has a unique name") }
-                    .map {
-                        // SPM-version needs to prepend "test" to all test methods created.
-                        if $0.hasPrefix("test ") {
-                            var method = $0
-                            method.removeFirst(5)
-                            return method
-                        }
-                        return $0
-                    }
                     .sorted(by: <)
             }
 
@@ -51,15 +42,6 @@ class FunctionalTests_ItSpec: QuickSpec {
             beforeEach {
                 allSelectors = FunctionalTests_ItSpec.allSelectors()
                     .filter { $0.contains("when two examples have the exact name") }
-                    .map {
-                        // SPM-version needs to prepend "test" to all test methods created.
-                        if $0.hasPrefix("test ") {
-                            var method = $0
-                            method.removeFirst(5)
-                            return method
-                        }
-                        return $0
-                    }
                     .sorted(by: <)
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -158,7 +158,6 @@ final class FunctionalTests_StoppingTestsSpec: QuickSpec {
     }
 }
 
-
 final class ItTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ItTests) -> () throws -> Void)] {
         return [

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ItTests.swift
@@ -22,7 +22,16 @@ class FunctionalTests_ItSpec: QuickSpec {
 
             beforeEach {
                 allSelectors = FunctionalTests_ItSpec.allSelectors()
-                    .filter { $0.hasPrefix("when_an_example_has_a_unique_name__") }
+                    .filter { $0.contains("when an example has a unique name") }
+                    .map {
+                        // SPM-version needs to prepend "test" to all test methods created.
+                        if $0.hasPrefix("test ") {
+                            var method = $0
+                            method.removeFirst(5)
+                            return method
+                        }
+                        return $0
+                    }
                     .sorted(by: <)
             }
 
@@ -30,8 +39,8 @@ class FunctionalTests_ItSpec: QuickSpec {
 
             it("doesn't add multiple selectors for it") {
                 expect(allSelectors) == [
-                    "when_an_example_has_a_unique_name__doesn_t_add_multiple_selectors_for_it",
-                    "when_an_example_has_a_unique_name__has_a_unique_name",
+                    "when an example has a unique name, doesn't add multiple selectors for it",
+                    "when an example has a unique name, has a unique name",
                 ]
             }
         }
@@ -41,7 +50,16 @@ class FunctionalTests_ItSpec: QuickSpec {
 
             beforeEach {
                 allSelectors = FunctionalTests_ItSpec.allSelectors()
-                    .filter { $0.hasPrefix("when_two_examples_have_the_exact_name__") }
+                    .filter { $0.contains("when two examples have the exact name") }
+                    .map {
+                        // SPM-version needs to prepend "test" to all test methods created.
+                        if $0.hasPrefix("test ") {
+                            var method = $0
+                            method.removeFirst(5)
+                            return method
+                        }
+                        return $0
+                    }
                     .sorted(by: <)
             }
 
@@ -50,9 +68,9 @@ class FunctionalTests_ItSpec: QuickSpec {
 
             it("makes a unique name for each of the above") {
                 expect(allSelectors) == [
-                    "when_two_examples_have_the_exact_name__has_exactly_the_same_name",
-                    "when_two_examples_have_the_exact_name__has_exactly_the_same_name_2",
-                    "when_two_examples_have_the_exact_name__makes_a_unique_name_for_each_of_the_above",
+                    "when two examples have the exact name, has exactly the same name",
+                    "when two examples have the exact name, has exactly the same name (2)",
+                    "when two examples have the exact name, makes a unique name for each of the above",
                 ]
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/ItTests+ObjC.m
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/ObjC/ItTests+ObjC.m
@@ -24,8 +24,8 @@ it(@"has a description with セレクター名に使えない文字が入って�
 it(@"is a test with a unique name", ^{
     NSSet<NSString*> *allSelectors = [FunctionalTests_ItSpec_ObjC allSelectors];
     
-    expect(allSelectors).to(contain(@"is_a_test_with_a_unique_name"));
-    expect(allSelectors).toNot(contain(@"is_a_test_with_a_unique_name_2"));
+    expect(allSelectors).to(contain(@"is a test with a unique name"));
+    expect(allSelectors).toNot(contain(@"is a test with a unique name (2)"));
 });
 
 it(@"is executed on the main thread", ^{


### PR DESCRIPTION
Apply the spec demangling as seen in AsyncSpec to QuickSpec.

There's a mild chance that this will break any scripts relying on mangled test names. I'm ok with that so long as we call it out in the release notes.

Big thanks to @bnickel for the [initial spike](https://github.com/Quick/Quick/pull/1167) on all this work, as well as for the idea behind it.