### PR TITLE
Make a public xitBehavesLike(_ name: String) for SyncDSLUser

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -297,6 +297,22 @@ extension SyncDSLUser {
         World.sharedWorld.xitBehavesLike(behavior, context: context, file: file, line: line)
     }
 
+    /**
+     Use this to quickly mark an `itBehavesLike` closure as pending.
+     This disables the example group defined by this behavior and ensures the code within is never run.
+     */
+    public static func xitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line) {
+        xitBehavesLike(name, file: file, line: line, sharedExampleContext: { return [:] })
+    }
+
+    /**
+     Use this to quickly mark an `itBehavesLike` closure as pending.
+     This disables the example group defined by this behavior and ensures the code within is never run.
+     */
+    public static func xitBehavesLike(_ name: String, file: FileString = #file, line: UInt = #line, sharedExampleContext: @escaping SharedExampleContext) {
+        World.sharedWorld.xitBehavesLike(name, sharedExampleContext: sharedExampleContext, file: file, line: line)
+    }
+
     // MARK: - Focused
     /**
      Use this to quickly focus a `describe` closure, focusing the examples in the closure.

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -14,10 +14,18 @@ class FunctionalTests_PendingSpec_Behavior: Behavior<Void> {
 }
 class FunctionalTests_PendingSpec: QuickSpec {
     override class func spec() {
+        sharedExamples("shared pending behavior") { aContext in
+            it("will not run") {
+                fail()
+            }
+        }
+
         xit("an example that will not run") {
             expect(true).to(beFalsy())
         }
         xitBehavesLike(FunctionalTests_PendingSpec_Behavior.self) { () -> Void in }
+        xitBehavesLike("shared pending behavior")
+        xitBehavesLike("shared pending behavior", sharedExampleContext: { [:] })
         describe("a describe block containing only one enabled example") {
             beforeEach { oneExampleBeforeEachExecutedCount += 1 }
             it("an example that will run") {}


### PR DESCRIPTION
Fixes #1227 for SyncDSLUser. I have no plans to make `itBehavesLike(_ name: String)`, `fitBehavesLike(_ name: String)`, nor `xitBehavesLike(_ name: String)` a thing for Async tests.

This adds a public `xitBehavesLike` for quickly pending out the string-based `itBehavesLike` api in `QuickSpec` and `Behavior`. Something which I apparently forgot to do when I created `SyncDSLUser`.

