### PR TITLE
Update the english documentation for Quick 7

### DIFF
--- a/Documentation/en-us/AsyncAwait.md
+++ b/Documentation/en-us/AsyncAwait.md
@@ -1,0 +1,129 @@
+# Async/Await in Quick
+
+Quick 7.0.0 added `AsyncSpec` for defining tests of behavior utilizing
+async/await. This is a change from the behavior in Quick 6. Now, tests only will
+run in Async contexts when they are in a subclass of `AsyncSpec`. Tests in a
+`QuickSpec` subclass will run in a synchronous context on the main thread, as
+they did in Quick 5 and earlier.
+
+This means that for `AsyncSpec` subclasses, all closures passed to `beforeEach`,
+`afterEach`, `aroundEach`, `it`, `fit`, and `xit` support async/await. Meaning
+the following code is possible:
+
+```swift
+final class MyAwesomeSpec: AsyncSpec {
+    override class func spec() {
+        describe("my awesome tests") {
+            beforeEach {
+                await someAsyncSetupFunction()
+            }
+            afterEach {
+                await teardownButAsync()
+            }
+            
+            aroundEach { runExample in
+                await runExample()
+            }
+            it("can run tests asynchronously!") {
+                let result = await methodBeingTested()
+                expect(result).to(equal(expectedValue))
+            }
+        }
+    }
+}
+```
+
+This allows you to natively test
+[Actors](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID645)
+and other async functions.
+
+## Running test code on the main thread
+
+When you do need to run test code on the main thread, the proper way is to tag
+the relevant closure with `@MainActor`. For example, in the following code
+`codeTaggedToRunOnTheMainActor` is a stand in for some implementation code:
+
+```swift
+func codeAssumedToRunOnTheMainThread() {
+    expect(Thread.isMainThread).to(beTrue())
+}
+it("will call async code that is tagged to run on the main actor") { @MainActor in
+    expect(Thread.isMainThread).to(beTrue())
+    await codeTaggedToRunOnTheMainActor()
+}
+```
+
+Alternatively, you can use `MainActor.run(body:)`. This will run the synchronous
+code on the main actor:
+
+```swift
+it("will call synchronous code that needs to run on the main actor") {
+    expect(Thread.isMainThread).to(beFalse())
+    await MainActor.run {
+        expect(Thread.isMainThread).to(beTrue())
+    }
+}
+```
+
+`beforeEach`, `afterEach` and `aroundEach` work in exactly the same manner.
+
+Currently, Quick does not have a mechanism to have every `it`, `beforeEach`,
+`afterEach`, `aroundEach` or `justBeforeEach` closure in an `AsyncSpec` to run
+on the main actor. The only real way to do that is manually tag each closure
+with `@MainActor in`, as shown in the earlier example. This is something we aim
+to address in a future release.
+
+## Thread Safety Concerns
+
+Quick will still execute `beforeEach`, `afterEach`, `aroundEach` elements in the
+order they're declared, following any nesting `describe`/`context`. Quick does
+not execute elements within a test in parallel, so there are no race conditions
+to worry about. Unless you are writing code that is very dependent on the thread
+it executes on, then you should not care about this. And if you are writing code
+that depends on the thread it uses, perhaps you should rewrite it to be an Actor?
+
+What has changed is that there's no guarantee that test code used in different
+`beforeEach`, `afterEach`, `aroundEach` or `it` elements will run on the same
+thread. That is, you can't even guarantee that the following tests will pass:
+
+```swift
+final class ThreadingSpec: AsyncSpec {
+    override class func spec() {
+        describe("test threading") {
+            var initialThread: Thread!
+            beforeEach {
+                initialThread = Thread.current
+            }
+    
+            it("is not guranteed to run closures in the same test on the same thread") {
+                expect(Thread.current).toNot(equal(initialThread)) // This test will sometimes fail and sometimes pass, depending on Swift version or even the platform it runs on.
+            }
+    
+            it("is not guranteed to run closures on the test on different threads") {
+                expect(Thread.current).to(equal(initialThread)) // This test will sometimes fail and sometimes pass, depending on Swift version or even the platform it runs on.
+            }
+        }
+    }
+}
+```
+
+The only way to guarantee that code called between all `beforeEach`,
+`afterEach`, `aroundEach`, and `it` closures run on the same thread is to force
+them all to run on the main thread. Even still, the test will not behave exactly
+as it would in a `QuickSpec` subclass. This is because the test is an async
+closure that is not tagged to run on the main actor which calls `beforeEach`,
+`afterEach`, `aroundEach` and `it` closures. There will be a slight delay as the
+system must switch from whichever default environment runs the test closure to
+the main actor. This has been known to cause test flakiness if not taken into
+account.
+
+## What about Objective-C?
+
+While it is possible to create Async specs in Objective-C, attempting to use the
+Quick DSL in an AsyncSpec will cause a runtime crash. Do not attempt to do so.
+
+## Resources
+
+- **[Swift Concurrency - The Swift Programming Language](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)**
+- **[Meet Swift Concurrency - Apple WWDC 2021](https://developer.apple.com/news/?id=2o3euotz)**
+- **[Swift Concurrency by Example - Paul Hudson, Hacking with Swift](https://www.hackingwithswift.com/quick-start/concurrency)**

--- a/Documentation/en-us/ConfiguringQuick.md
+++ b/Documentation/en-us/ConfiguringQuick.md
@@ -35,7 +35,11 @@ guarantee about the order in which those configurations are executed.
 ## Adding Global `beforeEach` and `afterEach` Closures
 
 Using `QuickConfiguration.beforeEach` and `QuickConfiguration.afterEach`, you
-can specify closures to be run before or after *every* example in a test suite:
+can specify closures to be run before or after *every* example in a test suite.
+These closures are even executed before or after examples in `AsyncSpec`, where
+they will be executed on the main actor.
+
+For example:
 
 ```swift
 // Swift

--- a/Documentation/en-us/InstallingQuick.md
+++ b/Documentation/en-us/InstallingQuick.md
@@ -11,7 +11,7 @@ There are three recommended ways of linking Quick to your tests:
 1. [Git Submodules](#git-submodules)
 2. [CocoaPods](#cocoapods)
 3. [Carthage](#carthage)
-4. [Swift Package Manager (experimental)](#swift-package-manager)
+4. [Swift Package Manager](#swift-package-manager)
 
 Choose one and follow the instructions below. Once you've completed them,
 you should be able to `import Quick` from within files in your test target.
@@ -163,8 +163,8 @@ let package = Package(
     	.library(name: "MyPackage", targets: ["MyPackage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
     ]
     targets: [
     	.target(name: "MyPackage", dependencies: []),

--- a/Documentation/en-us/TestUsingTestDoubles.md
+++ b/Documentation/en-us/TestUsingTestDoubles.md
@@ -45,7 +45,7 @@ For example, let's create an app which retrieves data from the Internet:
 
 ```swift
 protocol DataProviderProtocol: class {
-    func fetch(callback: (data: String) -> Void)
+    func fetch(callback: @escaping (data: String) -> Void)
 }
 ```
 
@@ -55,7 +55,7 @@ Here is the `DataProvider` class, which conforms to the `DataProviderProtocol` p
 
 ```swift
 class DataProvider: NSObject, DataProviderProtocol {
-    func fetch(callback: (data: String) -> Void) {
+    func fetch(callback: @escaping (data: String) -> Void) {
         let url = URL(string: "http://example.com/")!
         let session = URLSession(configuration: .default)
         let task = session.dataTask(with: url) {
@@ -81,10 +81,10 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        dataProvider = dataProvider ?? DataProvider()
+        let dataProvider = dataProvider ?? DataProvider()
 
-        dataProvider?.fetch({ [unowned self] (data) -> Void in
-            self.resultLabel.text = data
+        dataProvider.fetch({ [weak self] (data) -> Void in
+            self?.resultLabel.text = data
         })
     }
 }
@@ -97,7 +97,7 @@ class ViewController: UIViewController {
 ```swift
 class MockDataProvider: NSObject, DataProviderProtocol {
     var fetchCalled = false
-    func fetch(callback: (data: String) -> Void) {
+    func fetch(callback: @escaping (data: String) -> Void) {
         fetchCalled = true
         callback(data: "foobar")
     }
@@ -109,18 +109,386 @@ The `fetchCalled` property is set to `true` when `fetch()` is called, so that th
 The following test verifies that when `ViewController` is loaded, the view controller calls `dataProvider.fetch()`.
 
 ```swift
-override class func spec() {
-    describe("view controller") {
-        it("fetch data with data provider") {
-            let mockProvider = MockDataProvider()
-            let viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("ViewController") as! ViewController
-            viewController.dataProvider = mockProvider
+final class ViewControllerSpec: QuickSpec {
+    override class func spec() {
+        describe("view controller") {
+            it("fetches data with the data provider") {
+                let mockProvider = MockDataProvider()
+                let viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("ViewController") as! ViewController
+                viewController.dataProvider = mockProvider
 
-            expect(mockProvider.fetchCalled).to(beFalse())
+                expect(mockProvider.fetchCalled).to(beFalse())
 
-            let _ = viewController.view
+                _ = viewController.view
 
-            expect(mockProvider.fetchCalled).to(beTrue())
+                expect(mockProvider.fetchCalled).to(beTrue())
+            }
+        }
+    }
+}
+```
+
+##### Handling Different Errors in Callbacks
+
+What if DataProvider could fail and throw an error? This is easy to handle. The
+easiest way to handle that is to have `DataProviderProtocol.fetch(callback:)`'s
+callback take in a `Result<String, Error>`, instead of a `String`. Like so:
+
+```swift
+protocol DataProviderProtocol: class {
+    func fetch(callback: @escaping (Result<String, Error>) -> Void)
+}
+```
+
+This is also commonly expressed by having the callback take in `(data: String?, error: Error?)`
+arguments, which can express the same thing.
+
+Of course, with the updated `DataProviderProtocol`, we have to update our `DataProvider`:
+
+```swift
+class DataProvider: NSObject, DataProviderProtocol {
+    func fetch(callback: @escaping (Result<String, Error>) -> Void) {
+        let url = URL(string: "http://example.com/")!
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: url) {
+            (data, resp, err) in
+            if let data {
+                let string = String(data: data, encoding: .utf8)!
+                callback(.success(string))
+            } else {
+                callback(.failure(err!)
+            }
+        }
+        task.resume()
+    }
+}
+```
+
+Then, of course, our View Controller will need to be updated to deal with the
+fact that `DataProvider` can return an error:
+
+```swift
+class ViewController: UIViewController {
+    
+    // MARK: Properties
+    @IBOutlet weak var resultLabel: UILabel!
+    private var dataProvider: DataProviderProtocol?
+
+    // MARK: View Controller Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let dataProvider = dataProvider ?? DataProvider()
+
+        dataProvider.fetch({ [weak self] (result) -> Void in
+            switch result {
+            case .success(let data):
+                self?.resultLabel.text = data
+            case .failure(let error):
+                self?.resultLabel.text = "Error, try again"
+            }
+        })
+    }
+}
+```
+
+And then, we will update `MockDataProvider`. In this case, we will be changing
+`MockDataProvider` so that it doesn't immediately call the callback. This allows
+us to test the intermediate state in the code (before the callback has resolved),
+as well as both the success and failure cases.
+
+```swift
+class MockDataProvider: NSObject, DataProviderProtocol {
+    var fetchCalled: Bool { !fetchCalls.isEmpty }
+    private(set) var fetchCalls = [(Result<String, Error>) -> Void) = []
+    func fetch(callback: @escaping (Result<String, Error>) -> Void) {
+        fetchCalls.append(callback)
+    }
+}
+```
+
+In this case, we are explicitly storing the arguments that `fetch(callback:)` is
+called with, and, as a convenience, changing `fetchCalled` from a stored
+property to a computed property based on whether `fetchCalls` is empty or not.
+
+Finally, we update our test code. Here, we're going to take advantage of Quick's
+tree-like structure to have our tests represent the branching paths our code
+takes. This allows us to re-use the same setup code (create the dependencies, load
+the view, resolve the callback) without having to repeat ourselves, or create 
+setup functions that we could forget to call:
+
+```swift
+final class ViewControllerSpec: QuickSpec {
+    override class func spec() {
+        describe("view controller") {
+            var mockProvider: MockDataProvider!
+            var viewController: ViewController!
+                        
+            beforeEach {
+                mockProvider = MockDataProvider()
+                viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("ViewController") as! ViewController
+                viewController.dataProvider = mockProvider
+            }
+            
+            it("doesn't immediately fetch the data from the data provider") {
+                expect(mockProvider.fetchCalled).to(beFalse())
+            }
+            
+            context("when the view is loaded") {
+                beforeEach {
+                    _ = viewController.view
+                }
+
+                it("fetches data with the data provider") {
+                    expect(mockProvider.fetchCalled).to(beTrue())
+                }
+            
+                context("when the callback returns valid data") {
+                    beforeEach {
+                        mockProvider.fetchCalls.last?(.success("hello"))
+                    }
+                
+                    it("shows the data in the resultLabel") {
+                        expect(viewController.resultLabel.text).to(equal("hello"))
+                    }
+                }
+            
+                context("when the callback returns an error") {
+                    beforeEach {
+                        mockProvider.fetchCalls.last?(.failure(NSError()))
+                    }
+                
+                    it("let's the user know we had an error") {
+                        expect(viewController.resultLabel.text).to(equal("Error, try again"))
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+This example also took care to restructure the earliest tests so that each
+behavior is tested in its own test, as described and encouraged in [Behavioral Testing](BehavioralTesting.md).
+
+### Writing Mocks for Async/Await APIs in Swift
+
+Swift Concurrency, or async/await, requires a slight change in how we mock the
+return value, as well as how we structure tests to handle this. This example assumes
+basic familiarity with Async/Await in Swift. If you are unfamiliar with Async/Await
+in Swift, please review
+[Meet Swift Concurrency](https://developer.apple.com/news/?id=2o3euotz), from
+WWDC 2021.
+
+Utilizing the previous example, what if we wanted to provide an async version of
+`DataProviderProtocol.fetch(callback:)`? Assuming you're familiar with
+Async/Await in swift, this is relatively easy to provide. Again, going with our
+earlier example, we're going to start with the implementation code. First the
+`DataProviderProtocol`:
+
+```swift
+protocol DataProviderProtocol: class {
+    func fetch() async throws -> String
+}
+```
+
+This is a fairly straightforward conversion. Next, we'll update the actual
+`DataProvider`, in this case to use the Async/Await API for URLSession:
+
+```swift
+class DataProvider: NSObject, DataProviderProtocol {
+    func fetch() async throws -> String {
+        let url = URL(string: "http://example.com/")!
+        let session = URLSession(configuration: .default)
+        let (data, _) = try await session.dataTask(with: url)
+        return String(data: data, encoding: .utf8)!
+    }
+}
+```
+
+Third, we'll update the ViewController to use this new Async version of `fetch()`:
+
+```swift
+class ViewController: UIViewController {
+    
+    // MARK: Properties
+    @IBOutlet weak var resultLabel: UILabel!
+    private var dataProvider: DataProviderProtocol?
+    
+    private var fetchTask: Task<Void, Never>?
+    
+    deinit {
+        fetchTask?.cancel()
+    }
+
+    // MARK: View Controller Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        fetchTask = Task { [weak self] in
+            await self?.fetchData()
+        }
+    }
+    
+    @MainActor
+    func fetchData() async {
+        let dataProvider = dataProvider ?? DataProvider()
+        let labelString: String
+        do {
+            labelString = try await dataProvider.fetch()
+        } catch {
+            labelString = "Error, try again"
+        }
+        resultLabel.text = labelString
+    }
+}
+```
+
+This is slightly more complicated. Because `viewDidLoad` is not an async method,
+we need to kick off a background Task to create the async context to invoke these
+async methods in. This task then calls `fetchData`, which contains the bulk of
+what used to be in `viewDidLoad`.  
+Additionally, because `UILabel.text` must be updated on the main thread, we
+need to annotate the new `fetchData` method with `@MainActor` so that we set
+`resultLabel.text` on the main thread.  
+Also, while not required, we are saving off the created background task, for the
+explicit purpose of cancelling it when `ViewController` is deallocated.
+
+With the implementation code updated, now it's time to update our Mock. This
+is where things start to look different from what you'd expect. After much
+research and experimentation, I ([@younata](https://github.com/younata), the
+author) have determined that the best way to mock Async methods is to always
+have them "preresolved". In contrast to earlier, where we stored the arguments
+to `fetch(callback:)`, and then called the callback at our leisure; I have come
+to the conclusion that the Swift Concurrency runtime does not like to have
+tasks kept waiting for an indeterminate amount of time. Every mechanism I have
+come up with to force this results in ~50% of the tests randomly failing.
+Instead, I encourage a paradigm where mocks always return a known value. This
+paradigm requires a little extra infrastructure, which is not (currently) in
+Quick or Nimble. Which we'll call `AsyncResult`. `AsyncResult` is an enum which
+represents the 3 states an `Async` method can return: Success, Failure, and
+Pending. Part of the infrastructure we'll add is that Pending will always throw
+an error return after sleeping for a bit. This enables us to still test the
+intermediate state before the async method has resolved, while satisfying
+Swift's need to always return a value.
+
+```swift
+import Nimble
+
+enum AsyncResult<Value, Failure: Error> {
+    case success(Value)
+    case failure(Failure)
+    case pending
+    
+    func resolve(timeout: NimbleTimeInterval = PollingDefaults.pollInterval * 2) async throws -> Value {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        case .pending:
+            try await Task.sleep(for: timeout)
+            throw AsyncResultTimedOutError()
+        }
+    }
+}
+
+struct AsyncResultTimedOutError: Error {}
+```
+
+As you can see, in the `success` or `failure` cases, `AsyncResult.resolve`
+immediately returns the associated value. In the `pending` case,
+`AsyncResult.resolve` will wait for some period of time (defaulting to 2 \* 
+however long Nimble would poll for when using a `toEventually`-style matcher).
+This value feels like a good-enough wait time.  
+As-is, this mock only works with `async throws` methods. For mocking
+non-throwing methods, the following extension which utilizes a fallback will work:
+
+```swift
+extension AsyncResult where Failure == Never {
+    func resolve(fallback: Value, timeout: NimbleTimeInterval = PollingDefaults.pollInterval * 2) async -> Value {
+        do {
+            try await resolve(timeout: timeout)
+        } catch {
+            return fallback
+        }
+    }
+}
+```
+
+With this infrastructure, we will update our `MockDataProvider` to use it:
+
+```swift
+class MockDataProvider: NSObject, DataProviderProtocol {
+    private(set) var fetchCalled: Bool = false
+    private(set) var fetchStub = AsyncResult<String, Error>.pending
+    func fetch() async throws -> String {
+        fetchCalled = true
+        return fetchStub.resolve(fallback: .failure(NSError()))
+    }
+}
+```
+
+Next up, because we preresolve our mocks, we have to adjust our test structure
+such that `fetch()` is called after we change the value of `fetchStub`. In our
+case, this means that we want to make sure that `ViewController.viewDidLoad` is
+called immediately before each of the test called. Which we'll do using the
+`justBeforeEach` method in the Quick DSL. `justBeforeEach` works to add the
+associated closure at the end of the set of `beforeEach` closures. Additionally,
+because we'll be running background tasks, we'll need to use Nimble's polling
+matchers to test that the `resultLabel` will be updated eventually.
+Lastly, because this test isn't directly invoking any async calls, we do not to
+make this an `AsyncSpec`. This test will still run as a traditional `QuickSpec`.
+
+```swift
+final class ViewControllerSpec: QuickSpec {
+    override class func spec() {
+        describe("view controller") {
+            var mockProvider: MockDataProvider!
+            var viewController: ViewController!
+                        
+            beforeEach {
+                mockProvider = MockDataProvider()
+                viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("ViewController") as! ViewController
+                viewController.dataProvider = mockProvider
+            }
+            
+            it("doesn't immediately fetch the data from the data provider") {
+                expect(mockProvider.fetchCalled).to(beFalse())
+            }
+            
+            context("when the view is loaded") {
+                justBeforeEach {
+                    // if this were a regular beforeEach, MockDataProvider.fetch() would get called much too early
+                    _ = viewController.view
+                }
+
+                it("fetches data with the data provider") {
+                    expect(mockProvider.fetchCalled).toEventually(beTrue())
+                }
+            
+                context("when the callback returns valid data") {
+                    beforeEach {
+                        mockProvider.fetchStub = .success("hello")
+                    }
+                
+                    it("shows the data in the resultLabel") {
+                        expect(viewController.resultLabel.text).toEventually(equal("hello"))
+                    }
+                }
+            
+                context("when the callback returns an error") {
+                    beforeEach {
+                        mockProvider.fetchStub = .failure(NSError())
+                    }
+                
+                    it("let's the user know we had an error") {
+                        // because AsyncResult has a default timeout of 2 * Nimble's polling interval,
+                        // this test would fail if we had forgotten to reset mockProvider.fetchStub.
+                        expect(viewController.resultLabel.text).toEventually(equal("Error, try again"))
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Re-adds documentation on `AsyncAwait`, updated for Quick 7.
Adds documentation on making mocks of async functions, using a methodology I came up with a few months ago.

Removes marking the Swift Package Manager distribution as experimental.