### PR TITLE
Allow beforeEach, justBeforeEach, and afterEach in Swift to throw

### DIFF
--- a/Sources/Quick/Configuration/QCKConfiguration.swift
+++ b/Sources/Quick/Configuration/QCKConfiguration.swift
@@ -81,7 +81,7 @@ final public class QCKConfiguration: NSObject {
     */
 #if canImport(Darwin)
     @objc(beforeEachWithMetadata:)
-    public func objc_beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
+    public func objc_beforeEach(_ closure: @escaping BeforeExampleWithMetadataNonThrowingClosure) {
         exampleHooks.appendBefore(closure)
         asyncExampleHooks.appendBefore { exampleMetadata in
             await MainActor.run {
@@ -94,8 +94,8 @@ final public class QCKConfiguration: NSObject {
     public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         exampleHooks.appendBefore(closure)
         asyncExampleHooks.appendBefore { exampleMetadata in
-            await MainActor.run {
-                closure(exampleMetadata)
+            try await MainActor.run {
+                try closure(exampleMetadata)
             }
         }
     }
@@ -103,8 +103,8 @@ final public class QCKConfiguration: NSObject {
     public func beforeEach(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         exampleHooks.appendBefore(closure)
         asyncExampleHooks.appendBefore { exampleMetadata in
-            await MainActor.run {
-                closure(exampleMetadata)
+            try await MainActor.run {
+                try closure(exampleMetadata)
             }
         }
     }
@@ -132,7 +132,7 @@ final public class QCKConfiguration: NSObject {
     public func beforeEach(_ closure: @escaping BeforeExampleClosure) {
         exampleHooks.appendBefore(closure)
         asyncExampleHooks.appendBefore { @MainActor in
-            closure()
+            try closure()
         }
     }
 
@@ -145,7 +145,7 @@ final public class QCKConfiguration: NSObject {
     */
 #if canImport(Darwin)
     @objc(afterEachWithMetadata:)
-    public func objc_afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
+    public func objc_afterEach(_ closure: @escaping AfterExampleWithMetadataNonThrowingClosure) {
         exampleHooks.appendAfter(closure)
         asyncExampleHooks.appendAfter { exampleMetadata in
             await MainActor.run {
@@ -158,8 +158,8 @@ final public class QCKConfiguration: NSObject {
     public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
         exampleHooks.appendAfter(closure)
         asyncExampleHooks.appendAfter { exampleMetadata in
-            await MainActor.run {
-                closure(exampleMetadata)
+            try await MainActor.run {
+                try closure(exampleMetadata)
             }
         }
     }
@@ -167,8 +167,8 @@ final public class QCKConfiguration: NSObject {
     public func afterEach(_ closure: @escaping AfterExampleWithMetadataClosure) {
         exampleHooks.appendAfter(closure)
         asyncExampleHooks.appendAfter { exampleMetadata in
-            await MainActor.run {
-                closure(exampleMetadata)
+            try await MainActor.run {
+                try closure(exampleMetadata)
             }
         }
     }
@@ -196,7 +196,7 @@ final public class QCKConfiguration: NSObject {
     public func afterEach(_ closure: @escaping AfterExampleClosure) {
         exampleHooks.appendAfter(closure)
         asyncExampleHooks.appendAfter { @MainActor in
-            closure()
+            try closure()
         }
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -7,11 +7,27 @@ import Foundation
 */
 extension World {
     // MARK: - Before Suite
+#if canImport(Darwin)
+    @objc(beforeSuite:)
+    internal func objc_beforeSuite(_ closure: @escaping BeforeSuiteNonThrowingClosure) {
+        suiteHooks.appendBefore(closure)
+    }
+#endif
+
+    @nonobjc
     internal func beforeSuite(_ closure: @escaping BeforeSuiteClosure) {
         suiteHooks.appendBefore(closure)
     }
 
     // MARK: - After Suite
+#if canImport(Darwin)
+    @objc(afterSuite:)
+    internal func objc_afterSuite(_ closure: @escaping AfterSuiteNonThrowingClosure) {
+        suiteHooks.appendAfter(closure)
+    }
+#endif
+
+    @nonobjc
     internal func afterSuite(_ closure: @escaping AfterSuiteClosure) {
         suiteHooks.appendAfter(closure)
     }
@@ -78,7 +94,16 @@ extension World {
         }
         currentExampleGroup.hooks.appendBefore(closure)
     }
+
+    @objc(beforeEach:)
+    internal func objc_beforeEach(closure: @escaping BeforeExampleNonThrowingClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
+        }
+        currentExampleGroup.hooks.appendBefore(closure)
+    }
 #endif
+
     @nonobjc
     internal func beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
         guard currentExampleMetadata == nil else {
@@ -87,6 +112,7 @@ extension World {
         currentExampleGroup.hooks.appendBefore(closure)
     }
 
+    @nonobjc
     internal func beforeEach(_ closure: @escaping BeforeExampleClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
@@ -103,7 +129,16 @@ extension World {
         }
         currentExampleGroup.hooks.appendAfter(closure)
     }
+
+    @objc(afterEach:)
+    internal func objc_afterEach(_ closure: @escaping AfterExampleNonThrowingClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
+        }
+        currentExampleGroup.hooks.appendAfter(closure)
+    }
 #endif
+
     @nonobjc
     internal func afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
         guard currentExampleMetadata == nil else {
@@ -112,6 +147,7 @@ extension World {
         currentExampleGroup.hooks.appendAfter(closure)
     }
 
+    @nonobjc
     internal func afterEach(_ closure: @escaping AfterExampleClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
@@ -120,6 +156,24 @@ extension World {
     }
 
     // MARK: - Around Each
+    #if canImport(Darwin)
+    @objc(aroundEach:)
+    internal func objc_aroundEach(_ closure: @escaping AroundExampleNonThrowingClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'aroundEach' cannot be used inside '\(currentPhase)', 'aroundEach' may only be used inside 'context' or 'describe'. ")
+        }
+        currentExampleGroup.hooks.appendAround(closure)
+    }
+
+    @objc(aroundEachWithMetadata:)
+    internal func objc_aroundEach(_ closure: @escaping AroundExampleWithMetadataNonThrowingClosure) {
+        guard currentExampleMetadata == nil else {
+            raiseError("'aroundEach' cannot be used inside '\(currentPhase)', 'aroundEach' may only be used inside 'context' or 'describe'. ")
+        }
+        currentExampleGroup.hooks.appendAround(closure)
+    }
+    #endif
+
     @nonobjc
     internal func aroundEach(_ closure: @escaping AroundExampleClosure) {
         guard currentExampleMetadata == nil else {

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -53,7 +53,7 @@ extension World {
     // MARK: - Just Before Each
 #if canImport(Darwin)
     @objc(justBeforeEach:)
-    internal func objc_justBeforeEach(_ closure: @escaping BeforeExampleClosure) {
+    internal func objc_justBeforeEach(_ closure: @escaping BeforeExampleNonThrowingClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'justBeforeEach' cannot be used inside '\(currentPhase)', 'justBeforeEach' may only be used inside 'context' or 'describe'.")
         }
@@ -72,7 +72,7 @@ extension World {
     // MARK: - Before Each
 #if canImport(Darwin)
     @objc(beforeEachWithMetadata:)
-    internal func objc_beforeEach(closure: @escaping BeforeExampleWithMetadataClosure) {
+    internal func objc_beforeEach(closure: @escaping BeforeExampleWithMetadataNonThrowingClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'beforeEach' cannot be used inside '\(currentPhase)', 'beforeEach' may only be used inside 'context' or 'describe'.")
         }
@@ -97,7 +97,7 @@ extension World {
     // MARK: - After Each
 #if canImport(Darwin)
     @objc(afterEachWithMetadata:)
-    internal func objc_afterEach(closure: @escaping AfterExampleWithMetadataClosure) {
+    internal func objc_afterEach(closure: @escaping AfterExampleWithMetadataNonThrowingClosure) {
         guard currentExampleMetadata == nil else {
             raiseError("'afterEach' cannot be used inside '\(currentPhase)', 'afterEach' may only be used inside 'context' or 'describe'.")
         }

--- a/Sources/Quick/Hooks/AsyncExampleHooks.swift
+++ b/Sources/Quick/Hooks/AsyncExampleHooks.swift
@@ -10,21 +10,21 @@ final internal class AsyncExampleHooks {
 
     internal func appendJustBeforeEach(_ closure: @escaping BeforeExampleAsyncClosure) {
         justBeforeEachStatements.append { _, runExample in
-            await closure()
+            try await closure()
             await runExample()
         }
     }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleWithMetadataAsyncClosure) {
         wrappers.append { exampleMetadata, runExample in
-            await closure(exampleMetadata)
+            try await closure(exampleMetadata)
             await runExample()
         }
     }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleAsyncClosure) {
         wrappers.append { _, runExample in
-            await closure()
+            try await closure()
             await runExample()
         }
     }
@@ -32,14 +32,14 @@ final internal class AsyncExampleHooks {
     internal func appendAfter(_ closure: @escaping AfterExampleWithMetadataAsyncClosure) {
         wrappers.prepend { exampleMetadata, runExample in
             await runExample()
-            await closure(exampleMetadata)
+            try await closure(exampleMetadata)
         }
     }
 
     internal func appendAfter(_ closure: @escaping AfterExampleAsyncClosure) {
         wrappers.prepend { _, runExample in
             await runExample()
-            await closure()
+            try await closure()
         }
     }
 
@@ -48,6 +48,6 @@ final internal class AsyncExampleHooks {
     }
 
     internal func appendAround(_ closure: @escaping AroundExampleAsyncClosure) {
-        wrappers.append { _, runExample in await closure(runExample) }
+        wrappers.append { _, runExample in try await closure(runExample) }
     }
 }

--- a/Sources/Quick/Hooks/Closures.swift
+++ b/Sources/Quick/Hooks/Closures.swift
@@ -1,99 +1,141 @@
 // MARK: Example Hooks
 
 /**
-    An async closure executed before an example is run.
+    An async throwing closure executed before an example is run.
 */
-public typealias BeforeExampleAsyncClosure = () async -> Void
+public typealias BeforeExampleAsyncClosure = () async throws -> Void
+
+/**
+    A throwing closure executed before an example is run.
+ */
+public typealias BeforeExampleClosure = () throws -> Void
 
 /**
     A closure executed before an example is run.
-    Synchronous version for Objc support.
+    This is only used by ObjC.
  */
-public typealias BeforeExampleClosure = () -> Void
+public typealias BeforeExampleNonThrowingClosure = () -> Void
 
 /**
-    An async closure executed before an example is run. The closure is given example metadata,
+    An async throwing closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
 */
-public typealias BeforeExampleWithMetadataAsyncClosure = (_ exampleMetadata: ExampleMetadata) async -> Void
+public typealias BeforeExampleWithMetadataAsyncClosure = (_ exampleMetadata: ExampleMetadata) async throws -> Void
+
+/**
+    A throwing closure executed before an example is run. The closure is given example metadata,
+    which contains information about the example that is about to be run.
+ */
+public typealias BeforeExampleWithMetadataClosure = (_ exampleMetadata: ExampleMetadata) throws -> Void
 
 /**
     A closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
-    Synchronus version for Objc support.
+    This is only used by ObjC
  */
-public typealias BeforeExampleWithMetadataClosure = (_ exampleMetadata: ExampleMetadata) -> Void
+public typealias BeforeExampleWithMetadataNonThrowingClosure = (_ exampleMetadata: ExampleMetadata) -> Void
 
 /**
-    An async closure executed after an example is run.
+    An async throwing closure executed after an example is run.
 */
 public typealias AfterExampleAsyncClosure = BeforeExampleAsyncClosure
 
 /**
-    A closure executed after an example is run.
-    Synchronous version for Objc support.
+    A throwing closure executed after an example is run.
 */
 public typealias AfterExampleClosure = BeforeExampleClosure
 
 /**
-    An closure executed after an example is run. The closure is given example metadata,
+    A closure executed after an example is run.
+    This is only used by ObjC
+*/
+public typealias AfterExampleNonThrowingClosure = BeforeExampleNonThrowingClosure
+
+/**
+    An async throwing closure executed after an example is run. The closure is given example metadata,
     which contains information about the example that has just finished running.
 */
 public typealias AfterExampleWithMetadataAsyncClosure = BeforeExampleWithMetadataAsyncClosure
 
 /**
-    A closure executed after an example is run. The closure is given example metadata,
+    A throwing closure executed after an example is run. The closure is given example metadata,
     which contains information about the example that has just finished running.
-    Synchronous version for Objc support.
 */
 public typealias AfterExampleWithMetadataClosure = BeforeExampleWithMetadataClosure
 
 /**
-    A closure which wraps an example. The closure must call runExample() exactly once.
+    A closure executed after an example is run. The closure is given example metadata,
+    which contains information about the example that has just finished running.
 */
-public typealias AroundExampleClosure = (_ runExample: @escaping () -> Void) -> Void
+public typealias AfterExampleWithMetadataNonThrowingClosure = BeforeExampleWithMetadataNonThrowingClosure
 
 /**
-    A closure which wraps an example. The closure is given example metadata,
+    A throwing closure which wraps an example. The closure must call runExample() exactly once.
+*/
+public typealias AroundExampleClosure = (_ runExample: @escaping () -> Void) throws -> Void
+
+/**
+    A closure which wraps an example. The closure must call runExample() exactly once.
+*/
+public typealias AroundExampleNonThrowingClosure = (_ runExample: @escaping () -> Void) -> Void
+
+/**
+    A throwing closure which wraps an example. The closure is given example metadata,
     which contains information about the example that the wrapper will run.
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataClosure =
+    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) throws -> Void
+
+/**
+    A throwing closure which wraps an example. The closure is given example metadata,
+    which contains information about the example that the wrapper will run.
+    The closure must call runExample() exactly once.
+*/
+public typealias AroundExampleWithMetadataNonThrowingClosure =
     (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) -> Void
 
 /**
-    An async closure which wraps an example. The closure must call runExample() exactly once.
+    An async throwing closure which wraps an example. The closure must call runExample() exactly once.
 */
-public typealias AroundExampleAsyncClosure = (_ runExample: @escaping () async -> Void) async -> Void
+public typealias AroundExampleAsyncClosure = (_ runExample: @escaping () async -> Void) async throws -> Void
 
 /**
-    An async closure which wraps an example. The closure is given example metadata,
+    An async throwing closure which wraps an example. The closure is given example metadata,
     which contains information about the example that the wrapper will run.
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataAsyncClosure =
-    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () async -> Void) async -> Void
+    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () async -> Void) async throws -> Void
 
 // MARK: Suite Hooks
 
 /**
-    An closure executed before any examples are run.
+    An async throwing closure executed before any examples are run.
 */
-public typealias BeforeSuiteAsyncClosure = () async -> Void
+public typealias BeforeSuiteAsyncClosure = () async throws -> Void
+
+/**
+    A throwing closure executed before any examples are run.
+*/
+public typealias BeforeSuiteClosure = () throws -> Void
 
 /**
     A closure executed before any examples are run.
-    Synchronous version for Objc support.
 */
-public typealias BeforeSuiteClosure = () -> Void
+public typealias BeforeSuiteNonThrowingClosure = () -> Void
 
 /**
-    A closure executed after all examples have finished running.
+    An async throwing closure executed after all examples have finished running.
 */
 public typealias AfterSuiteAsyncClosure = BeforeSuiteAsyncClosure
 
 /**
-    A closure executed after all examples have finished running.
-    Synchronous version for Objc support.
+    A throwing closure executed after all examples have finished running.
 */
 public typealias AfterSuiteClosure = BeforeSuiteClosure
+
+/**
+    A closure executed after all examples have finished running.
+*/
+public typealias AfterSuiteNonThrowingClosure = BeforeSuiteNonThrowingClosure

--- a/Sources/Quick/Hooks/ExampleHooks.swift
+++ b/Sources/Quick/Hooks/ExampleHooks.swift
@@ -10,21 +10,21 @@ final internal class ExampleHooks {
 
     internal func appendJustBeforeEach(_ closure: @escaping BeforeExampleClosure) {
         justBeforeEachStatements.append { _, runExample in
-            closure()
+            try closure()
             runExample()
         }
     }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleWithMetadataClosure) {
         wrappers.append { exampleMetadata, runExample in
-            closure(exampleMetadata)
+            try closure(exampleMetadata)
             runExample()
         }
     }
 
     internal func appendBefore(_ closure: @escaping BeforeExampleClosure) {
         wrappers.append { _, runExample in
-            closure()
+            try closure()
             runExample()
         }
     }
@@ -32,14 +32,14 @@ final internal class ExampleHooks {
     internal func appendAfter(_ closure: @escaping AfterExampleWithMetadataClosure) {
         wrappers.prepend { exampleMetadata, runExample in
             runExample()
-            closure(exampleMetadata)
+            try closure(exampleMetadata)
         }
     }
 
     internal func appendAfter(_ closure: @escaping AfterExampleClosure) {
         wrappers.prepend { _, runExample in
             runExample()
-            closure()
+            try closure()
         }
     }
 
@@ -48,7 +48,7 @@ final internal class ExampleHooks {
     }
 
     internal func appendAround(_ closure: @escaping AroundExampleClosure) {
-        wrappers.append { _, runExample in closure(runExample) }
+        wrappers.append { _, runExample in try closure(runExample) }
     }
 }
 

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -17,7 +17,11 @@ final internal class SuiteHooks {
     internal func executeBefores() {
         phase = .beforesExecuting
         for before in befores {
-            before()
+            do {
+                try before()
+            } catch {
+                break
+            }
         }
         phase = .beforesFinished
     }
@@ -25,7 +29,11 @@ final internal class SuiteHooks {
     internal func executeAfters() {
         phase = .aftersExecuting
         for after in afters {
-            after()
+            do {
+                try after()
+            } catch {
+                break
+            }
         }
         phase = .aftersFinished
     }

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -74,14 +74,14 @@ QUICK_EXPORT void qck_fcontext(NSString *description, QCKDSLEmptyBlock closure);
 
 #ifndef QUICK_DISABLE_SHORT_SYNTAX
 /**
-    Defines a closure to be run prior to any examples in the test suite.
-    You may define an unlimited number of these closures, but there is no
-    guarantee as to the order in which they're run.
+ Defines a closure to be run prior to any examples in the test suite.
+ You may define an unlimited number of these closures, but there is no
+ guarantee as to the order in which they're run.
  
-    If the test suite crashes before the first example is run, this closure
-    will not be executed.
+ If the test suite crashes before the first example is run, this closure
+ will not be executed.
  
-    @param closure The closure to be run prior to any examples in the test suite.
+ @param closure The closure to be run prior to any examples in the test suite.
  */
 static inline void beforeSuite(QCKDSLEmptyBlock closure) {
     qck_beforeSuite(closure);
@@ -89,145 +89,171 @@ static inline void beforeSuite(QCKDSLEmptyBlock closure) {
 
 
 /**
-    Defines a closure to be run after all of the examples in the test suite.
-    You may define an unlimited number of these closures, but there is no
-    guarantee as to the order in which they're run.
+ Defines a closure to be run after all of the examples in the test suite.
+ You may define an unlimited number of these closures, but there is no
+ guarantee as to the order in which they're run.
      
-    If the test suite crashes before all examples are run, this closure
-    will not be executed.
+ If the test suite crashes before all examples are run, this closure
+ will not be executed.
  
-    @param closure The closure to be run after all of the examples in the test suite.
+ @param closure The closure to be run after all of the examples in the test suite.
  */
 static inline void afterSuite(QCKDSLEmptyBlock closure) {
     qck_afterSuite(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines a group of shared examples. These examples can be re-used in several locations
-    by using the `itBehavesLike` function.
- 
-    @param name The name of the shared example group. This must be unique across all shared example
-                groups defined in a test suite.
-    @param closure A closure containing the examples. This behaves just like an example group defined
-                   using `describe` or `context`--the closure may contain any number of `beforeEach`
-                   and `afterEach` closures, as well as any number of examples (defined using `it`).
+ Defines a group of shared examples. These examples can be re-used in several locations
+ by using the ``itBehavesLike`` function.
+
+ @param name The name of the shared example group. This must be unique across all shared example
+             groups defined in a test suite.
+ @param closure A closure containing the examples. This behaves just like an example group defined
+                using `describe` or `context`--the closure may contain any number of `beforeEach`
+                and `afterEach` closures, as well as any number of examples (defined using `it`).
  */
 static inline void sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure) {
     qck_sharedExamples(name, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines an example group. Example groups are logical groupings of examples.
-    Example groups can share setup and teardown code.
+ Defines an example group. Example groups are logical groupings of examples.
+ Example groups can share setup and teardown code.
  
-    @param description An arbitrary string describing the example group.
-    @param closure A closure that can contain other examples.
+ @param description An arbitrary string describing the example group.
+ @param closure A closure that can contain other examples.
  */
 static inline void describe(NSString *description, QCKDSLEmptyBlock closure) {
     qck_describe(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines an example group. Equivalent to `describe`.
+ Defines an example group. Equivalent to ``describe(description, closure)``.
  */
 static inline void context(NSString *description, QCKDSLEmptyBlock closure) {
     qck_context(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines a closure to be run prior to each example in the current example
-    group. This closure is not run for pending or otherwise disabled examples.
-    An example group may contain an unlimited number of beforeEach. They'll be
-    run in the order they're defined, but you shouldn't rely on that behavior.
+ Defines a closure to be run prior to each example in the current example
+ group. This closure is not run for pending or otherwise disabled examples.
+ An example group may contain an unlimited number of beforeEach. They'll be
+ run in the order they're defined, but you shouldn't rely on that behavior.
  
-    @param closure The closure to be run prior to each example.
+ @param closure The closure to be run prior to each example.
  */
 static inline void beforeEach(QCKDSLEmptyBlock closure) {
     qck_beforeEach(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Identical to QCKDSL.beforeEach, except the closure is provided with
-    metadata on the example that the closure is being run prior to.
+ Identical to ``beforeEach(closure)``, except the closure is provided with
+ metadata on the example that the closure is being run prior to.
  */
 static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     qck_beforeEachWithMetadata(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines a closure to be run after each example in the current example
-    group. This closure is not run for pending or otherwise disabled examples.
-    An example group may contain an unlimited number of afterEach. They'll be
-    run in the order they're defined, but you shouldn't rely on that behavior.
- 
-    @param closure The closure to be run after each example.
+ Defines a closure to be run after each example in the current example
+ group. This closure is not run for pending or otherwise disabled examples.
+ An example group may contain an unlimited number of afterEach. They'll be
+ run in the order they're defined, but you shouldn't rely on that behavior.
+
+ @param closure The closure to be run after each example.
  */
 static inline void afterEach(QCKDSLEmptyBlock closure) {
     qck_afterEach(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Identical to QCKDSL.afterEach, except the closure is provided with
-    metadata on the example that the closure is being run after.
+ Identical to ``afterEach(closure)``, except the closure is provided with
+ metadata on the example that the closure is being run after.
  */
 static inline void afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
     qck_afterEachWithMetadata(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
-static inline void aroundEach(QCKDSLAroundExampleBlock closure) __attribute__((unavailable("aroundEach is no longer supported for Objective-C tests."))) {};
+/**
+ Defines a closure to be run around each example in the currente example group.
+ You must call the passed-in `runClosure` argument at least once in order to
+ run the example. This closure is not run for pending or otherwise disabled example.
+ An example group may contain an unlimited number of `aroundEach`. They'll be
+ run in the order they're defined, but you shouldn't rely on that behavior.
 
-static inline void aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure) __attribute__((unavailable("aroundEachWithMetadata is no longer supported for Objective-C tests."))) {};
+ @param closure The closure to run around each example. This closure itself takes
+    in a closure: the before-mentioned `runClosure` argument. The `runClosure` argument
+    must be called at once and only once.
+ */
+static inline void aroundEach(QCKDSLAroundExampleBlock closure) {
+    qck_aroundEach(closure);
+} NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines a closure to be run prior to each example but after any beforeEach blocks.
-    This closure is not run for pending or otherwise disabled examples.
-    An example group may contain an unlimited number of justBeforeEach. They'll be
-    run in the order they're defined, but you shouldn't rely on that behavior.
+ Identical to ``aroundEach(closure)``, except the closure is provided with
+ metadata on the example that the closure is being run around.
 
-    @param closure The closure to be run prior to each example but before any beforeEach blocks in the test suite.
+ @param closure The closure to run around each example. This closure itself takes
+    in an ``ExampleMetadata-swift.class`` object and a closure.
+    The ``ExampleMetadata-swift.class`` provides information about the example being run around.
+    The closure is the example to run, and must be called at once and only once.
+ */
+static inline void aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure) {
+    qck_aroundEachWithMetadata(closure);
+} NS_SWIFT_UNAVAILABLE("")
+
+/**
+ Defines a closure to be run prior to each example but after any beforeEach blocks.
+ This closure is not run for pending or otherwise disabled examples.
+ An example group may contain an unlimited number of justBeforeEach. They'll be
+ run in the order they're defined, but you shouldn't rely on that behavior.
+
+ @param closure The closure to be run prior to each example but before any beforeEach blocks in the test suite.
  */
 static inline void justBeforeEach(QCKDSLEmptyBlock closure) {
     qck_justBeforeEach(closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Defines an example or example group that should not be executed. Use `pending` to temporarily disable
-    examples or groups that should not be run yet.
+ Defines an example or example group that should not be executed. Use
+ ``pending(description, closure)`` to temporarily disable
+ examples or groups that should not be run yet.
  
-    @param description An arbitrary string describing the example or example group.
-    @param closure A closure that will not be evaluated.
+ @param description An arbitrary string describing the example or example group.
+ @param closure A closure that will not be evaluated.
  */
 static inline void pending(NSString *description, QCKDSLEmptyBlock closure) {
     qck_pending(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Use this to quickly mark a `describe` block as pending.
-    This disables all examples within the block.
+ Use this to quickly mark a ``describe(description, closure)`` block as pending.
+ This disables all examples within the block.
  */
 static inline void xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
     qck_xdescribe(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Use this to quickly mark a `context` block as pending.
-    This disables all examples within the block.
+ Use this to quickly mark a ``context(description, closure)`` block as pending.
+ This disables all examples within the block.
  */
 static inline void xcontext(NSString *description, QCKDSLEmptyBlock closure) {
     qck_xcontext(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Use this to quickly focus a `describe` block, focusing the examples in the block.
-    If any examples in the test suite are focused, only those examples are executed.
-    This trumps any explicitly focused or unfocused examples within the block--they are all treated as focused.
+ Use this to quickly focus a ``describe(description, closure)`` block, focusing the examples in the block.
+ If any examples in the test suite are focused, only those examples are executed.
+ This trumps any explicitly focused or unfocused examples within the block--they are all treated as focused.
  */
 static inline void fdescribe(NSString *description, QCKDSLEmptyBlock closure) {
     qck_fdescribe(description, closure);
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
-    Use this to quickly focus a `context` block. Equivalent to `fdescribe`.
+ Use this to quickly focus a ``context(description, closure)`` block.
+ Equivalent to ``fdescribe(description, closure)``.
  */
 static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
     qck_fcontext(description, closure);

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -46,6 +46,14 @@ void qck_justBeforeEach(QCKDSLEmptyBlock closure) {
     [[World sharedWorld] justBeforeEach:closure];
 }
 
+void qck_aroundEach(QCKDSLAroundExampleBlock closure) {
+    [[World sharedWorld] aroundEach:closure];
+}
+
+void qck_aroundEachWithMetadata(QCKDSLAroundExampleMetadataBlock closure) {
+    [[World sharedWorld] aroundEachWithMetadata:closure];
+}
+
 QCKItBlock qck_it_builder(NSString *file, NSUInteger line) {
     return ^(NSString *description, QCKDSLEmptyBlock closure) {
         [[World sharedWorld] itWithDescription:description

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -26,6 +26,8 @@ private var throwingAfterEachOrder = [ThrowingAfterEachType]()
 
 private struct AfterEachError: Error {}
 
+private var isRunningFunctionalTests = false
+
 class FunctionalTests_AfterEachSpec: QuickSpec {
     override class func spec() {
         describe("afterEach ordering") {
@@ -65,8 +67,6 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
         }
 
         describe("throwing errors") {
-            beforeEach { XCTExpectFailure("Throws an AfterEachError") }
-
             afterEach { throwingAfterEachOrder.append(.outerOne) }
 
             context("when nested") {
@@ -76,7 +76,9 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
 
                 afterEach {
                     throwingAfterEachOrder.append(.innerTwo)
-                    throw AfterEachError()
+                    if isRunningFunctionalTests {
+                        throw AfterEachError()
+                    }
                 }
 
                 afterEach {
@@ -113,11 +115,13 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
     override func setUp() {
         afterEachOrder = []
         throwingAfterEachOrder = []
+        isRunningFunctionalTests = true
     }
 
     override func tearDown() {
         afterEachOrder = []
         throwingAfterEachOrder = []
+        isRunningFunctionalTests = false
     }
 
     func testAfterEachIsExecutedInTheCorrectOrder() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -13,6 +13,19 @@ private enum AfterEachType {
 
 private var afterEachOrder = [AfterEachType]()
 
+private enum ThrowingAfterEachType: String, CustomStringConvertible {
+    case outerOne
+    case innerOne
+    case innerTwo
+    case innerThree
+
+    var description: String { rawValue }
+}
+
+private var throwingAfterEachOrder = [ThrowingAfterEachType]()
+
+private struct AfterEachError: Error {}
+
 class FunctionalTests_AfterEachSpec: QuickSpec {
     override class func spec() {
         describe("afterEach ordering") {
@@ -51,6 +64,29 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
             }
         }
 
+        describe("throwing errors") {
+            beforeEach { XCTExpectFailure("Throws an AfterEachError") }
+
+            afterEach { throwingAfterEachOrder.append(.outerOne) }
+
+            context("when nested") {
+                beforeEach {
+                    throwingAfterEachOrder.append(.innerOne)
+                }
+
+                afterEach {
+                    throwingAfterEachOrder.append(.innerTwo)
+                    throw AfterEachError()
+                }
+
+                afterEach {
+                    throwingAfterEachOrder.append(.innerThree)
+                }
+
+                it("runs this test") {}
+            }
+        }
+
 #if canImport(Darwin) && !SWIFT_PACKAGE
         describe("error handling when misusing ordering") {
             it("should throw an exception when including afterEach in it block") {
@@ -70,12 +106,21 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (AfterEachTests) -> () throws -> Void)] {
         return [
             ("testAfterEachIsExecutedInTheCorrectOrder", testAfterEachIsExecutedInTheCorrectOrder),
+            ("testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs", testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs),
         ]
     }
 
-    func testAfterEachIsExecutedInTheCorrectOrder() {
+    override func setUp() {
         afterEachOrder = []
+        throwingAfterEachOrder = []
+    }
 
+    override func tearDown() {
+        afterEachOrder = []
+        throwingAfterEachOrder = []
+    }
+
+    func testAfterEachIsExecutedInTheCorrectOrder() {
         qck_runSpec(FunctionalTests_AfterEachSpec.self)
         let expectedOrder: [AfterEachType] = [
             // [1] The outer afterEach closures are executed from top to bottom.
@@ -87,7 +132,21 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
             .innerOne, .innerTwo, .outerOne, .outerTwo, .outerThree,
         ]
         XCTAssertEqual(afterEachOrder, expectedOrder)
+    }
 
-        afterEachOrder = []
+    func testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs() {
+        qck_runSpec(FunctionalTests_AfterEachSpec.self)
+
+        let expectedOrder: [ThrowingAfterEachType] = [
+            .innerOne,
+            .innerTwo,
+            .innerThree,
+            .outerOne
+        ]
+
+        XCTAssertEqual(
+            throwingAfterEachOrder,
+            expectedOrder
+        )
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
@@ -26,6 +26,8 @@ private var throwingAfterEachOrder = [ThrowingAfterEachType]()
 
 private struct AfterEachError: Error {}
 
+private var isRunningFunctionalTests = false
+
 class FunctionalTests_AfterEachAsyncSpec: AsyncSpec {
     override class func spec() {
         describe("afterEach ordering") {
@@ -65,8 +67,6 @@ class FunctionalTests_AfterEachAsyncSpec: AsyncSpec {
         }
 
         describe("throwing errors") {
-            beforeEach { XCTExpectFailure("Throws an AfterEachError") }
-
             afterEach { throwingAfterEachOrder.append(.outerOne) }
 
             context("when nested") {
@@ -76,7 +76,9 @@ class FunctionalTests_AfterEachAsyncSpec: AsyncSpec {
 
                 afterEach {
                     throwingAfterEachOrder.append(.innerTwo)
-                    throw AfterEachError()
+                    if isRunningFunctionalTests {
+                        throw AfterEachError()
+                    }
                 }
 
                 afterEach {
@@ -113,11 +115,13 @@ final class AfterEachAsyncTests: XCTestCase, XCTestCaseProvider {
     override func setUp() {
         afterEachOrder = []
         throwingAfterEachOrder = []
+        isRunningFunctionalTests = true
     }
 
     override func tearDown() {
         afterEachOrder = []
         throwingAfterEachOrder = []
+        isRunningFunctionalTests = false
     }
 
     func testAfterEachIsExecutedInTheCorrectOrder() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
@@ -29,6 +29,8 @@ private var throwingBeforeEachOrder = [ThrowingBeforeEachType]()
 
 private struct BeforeEachError: Error {}
 
+private var isRunningFunctionalTests = false
+
 class FunctionalTests_BeforeEachAsyncSpec: AsyncSpec {
     override class func spec() {
 
@@ -58,8 +60,9 @@ class FunctionalTests_BeforeEachAsyncSpec: AsyncSpec {
 
             beforeEach {
                 throwingBeforeEachOrder.append(.outerTwo)
-                XCTExpectFailure("Throws a BeforeEachError")
-                throw BeforeEachError()
+                if isRunningFunctionalTests {
+                    throw BeforeEachError()
+                }
             }
 
             beforeEach {
@@ -69,7 +72,9 @@ class FunctionalTests_BeforeEachAsyncSpec: AsyncSpec {
             afterEach { throwingBeforeEachOrder.append(.afterEach) }
 
             it("does not run tests") {
-                fail("tests should not be run here")
+                if isRunningFunctionalTests {
+                    fail("tests should not be run here")
+                }
             }
 
             context("when nested") {
@@ -82,7 +87,9 @@ class FunctionalTests_BeforeEachAsyncSpec: AsyncSpec {
                 }
 
                 it("still does not run tests") {
-                    fail("tests should not be run.")
+                    if isRunningFunctionalTests {
+                        fail("tests should not be run.")
+                    }
                 }
             }
         }
@@ -108,6 +115,14 @@ final class BeforeEachAsyncTests: XCTestCase, XCTestCaseProvider {
             ("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
             ("testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs", testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs),
         ]
+    }
+
+    override func setUp() {
+        isRunningFunctionalTests = true
+    }
+
+    override func tearDown() {
+        isRunningFunctionalTests = false
     }
 
     func testBeforeEachIsExecutedInTheCorrectOrder() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -28,6 +28,8 @@ private var throwingBeforeEachOrder = [ThrowingBeforeEachType]()
 
 private struct BeforeEachError: Error {}
 
+private var isRunningFunctionalTests = false
+
 class FunctionalTests_BeforeEachSpec: QuickSpec {
     override class func spec() {
         describe("beforeEach ordering") {
@@ -55,8 +57,9 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
 
             beforeEach {
                 throwingBeforeEachOrder.append(.outerTwo)
-                XCTExpectFailure("Throws a BeforeEachError")
-                throw BeforeEachError()
+                if isRunningFunctionalTests {
+                    throw BeforeEachError()
+                }
             }
 
             beforeEach {
@@ -66,7 +69,9 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
             afterEach { throwingBeforeEachOrder.append(.afterEach) }
 
             it("does not run tests") {
-                fail("tests should not be run here")
+                if isRunningFunctionalTests {
+                    fail("tests should not be run here")
+                }
             }
 
             context("when nested") {
@@ -79,7 +84,9 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
                 }
 
                 it("still does not run tests") {
-                    fail("tests should not be run.")
+                    if isRunningFunctionalTests {
+                        fail("tests should not be run.")
+                    }
                 }
             }
         }
@@ -105,6 +112,14 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
             ("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
             ("testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs", testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs),
         ]
+    }
+
+    override func setUp() {
+        isRunningFunctionalTests = true
+    }
+
+    override func tearDown() {
+        isRunningFunctionalTests = false
     }
 
     func testBeforeEachIsExecutedInTheCorrectOrder() {


### PR DESCRIPTION
Fixes #1122.

In a non-breaking manner, adds support for throwing expressions in `beforeEach`, `justBeforeEach`, and `afterEach`. These behave similarly to if you used the `setupWithError` and `teardownWithError` methods on XCTestCase: The subsequent `beforeEach`s are skipped. The test is skipped/not run. The appropriate `afterEach`s still run (but not nested `afterEach`s).

This does not affect Objective-C tests at all. i.e. None of the setup or teardown functions support an `NSError **` parameter for throwing. Similarly, you cannot throw an NSException to get this same behavior.

The logic for this is implemented in `Example`/`AsyncExample`: When a setup/teardown throws, then we set a `cancelTests` variable that is checked before running another closure for the test. With the way this works and how our tree-structure of tests is set up, this means that errors thrown really only stop subsequent blocks when a `beforeEach` or `justBeforeEach` throws. Which is precisely the behavior I wanted out of this. What a happy coincidence!

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?

