### PR TITLE
Allow xit in the Async DSL to take in async closures

### DIFF
--- a/Sources/Quick/DSL/AsyncDSL.swift
+++ b/Sources/Quick/DSL/AsyncDSL.swift
@@ -223,7 +223,7 @@ extension AsyncDSLUser {
      Use this to quickly mark an `it` closure as pending.
      This disables the example and ensures the code within the closure is never run.
      */
-    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) {
         AsyncWorld.sharedWorld.xit(description, file: file, line: line, closure: closure)
     }
 

--- a/Sources/Quick/DSL/AsyncWorld+DSL.swift
+++ b/Sources/Quick/DSL/AsyncWorld+DSL.swift
@@ -110,7 +110,7 @@ extension AsyncWorld {
     }
 
     @nonobjc
-    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping () async throws -> Void) {
         self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/PendingAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/PendingAsyncTests.swift
@@ -15,7 +15,7 @@ class FunctionalTests_PendingAsyncSpec_AsyncBehavior: AsyncBehavior<Void> {
 class FunctionalTests_PendingAsyncSpec: AsyncSpec {
     override class func spec() {
         xit("an example that will not run") {
-            expect(true).to(beFalsy())
+            await expect(true).toEventually(beFalsy())
         }
         xitBehavesLike(FunctionalTests_PendingAsyncSpec_AsyncBehavior.self) { () -> Void in }
         describe("a describe block containing only one enabled example") {


### PR DESCRIPTION
Fixes https://github.com/Quick/Quick/issues/1219

Thanks @stonko1994!

