### PR TITLE
[doc] Corrected to class method

### DIFF
--- a/Documentation/en-us/DataDrivenExamples.md
+++ b/Documentation/en-us/DataDrivenExamples.md
@@ -27,7 +27,7 @@ import Quick
 import Nimble
 
 class DoubleFunctionTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("the double function") {
             let dataSet: [(input: Int, output: Int)] = [
                 (input: 0, output: 0),
@@ -70,7 +70,7 @@ class TestData<T> {
 }
 
 class QuickDataDrivenTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("the double function") {
             let dataSet: [TestData<Int>] = [
                 .init(input: 0, output: 0),
@@ -104,7 +104,7 @@ import Quick
 import Nimble
 
 class WeirdClassTests: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("the WeirdClass") {
             let dataSet: [(input: String, firstThree: String, weirdness: Int)] = [
                 (input: "foobar", firstThree: "foo", weirdness: 35),

--- a/Documentation/en-us/QuickExamplesAndGroups.md
+++ b/Documentation/en-us/QuickExamplesAndGroups.md
@@ -28,7 +28,7 @@ import Nimble
 import Sea
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     it("is friendly") {
       expect(Dolphin().isFriendly).to(beTruthy())
     }
@@ -82,7 +82,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       describe("its click") {
         it("is loud") {
@@ -149,7 +149,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach {
@@ -274,7 +274,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach { dolphin = Dolphin() }
@@ -458,7 +458,7 @@ the examples have finished:
 import Quick
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     beforeSuite {
       OceanDatabase.createDatabase(name: "test.db")
       OceanDatabase.connectToDatabase(name: "test.db")

--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -50,7 +50,7 @@ class SomethingEdible: Behavior<Edible> {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -61,7 +61,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()
@@ -99,7 +99,7 @@ class EdibleSharedExamplesConfiguration: QuickConfiguration {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -110,7 +110,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()

--- a/Documentation/en-us/TestUsingTestDoubles.md
+++ b/Documentation/en-us/TestUsingTestDoubles.md
@@ -109,7 +109,7 @@ The `fetchCalled` property is set to `true` when `fetch()` is called, so that th
 The following test verifies that when `ViewController` is loaded, the view controller calls `dataProvider.fetch()`.
 
 ```swift
-override func spec() {
+override class func spec() {
     describe("view controller") {
         it("fetch data with data provider") {
             let mockProvider = MockDataProvider()

--- a/Documentation/en-us/TestingApps.md
+++ b/Documentation/en-us/TestingApps.md
@@ -26,7 +26,7 @@ import Nimble
 import BananaApp
 
 class BananaViewControllerSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var viewController: BananaViewController!
     beforeEach {
       viewController = BananaViewController()

--- a/Documentation/ja/QuickExamplesAndGroups.md
+++ b/Documentation/ja/QuickExamplesAndGroups.md
@@ -28,7 +28,7 @@ import Nimble
 import Sea
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     it("is friendly") {
       expect(Dolphin().isFriendly).to(beTruthy())
     }
@@ -81,7 +81,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       describe("its click") {
         it("is loud") {
@@ -145,7 +145,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach {
@@ -227,7 +227,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach { dolphin = Dolphin() }
@@ -405,7 +405,7 @@ fcontext(@"when the dolphin is near something interesting", ^{
 import Quick
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     beforeSuite {
       OceanDatabase.createDatabase(name: "test.db")
       OceanDatabase.connectToDatabase(name: "test.db")

--- a/Documentation/ja/SharedExamples.md
+++ b/Documentation/ja/SharedExamples.md
@@ -31,7 +31,7 @@ class EdibleSharedExamplesConfiguration: QuickConfiguration {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -42,7 +42,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()

--- a/Documentation/ja/TestUsingTestDoubles.md
+++ b/Documentation/ja/TestUsingTestDoubles.md
@@ -116,7 +116,7 @@ class MockDataProvider: NSObject, DataProviderProtocol {
 
 ```swift
 // Swift
-override func spec() {
+override class func spec() {
     describe("view controller") {
         it("fetch data with data provider") {
             let mockProvier = MockDataProvider()

--- a/Documentation/ja/TestingApps.md
+++ b/Documentation/ja/TestingApps.md
@@ -23,7 +23,7 @@ import Nimble
 import BananaApp
 
 class BananaViewControllerSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var viewController: BananaViewController!
     beforeEach {
       viewController = BananaViewController()

--- a/Documentation/ko-kr/QuickExamplesAndGroups.md
+++ b/Documentation/ko-kr/QuickExamplesAndGroups.md
@@ -26,7 +26,7 @@ import Nimble
 import Sea
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     it("is friendly") {
       expect(Dolphin().isFriendly).to(beTruthy())
     }
@@ -75,7 +75,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       describe("its click") {
         it("is loud") {
@@ -139,7 +139,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach {
@@ -217,7 +217,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach { dolphin = Dolphin() }
@@ -392,7 +392,7 @@ fcontext(@"when the dolphin is near something interesting", ^{
 import Quick
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     beforeSuite {
       OceanDatabase.createDatabase(name: "test.db")
       OceanDatabase.connectToDatabase(name: "test.db")

--- a/Documentation/ko-kr/SharedExamples.md
+++ b/Documentation/ko-kr/SharedExamples.md
@@ -27,7 +27,7 @@ class EdibleSharedExamplesConfiguration: QuickConfiguration {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -38,7 +38,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()

--- a/Documentation/ko-kr/TestUsingTestDoubles.md
+++ b/Documentation/ko-kr/TestUsingTestDoubles.md
@@ -109,7 +109,7 @@ class MockDataProvider: NSObject, DataProviderProtocol {
 다음 테스트에서는  `ViewController` 가 로드될 때, `dataProvider.fetch() `를 호출하는지 확인합니다. 
 
 ```swift
-override func spec() {
+override class func spec() {
     describe("view controller") {
         it("fetch data with data provider") {
             let mockProvider = MockDataProvider()

--- a/Documentation/ko-kr/TestingApps.md
+++ b/Documentation/ko-kr/TestingApps.md
@@ -22,7 +22,7 @@ import Nimble
 import BananaApp
 
 class BananaViewControllerSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var viewController: BananaViewController!
     beforeEach {
       viewController = BananaViewController()

--- a/Documentation/pt-br/SharedExamples.md
+++ b/Documentation/pt-br/SharedExamples.md
@@ -27,7 +27,7 @@ class EdibleSharedExamplesConfiguration: QuickConfiguration {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -38,7 +38,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()

--- a/Documentation/zh-cn/QuickExamplesAndGroups.md
+++ b/Documentation/zh-cn/QuickExamplesAndGroups.md
@@ -24,7 +24,7 @@ import Nimble
 import Sea
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     it("is friendly") {
       expect(Dolphin().isFriendly).to(beTruthy())
     }
@@ -73,7 +73,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       describe("its click") {
         it("is loud") {
@@ -137,7 +137,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach {
@@ -215,7 +215,7 @@ import Quick
 import Nimble
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("a dolphin") {
       var dolphin: Dolphin!
       beforeEach { dolphin = Dolphin() }
@@ -389,7 +389,7 @@ fcontext(@"when the dolphin is near something interesting", ^{
 import Quick
 
 class DolphinSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     beforeSuite {
       OceanDatabase.createDatabase(name: "test.db")
       OceanDatabase.connectToDatabase(name: "test.db")

--- a/Documentation/zh-cn/SharedExamples.md
+++ b/Documentation/zh-cn/SharedExamples.md
@@ -26,7 +26,7 @@ class EdibleSharedExamplesConfiguration: QuickConfiguration {
 }
 
 class MackerelSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var mackerel: Mackerel!
     beforeEach {
       mackerel = Mackerel()
@@ -37,7 +37,7 @@ class MackerelSpec: QuickSpec {
 }
 
 class CodSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var cod: Cod!
     beforeEach {
       cod = Cod()

--- a/Documentation/zh-cn/TestUsingTestDoubles.md
+++ b/Documentation/zh-cn/TestUsingTestDoubles.md
@@ -109,7 +109,7 @@ class MockDataProvider: NSObject, DataProviderProtocol {
 下面的代码验证了当 `ViewController` 加载时，会运行 `dataProvider.fetch()` 。
 
 ```swift
-override func spec() {
+override class func spec() {
     describe("view controller") {
         it("fetch data with data provider") {
             let mockProvier = MockDataProvider()

--- a/Documentation/zh-cn/TestingApps.md
+++ b/Documentation/zh-cn/TestingApps.md
@@ -21,7 +21,7 @@ import Nimble
 import BananaApp
 
 class BananaViewControllerSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     var viewController: BananaViewController!
     beforeEach {
       viewController = BananaViewController()

--- a/Quick Templates/Quick Spec Class.xctemplate/Swift/___FILEBASENAME___.swift
+++ b/Quick Templates/Quick Spec Class.xctemplate/Swift/___FILEBASENAME___.swift
@@ -10,7 +10,7 @@ import Quick
 import Nimble
 
 class ___FILEBASENAMEASIDENTIFIER___: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import Quick
 import Nimble
 
 class TableOfContentsSpec: QuickSpec {
-  override func spec() {
+  override class func spec() {
     describe("the 'Documentation' directory") {
       it("has everything you need to get started") {
         let sections = Directory("Documentation").sections


### PR DESCRIPTION
Hi, I'm @coffmark. Thanks for always maintaining !

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
   - I converted `override func spec() { ... }` to `override class func spec() { ... }` in docs.
 - What code was refactored / updated to support this change?
   - Docs.
 - What issues are related to this PR? Or why was this change introduced?
   - None.

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

