### PR TITLE
Improve documentation for installing Quick and Nimble via Cocoapods in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Certain versions of Quick and Nimble only support certain versions of Swift. Dep
 
 ## Documentation
 
-All documentation can be found in the [Documentation folder](./Documentation), including [detailed installation instructions](./Documentation/en-us/InstallingQuick.md) for CocoaPods, Carthage, Git submodules, and more. For example, you can install Quick and [Nimble](https://github.com/Quick/Nimble) using CocoaPods by adding the following to your Podfile:
+All documentation can be found in the [Documentation folder](./Documentation), including [detailed installation instructions](./Documentation/en-us/InstallingQuick.md) for CocoaPods, Carthage, Git submodules, Swift Package Manager, and more. For example, you can install Quick and [Nimble](https://github.com/Quick/Nimble) using CocoaPods by adding the following to your `Podfile`:
 
 ```rb
 # Podfile
@@ -61,15 +61,22 @@ use_frameworks!
 target "MyApp" do
   # Normal libraries
 
-  abstract_target 'Tests' do
+  target 'MyApp_Tests' do
     inherit! :search_paths
-    target "MyAppTests"
-    target "MyAppUITests"
 
     pod 'Quick'
     pod 'Nimble'
   end
 end
+```
+
+You can also install Quick and Nimble using Swift Package Manager by adding the following to the dependencies section your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
+],
 ```
 
 ## Projects using Quick


### PR DESCRIPTION
Fixes #774

Documentation update to the README.
Gives more correct instructions for installing Quick and Nimble via Cocoapods.
Also provides instructions for installing Quick and Nimble via Swift Package Manager in the readme.

