### PR TITLE
Attempt to run tests within a QuickSpec or AsyncSpec in the order they are defined in

### DIFF
--- a/Documentation/en-us/TestOrdering.md
+++ b/Documentation/en-us/TestOrdering.md
@@ -1,0 +1,76 @@
+# Test Ordering
+
+By default, Quick will suggest that XCTest runs tests in a `QuickSpec` or
+`AsyncSpec` in the order they are defined in. This can be easily overriden by
+specifying the "Randomize Execution Order" option in your testplan.
+Additionally, we have found that doing any kind of filtering, such as selecting
+a test gem, will also override this suggestion.
+
+However, if you run all tests at once (via `xcodebuild test`, product -> Test,
+or `swift test`), then XCTest should run tests in the order as specified. For
+example, with the following tests:
+
+
+```swift
+describe("A describe block") {
+    it("runs this test first every time") {}
+    it("runs this test second every time") {}
+}
+
+context("A context block") {
+    it("runs this test third every time") {}
+    it("runs this test fourth every time") {}
+}
+```
+
+Quick will try to run them in the order as:
+
+- `A describe block, runs this test first every time`
+- `A describe block, runs this test second every time`
+- `A context block, runs this test third every time`
+- `A context block, runs this test fourth every time`.
+
+Using the `.defined` switch on the `order` parameter of a `describe` or
+`context` block will ensure Quick runs the tests within this block in the
+order they are defined.
+
+That said, despite this attempt to suggest ordering, we strongly suggest that
+you enable XCTest's "Randomize Execution Order". Good, robust unit testing
+suites avoid imposing ordering on tests as much as possible.
+
+## Nested `describe` and `context` blocks
+
+How does this all work for deeply nested tests with many layers of `describe`
+and `context` blocks? Let's look at some examples:
+
+```swift
+// 1
+describe("Top level is defined") {
+    it("runs this test first every time") {}
+
+    // 2
+    context("Nested context with defined order") {
+        it("runs this test second every time") {}
+        it("runs this test third every time") {}
+    }
+
+    it("runs this test fourth every time") {}
+}
+```
+
+- At `1`, we have defined a `describe` block with `.defined`. It will thus order
+all Quick "elements" inside (`it`s, `describe`s, and `context`s) in the
+sequence they appear within the block.
+- At `2`, we've defined a `context` block with `.defined`. It will runs its
+Quick elements in the order they appear in the block, just as is happening with
+the `describe` block defined at `1`. Note that when this `context` gets "its
+ turn" in the order, it will run through all the elements it has inside.
+
+ All the above would apply if the block were a `describe` instead.
+
+## Why specify an order if random ordering is recommended?
+
+This is done primarily to maintain expectations with how XCTest tests are run.
+This ordering of tests is how most people expect Quick tests to run, and by
+using the "Randomize Execution Order" option of test plans, we are also
+maintaining compatibility with XCTest-based tests you may have.

--- a/Documentation/en-us/TestOrdering.md
+++ b/Documentation/en-us/TestOrdering.md
@@ -1,10 +1,15 @@
 # Test Ordering
 
+**We highly recommend enabling "Randomize Execution Order" in your xctestplan.**  
+That said, this document exists to specify the ordering of the list of tests
+that Quick supplies to XCTest.
+
 By default, Quick will suggest that XCTest runs tests in a `QuickSpec` or
 `AsyncSpec` in the order they are defined in. This can be easily overriden by
 specifying the "Randomize Execution Order" option in your testplan.
 Additionally, we have found that doing any kind of filtering, such as selecting
-a test gem, will also override this suggestion.
+a test gem, will also override this suggestion. Typically, this will cause
+XCTest to run the tests in lexicographical order.
 
 However, if you run all tests at once (via `xcodebuild test`, product -> Test,
 or `swift test`), then XCTest should run tests in the order as specified. For
@@ -34,9 +39,9 @@ Using the `.defined` switch on the `order` parameter of a `describe` or
 `context` block will ensure Quick runs the tests within this block in the
 order they are defined.
 
-That said, despite this attempt to suggest ordering, we strongly suggest that
-you enable XCTest's "Randomize Execution Order". Good, robust unit testing
-suites avoid imposing ordering on tests as much as possible.
+That said, despite this attempt to suggest ordering, we still strongly suggest that
+you enable XCTest's "Randomize Execution Order". No test should have to depend
+on another test running before it in order to pass.
 
 ## Nested `describe` and `context` blocks
 
@@ -71,6 +76,8 @@ the `describe` block defined at `1`. Note that when this `context` gets "its
 ## Why specify an order if random ordering is recommended?
 
 This is done primarily to maintain expectations with how XCTest tests are run.
-This ordering of tests is how most people expect Quick tests to run, and by
-using the "Randomize Execution Order" option of test plans, we are also
-maintaining compatibility with XCTest-based tests you may have.
+Additionally, this ordering of tests is the order most people expect Quick tests
+to run in.
+Additionally, there are some cases where it's necessary, if not recommended,
+for tests to run in a specific order. In that case, it's better to define an
+order than to always randomize it.

--- a/Quick.xcodeproj/project.pbxproj
+++ b/Quick.xcodeproj/project.pbxproj
@@ -200,6 +200,12 @@
 		8961ABC827B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABC927B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
 		8961ABCA27B3546E008DD498 /* SelectedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */; };
+		89BFE9BF2A5270C400EC1C47 /* OrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9BE2A5270C400EC1C47 /* OrderingTests.swift */; };
+		89BFE9C02A5270C400EC1C47 /* OrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9BE2A5270C400EC1C47 /* OrderingTests.swift */; };
+		89BFE9C12A5270C400EC1C47 /* OrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9BE2A5270C400EC1C47 /* OrderingTests.swift */; };
+		89BFE9C32A52713C00EC1C47 /* AsyncOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9C22A52711000EC1C47 /* AsyncOrderingTests.swift */; };
+		89BFE9C72A52713E00EC1C47 /* AsyncOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9C22A52711000EC1C47 /* AsyncOrderingTests.swift */; };
+		89BFE9CA2A52714400EC1C47 /* AsyncOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BFE9C22A52711000EC1C47 /* AsyncOrderingTests.swift */; };
 		89D2C671284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
 		89D2C672284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
 		89D2C673284D9E18004B108C /* SubclassDetectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */; };
@@ -488,6 +494,8 @@
 		8961ABC727B3546E008DD498 /* SelectedTests+ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SelectedTests+ObjC.m"; sourceTree = "<group>"; };
 		89A7919C28139D0900D99622 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		89A7919D28139D0900D99622 /* Quick.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Quick.podspec; sourceTree = "<group>"; };
+		89BFE9BE2A5270C400EC1C47 /* OrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingTests.swift; sourceTree = "<group>"; };
+		89BFE9C22A52711000EC1C47 /* AsyncOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOrderingTests.swift; sourceTree = "<group>"; };
 		89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetectionSpec.swift; sourceTree = "<group>"; };
 		89D2C674284DA77D004B108C /* SubclassDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubclassDetection.swift; sourceTree = "<group>"; };
 		89E3F80A29F5A94400EA7370 /* AsyncSpec+testMethodSelectors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AsyncSpec+testMethodSelectors.m"; sourceTree = "<group>"; };
@@ -691,6 +699,7 @@
 		1E4441882988A3BC009AE584 /* Async */ = {
 			isa = PBXGroup;
 			children = (
+				89BFE9C22A52711000EC1C47 /* AsyncOrderingTests.swift */,
 				1E4441922988A3D4009AE584 /* AfterEachAsyncTests.swift */,
 				1E44418E2988A3D4009AE584 /* AroundEachAsyncTests.swift */,
 				1E44418B2988A3D4009AE584 /* AsyncBehaviorTests.swift */,
@@ -864,6 +873,7 @@
 				DA8F91AA19F3299E006F6675 /* SharedExamplesTests.swift */,
 				89D2C670284D9E18004B108C /* SubclassDetectionSpec.swift */,
 				89E3F81529F7738B00EA7370 /* TestSelectorNameProviderTests.swift */,
+				89BFE9BE2A5270C400EC1C47 /* OrderingTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -1567,6 +1577,7 @@
 				1F118D0F1BDCA54B005013A2 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
 				1E4441C52988A3FC009AE584 /* PendingAsyncTests.swift in Sources */,
 				CD1F6507226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
+				89BFE9CA2A52714400EC1C47 /* AsyncOrderingTests.swift in Sources */,
 				1F118D101BDCA556005013A2 /* Configuration+AfterEach.swift in Sources */,
 				1E4441C32988A3FC009AE584 /* AroundEachAsyncTests.swift in Sources */,
 				1E4441C12988A3FC009AE584 /* DescribeAsyncTests.swift in Sources */,
@@ -1597,6 +1608,7 @@
 				8D010A591C11726F00633E2B /* DescribeTests.swift in Sources */,
 				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
 				1E4441BF2988A3FC009AE584 /* AsyncBehaviorTests.swift in Sources */,
+				89BFE9C12A5270C400EC1C47 /* OrderingTests.swift in Sources */,
 				1E4441C02988A3FC009AE584 /* BeforeEachAsyncTests.swift in Sources */,
 				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
 				DA5CBB4B1EAFA61D00297C9E /* CurrentSpecTests.swift in Sources */,
@@ -1687,6 +1699,7 @@
 				DA8F91A619F3208B006F6675 /* BeforeSuiteTests.swift in Sources */,
 				1E4441B92988A3FB009AE584 /* PendingAsyncTests.swift in Sources */,
 				CD1F6505226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
+				89BFE9C72A52713E00EC1C47 /* AsyncOrderingTests.swift in Sources */,
 				DA8C00221A01E4B900CE58A6 /* QuickConfigurationTests.m in Sources */,
 				1E4441B72988A3FB009AE584 /* AroundEachAsyncTests.swift in Sources */,
 				1E4441B52988A3FB009AE584 /* DescribeAsyncTests.swift in Sources */,
@@ -1717,6 +1730,7 @@
 				47FAEA371A3F49EB005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECC1A43442900043E50 /* AfterEachTests+ObjC.m in Sources */,
 				1E4441B32988A3FB009AE584 /* AsyncBehaviorTests.swift in Sources */,
+				89BFE9C02A5270C400EC1C47 /* OrderingTests.swift in Sources */,
 				1E4441B42988A3FB009AE584 /* BeforeEachAsyncTests.swift in Sources */,
 				47876F7E1A49AD71002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB4A1EAFA61C00297C9E /* CurrentSpecTests.swift in Sources */,
@@ -1857,6 +1871,7 @@
 				DA05D61019F73A3800771050 /* AfterEachTests.swift in Sources */,
 				1E4441AD2988A3FA009AE584 /* PendingAsyncTests.swift in Sources */,
 				CD1F6503226398F600EBE9D8 /* XCTestObservationCenter+QCKSuspendObservation.swift in Sources */,
+				89BFE9C32A52713C00EC1C47 /* AsyncOrderingTests.swift in Sources */,
 				DAB0136F19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift in Sources */,
 				1E4441AB2988A3FA009AE584 /* AroundEachAsyncTests.swift in Sources */,
 				1E4441A92988A3FA009AE584 /* DescribeAsyncTests.swift in Sources */,
@@ -1887,6 +1902,7 @@
 				47FAEA361A3F49E6005A1D2F /* BeforeEachTests+ObjC.m in Sources */,
 				470D6ECB1A43442400043E50 /* AfterEachTests+ObjC.m in Sources */,
 				1E4441A72988A3FA009AE584 /* AsyncBehaviorTests.swift in Sources */,
+				89BFE9BF2A5270C400EC1C47 /* OrderingTests.swift in Sources */,
 				1E4441A82988A3FA009AE584 /* BeforeEachAsyncTests.swift in Sources */,
 				47876F7D1A49AD63002575C7 /* BeforeSuiteTests+ObjC.m in Sources */,
 				DA5CBB491EAFA61A00297C9E /* CurrentSpecTests.swift in Sources */,

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncOrderingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AsyncOrderingTests.swift
@@ -1,0 +1,71 @@
+import Quick
+import Nimble
+
+class AsyncOrderingTests: AsyncSpec {
+    override class func spec() {
+        describe("Running a set of tests exactly in the order that they're written") {
+            var testRunCount = 0
+
+            it("b should run this one first") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(1))
+            }
+
+            it("z should run this one second") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(2))
+            }
+
+            it("e should run this one third") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(3))
+            }
+
+            it("a should run this one fourth") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(4))
+            }
+
+            describe("h even handles describes") {
+                it("c should run this one fifth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(5))
+                }
+
+                it("j should run this one sixth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(6))
+                }
+            }
+
+            it("d should run this one seventh") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(7))
+            }
+
+            describe("k more describes don't break it") {
+                it("c should run this one eighth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(8))
+                }
+
+                it("j should run this one ninth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(9))
+                }
+            }
+
+            context("n works for contexts too") {
+                it("c should run this one tenth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(10))
+                }
+
+                it("j should run this one eleventh") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(11))
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuickTests/QuickTests/FunctionalTests/OrderingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/OrderingTests.swift
@@ -1,0 +1,71 @@
+import Quick
+import Nimble
+
+class OrderingTests: QuickSpec {
+    override class func spec() {
+        describe("Running a set of tests exactly in the order that they're written") {
+            var testRunCount = 0
+
+            it("b should run this one first") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(1))
+            }
+
+            it("z should run this one second") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(2))
+            }
+
+            it("e should run this one third") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(3))
+            }
+
+            it("a should run this one fourth") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(4))
+            }
+
+            describe("h even handles describes") {
+                it("c should run this one fifth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(5))
+                }
+
+                it("j should run this one sixth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(6))
+                }
+            }
+
+            it("d should run this one seventh") {
+                testRunCount += 1
+                expect(testRunCount).to(equal(7))
+            }
+
+            describe("k more describes don't break it") {
+                it("c should run this one eighth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(8))
+                }
+
+                it("j should run this one ninth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(9))
+                }
+            }
+
+            context("n works for contexts too") {
+                it("c should run this one tenth") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(10))
+                }
+
+                it("j should run this one eleventh") {
+                    testRunCount += 1
+                    expect(testRunCount).to(equal(11))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #759

See also #766, which this is inspired by.

This suggests to XCTest that we run tests in the order they are defined in. As #766 notes, this is a suggestion and XCTest can and will easily ignore that in certain circumstances. This is even desirable, as the preferred mechanism for randomizing test execution order is through enabling "Randomize Execution Order" in your xctestplan.

This is a departure from how tests were previously ordered. Before we didn't suggest an order, but in practice, tests would usually run as un-nested examples first, then nested examples later (unless you did any kind of filtering - including using test gems -, then tests would run in lexicographical order). Now we suggest that tests run in the order they are defined in. I don't consider this to be a breaking change because, despite the change in behavior, we are moving from a behavior that was otherwise undocumented to documenting and specifying the behavior.

Massive thanks to @jwfriese for #766, which provided the inspiration for this.

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?

