### PR TITLE
Don't imply that we plan to remove the option to force encoded test selector names

### DIFF
--- a/Sources/Quick/TestSelectorNameProvider.swift
+++ b/Sources/Quick/TestSelectorNameProvider.swift
@@ -19,7 +19,7 @@ import Foundation
     }
 
     internal static var useLegacyStyleTestSelectorNames: Bool = {
-        ProcessInfo.processInfo.environment["QUICK_USE_LEGACY_TEST_SELECTOR_NAMES"] != nil
+        ProcessInfo.processInfo.environment["QUICK_USE_ENCODED_TEST_SELECTOR_NAMES"] != nil
     }()
 
     private static func legacyStyleTestSelectorName(exampleName: String, classSelectorNames selectorNames: Set<String>, isAsync: Bool) -> String {


### PR DESCRIPTION
Changes the environment variable we query to use encoded test selector names from  `QUICK_USE_LEGACY_TEST_SELECTOR_NAMES` to `QUICK_USE_ENCODED_TEST_SELECTOR_NAMES`.

CC @tikitu (who suggested a rename of the flag), @stonko1994 (who suggested we provide this option in the first place).