### PR TITLE
Correct a few places where we falsely assume "SWIFT_PACKAGE" == not darwin

### DIFF
--- a/Sources/Quick/Callsite.swift
+++ b/Sources/Quick/Callsite.swift
@@ -14,7 +14,7 @@ public class _CallsiteBase: NSObject {}
 // stdlib, and because recent versions of the XCTest overlay require `StaticString`
 // when calling `XCTFail`. Under the Objective-C runtime (i.e. building on macOS), we
 // have to use `String` instead because StaticString can't be generated from Objective-C
-#if SWIFT_PACKAGE
+#if !canImport(Darwin)
 public typealias FileString = StaticString
 #else
 public typealias FileString = String

--- a/Sources/Quick/Examples/AsyncExample.swift
+++ b/Sources/Quick/Examples/AsyncExample.swift
@@ -176,13 +176,8 @@ public class AsyncExample: ExampleBase {
     internal func reportFailedTest(_ error: Error, name: String, callsite: Callsite) {
         let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
 
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
+        #if canImport(Darwin)
             let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
             let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
             let sourceCodeContext = XCTSourceCodeContext(location: location)
             let issue = XCTIssue(
@@ -192,6 +187,7 @@ public class AsyncExample: ExampleBase {
             )
             AsyncSpec.current?.record(issue)
         #else
+            let file = callsite.file.description
             AsyncSpec.current?.recordFailure(
                 withDescription: description,
                 inFile: file,
@@ -206,13 +202,8 @@ public class AsyncExample: ExampleBase {
 
         let callsite = stopTestError.callsite
 
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
+        #if canImport(Darwin)
             let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
             let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
             let sourceCodeContext = XCTSourceCodeContext(location: location)
             let issue = XCTIssue(
@@ -222,6 +213,7 @@ public class AsyncExample: ExampleBase {
             )
             AsyncSpec.current?.record(issue)
         #else
+            let file = callsite.file.description
             AsyncSpec.current?.recordFailure(
                 withDescription: stopTestError.failureDescription,
                 inFile: file,

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -227,13 +227,8 @@ public class Example: ExampleBase {
     internal func reportFailedTest(_ error: Error, name: String, callsite: Callsite) {
         let description = "Test \(name) threw unexpected error: \(error.localizedDescription)"
 
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
+        #if canImport(Darwin)
             let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
             let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
             let sourceCodeContext = XCTSourceCodeContext(location: location)
             let issue = XCTIssue(
@@ -243,6 +238,7 @@ public class Example: ExampleBase {
             )
             QuickSpec.current.record(issue)
         #else
+            let file = callsite.file.description
             QuickSpec.current.recordFailure(
                 withDescription: description,
                 inFile: file,
@@ -257,13 +253,8 @@ public class Example: ExampleBase {
 
         let callsite = stopTestError.callsite
 
-        #if SWIFT_PACKAGE
-            let file = callsite.file.description
-        #else
+        #if canImport(Darwin)
             let file = callsite.file
-        #endif
-
-        #if !SWIFT_PACKAGE
             let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
             let sourceCodeContext = XCTSourceCodeContext(location: location)
             let issue = XCTIssue(
@@ -273,6 +264,7 @@ public class Example: ExampleBase {
             )
             QuickSpec.current.record(issue)
         #else
+            let file = callsite.file.description
             QuickSpec.current.recordFailure(
                 withDescription: stopTestError.failureDescription,
                 inFile: file,


### PR DESCRIPTION
Noticed a bug (type conflict) between Nimble's definition of `FileString` and Quick's definition of `FileString`.

For reference/posterity, here's Nimble's definition:

```swift
#if !canImport(Darwin)
public typealias FileString = StaticString
#else
public typealias FileString = String
#endif
```

And here's Quick's definition of `FileString`:

```swift
#if SWIFT_PACKAGE
public typealias FileString = StaticString
#else
public typealias FileString = String
#endif
```

(The reasoning for FileString to exist in the first place is because objective-c cannot generate StaticString)

Basically, Quick makes the assumption that SWIFT_PACKAGE = objective-c is unavailable, which is not a valid assumption. This PR fixes that, and goes beyond to fix some longstanding warnings when using Quick from SPM.

This is patch version update, so Quick 7.0.2.

