### PR TITLE
Ensure beforeEach in Configuration run for AsyncSpec

### DIFF
--- a/Sources/Quick/Async/AsyncWorld.swift
+++ b/Sources/Quick/Async/AsyncWorld.swift
@@ -44,8 +44,8 @@ final internal class AsyncWorld: _WorldBase {
 
     internal private(set) var isConfigurationFinalized = false
 
-    private var exampleHooks: ExampleHooks { return World.sharedWorld.exampleHooks }
-    private var suiteHooks: SuiteHooks { return World.sharedWorld.suiteHooks }
+    internal var exampleHooks: AsyncExampleHooks { return World.sharedWorld.asyncExampleHooks }
+    internal var suiteHooks: SuiteHooks { return World.sharedWorld.suiteHooks }
 
     // MARK: Singleton Constructor
 

--- a/Sources/Quick/Examples/AsyncExample.swift
+++ b/Sources/Quick/Examples/AsyncExample.swift
@@ -66,12 +66,12 @@ public class AsyncExample: ExampleBase {
             self.group!.phase = .aftersExecuting
         }
 
-        let allJustBeforeEachStatements = group!.justBeforeEachStatements
+        let allJustBeforeEachStatements = group!.justBeforeEachStatements + asyncWorld.exampleHooks.justBeforeEachStatements
         let justBeforeEachExample = allJustBeforeEachStatements.reduce(runExample) { closure, wrapper in
             return { await wrapper(exampleMetadata, closure) }
         }
 
-        let allWrappers = group!.wrappers
+        let allWrappers = group!.wrappers + asyncWorld.exampleHooks.wrappers
         let wrappedExample = allWrappers.reduce(justBeforeEachExample) { closure, wrapper in
             return { await wrapper(exampleMetadata, closure) }
         }

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -72,6 +72,7 @@ final internal class World: _WorldBase {
     internal private(set) var isConfigurationFinalized = false
 
     internal var exampleHooks: ExampleHooks { return configuration.exampleHooks }
+    internal var asyncExampleHooks: AsyncExampleHooks { return configuration.asyncExampleHooks }
     internal var suiteHooks: SuiteHooks { return configuration.suiteHooks }
 
     // MARK: Singleton Constructor

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/AfterEach/Configuration+AfterEachAsyncTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Quick
 import Nimble
 
-class Configuration_AfterEachSpec: QuickSpec {
+class Configuration_AfterEachAsyncSpec: AsyncSpec {
     override class func spec() {
         beforeEach {
             FunctionalTests_Configuration_AfterEachWasExecuted = false
@@ -13,8 +13,8 @@ class Configuration_AfterEachSpec: QuickSpec {
     }
 }
 
-final class Configuration_AfterEachTests: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (Configuration_AfterEachTests) -> () throws -> Void)] {
+final class Configuration_AfterEachAsyncTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (Configuration_AfterEachAsyncTests) -> () throws -> Void)] {
         return [
             ("testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted", testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted),
         ]
@@ -23,7 +23,7 @@ final class Configuration_AfterEachTests: XCTestCase, XCTestCaseProvider {
     func testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted() {
         FunctionalTests_Configuration_AfterEachWasExecuted = false
 
-        qck_runSpec(Configuration_AfterEachSpec.self)
+        qck_runSpec(Configuration_AfterEachAsyncSpec.self)
         XCTAssert(FunctionalTests_Configuration_AfterEachWasExecuted)
 
         FunctionalTests_Configuration_AfterEachWasExecuted = false

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachAsyncSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Configuration/BeforeEach/Configuration+BeforeEachAsyncSpec.swift
@@ -1,0 +1,28 @@
+import XCTest
+import Quick
+import Nimble
+
+class Configuration_BeforeEachAsyncSpec: AsyncSpec {
+    override class func spec() {
+        it("is executed after the configuration beforeEach") {
+            expect(FunctionalTests_Configuration_BeforeEachWasExecuted).to(beTruthy())
+        }
+    }
+}
+
+final class Configuration_BeforeEachAsyncTests: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (Configuration_BeforeEachAsyncTests) -> () throws -> Void)] {
+        return [
+            ("testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted", testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted),
+        ]
+    }
+
+    func testExampleIsRunAfterTheConfigurationBeforeEachIsExecuted() {
+        FunctionalTests_Configuration_BeforeEachWasExecuted = false
+
+        qck_runSpec(Configuration_BeforeEachAsyncSpec.self)
+        XCTAssert(FunctionalTests_Configuration_BeforeEachWasExecuted)
+
+        FunctionalTests_Configuration_BeforeEachWasExecuted = false
+    }
+}


### PR DESCRIPTION
This PR ensures documented behavior below.

https://github.com/Quick/Quick/blob/v7.0.2/Documentation/en-us/ConfiguringQuick.md#adding-global-beforeeach-and-aftereach-closures

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

