### PR TITLE
Updated TestState to remove the value after the test.

### DIFF
--- a/Sources/Quick/TestState.swift
+++ b/Sources/Quick/TestState.swift
@@ -16,7 +16,7 @@ public struct TestState<T> {
     public init() {
         if AsyncWorld.sharedWorld.currentExampleGroup != nil {
             AsyncWorld.sharedWorld.beforeEach { [container] in
-                TestStateConfiguration.afterEach.append {
+                AsyncSpec.current.addTeardownBlock {
                     container.value = nil
                 }
             }
@@ -24,7 +24,7 @@ public struct TestState<T> {
 
         if World.sharedWorld.currentExampleGroup != nil {
             World.sharedWorld.beforeEach { [container] in
-                TestStateConfiguration.afterEach.append {
+                QuickSpec.current.addTeardownBlock {
                     container.value = nil
                 }
             }
@@ -35,7 +35,7 @@ public struct TestState<T> {
         if AsyncWorld.sharedWorld.currentExampleGroup != nil {
             AsyncWorld.sharedWorld.beforeEach { [container] in
                 container.value = wrappedValue()
-                TestStateConfiguration.afterEach.append {
+                AsyncSpec.current.addTeardownBlock {
                     container.value = nil
                 }
             }
@@ -44,7 +44,7 @@ public struct TestState<T> {
         if World.sharedWorld.currentExampleGroup != nil {
             World.sharedWorld.beforeEach { [container] in
                 container.value = wrappedValue()
-                TestStateConfiguration.afterEach.append {
+                QuickSpec.current.addTeardownBlock {
                     container.value = nil
                 }
             }
@@ -55,16 +55,5 @@ public struct TestState<T> {
     /// - Parameter initialValue: An autoclosure to return the initial value to use before the test.
     public init(_ initialValue: @escaping @autoclosure () -> T) {
         self.init(wrappedValue: initialValue())
-    }
-}
-
-private final class TestStateConfiguration: QuickConfiguration {
-    static var afterEach: [() -> Void] = []
-
-    override class func configure(_ configuration: QCKConfiguration) {
-        configuration.afterEach {
-            afterEach.forEach { $0() }
-            afterEach = []
-        }
     }
 }

--- a/Sources/Quick/TestState.swift
+++ b/Sources/Quick/TestState.swift
@@ -15,32 +15,38 @@ public struct TestState<T> {
     /// Resets the property to nil after each test.
     public init() {
         if AsyncWorld.sharedWorld.currentExampleGroup != nil {
-            AsyncWorld.sharedWorld.afterEach { [container] in
-                container.value = nil
+            AsyncWorld.sharedWorld.beforeEach { [container] in
+                TestStateConfiguration.afterEach.append {
+                    container.value = nil
+                }
             }
         }
 
         if World.sharedWorld.currentExampleGroup != nil {
-            World.sharedWorld.afterEach { [container] in
-                container.value = nil
+            World.sharedWorld.beforeEach { [container] in
+                TestStateConfiguration.afterEach.append {
+                    container.value = nil
+                }
             }
         }
     }
 
     public init(wrappedValue: @escaping @autoclosure () -> T?) {
         if AsyncWorld.sharedWorld.currentExampleGroup != nil {
-            AsyncWorld.sharedWorld.aroundEach { [container] runExample in
+            AsyncWorld.sharedWorld.beforeEach { [container] in
                 container.value = wrappedValue()
-                await runExample()
-                container.value = nil
+                TestStateConfiguration.afterEach.append {
+                    container.value = nil
+                }
             }
         }
 
         if World.sharedWorld.currentExampleGroup != nil {
-            World.sharedWorld.aroundEach { [container] runExample in
+            World.sharedWorld.beforeEach { [container] in
                 container.value = wrappedValue()
-                runExample()
-                container.value = nil
+                TestStateConfiguration.afterEach.append {
+                    container.value = nil
+                }
             }
         }
     }
@@ -48,20 +54,17 @@ public struct TestState<T> {
     /// Sets the property to an initial value before each test and resets it to nil after each test.
     /// - Parameter initialValue: An autoclosure to return the initial value to use before the test.
     public init(_ initialValue: @escaping @autoclosure () -> T) {
-        if AsyncWorld.sharedWorld.currentExampleGroup != nil {
-            AsyncWorld.sharedWorld.aroundEach { [container] runExample in
-                container.value = initialValue()
-                await runExample()
-                container.value = nil
-            }
-        }
+        self.init(wrappedValue: initialValue())
+    }
+}
 
-        if World.sharedWorld.currentExampleGroup != nil {
-            World.sharedWorld.aroundEach { [container] runExample in
-                container.value = initialValue()
-                runExample()
-                container.value = nil
-            }
+private final class TestStateConfiguration: QuickConfiguration {
+    static var afterEach: [() -> Void] = []
+
+    override class func configure(_ configuration: QCKConfiguration) {
+        configuration.afterEach {
+            afterEach.forEach { $0() }
+            afterEach = []
         }
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/TestStateSpec.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/TestStateSpec.swift
@@ -22,8 +22,26 @@ class FunctionalTests_TestStateSpec: QuickSpec {
             }
         }
 
-        describe("testState with an initial value") {
-            @TestState(9876) var testState: Int!
+        describe("testState with initial wrapped value") {
+            @TestState var testState = 9876
+            var beforeEachValue: Int?
+            var afterEachValue: Int?
+
+            beforeEach {
+                beforeEachValue = testState
+            }
+
+            afterEach {
+                afterEachValue = testState
+            }
+
+            it("should be set in beforeEach") {
+                expect(beforeEachValue) == testState
+            }
+
+            it("should have a value in afterEach") {
+                expect(afterEachValue) == testState
+            }
 
             it("starts with the initial value") {
                 expect(testState) == 9876
@@ -41,8 +59,26 @@ class FunctionalTests_TestStateSpec: QuickSpec {
             }
         }
 
-        describe("testState with initial wrapped value") {
-            @TestState var testState = 9876
+        describe("testState with an initial value") {
+            @TestState(9876) var testState: Int!
+            var beforeEachValue: Int?
+            var afterEachValue: Int?
+
+            beforeEach {
+                beforeEachValue = testState
+            }
+
+            afterEach {
+                afterEachValue = testState
+            }
+
+            it("should be set in beforeEach") {
+                expect(beforeEachValue) == testState
+            }
+
+            it("should have a value in afterEach") {
+                expect(afterEachValue) == testState
+            }
 
             it("starts with the initial value") {
                 expect(testState) == 9876
@@ -83,8 +119,63 @@ class FunctionalTests_TestStateAsyncSpec: AsyncSpec {
             }
         }
 
+        describe("testState with initial wrapped value") {
+            @TestState var testState = 9876
+            var beforeEachValue: Int?
+            var afterEachValue: Int?
+
+            beforeEach {
+                beforeEachValue = testState
+            }
+
+            afterEach {
+                afterEachValue = testState
+            }
+
+            it("should be set in beforeEach") {
+                expect(beforeEachValue) == testState
+            }
+
+            it("should have a value in afterEach") {
+                expect(afterEachValue) == testState
+            }
+
+            it("starts with the initial value") {
+                expect(testState) == 9876
+            }
+
+            context("when it's assigned a value") {
+                it("should have the value in the test where it was set") {
+                    testState = 1234
+                    expect(testState) == 1234
+                }
+
+                it("should be reset to the initial in the following test") {
+                    expect(testState) == 9876
+                }
+            }
+        }
+
         describe("testState with an initial value") {
             @TestState(9876) var testState: Int!
+            var beforeEachValue: Int?
+            var afterEachValue: Int?
+
+            beforeEach {
+                beforeEachValue = testState
+            }
+
+            afterEach {
+                afterEachValue = testState
+            }
+
+            it("should be set in beforeEach") {
+                expect(beforeEachValue) == testState
+            }
+
+            it("should have a value in afterEach") {
+                expect(afterEachValue) == testState
+            }
 
             it("starts with the initial value") {
                 expect(testState) == 9876


### PR DESCRIPTION
Currently, a property with `@TestState` will have its value reset to `nil` before any `afterEach` in the same `ExampleGroup` is run. This is because:
- the `@TestState` needs to be defined first so the tests can use it
- the `@TestState` was adding an `afterEach` to the current `ExampleGroup`
- the `afterEach` closures are run in the order they are defined in an `ExampleGroup`

This causes the `afterEach` resetting the `TestState` value to always be run before the `afterEach` closures defined in the same `ExampleGroup`.

This is an issue when a test needs to do additional cleanup using the value from `TestState. Ideally the value in the `TestState` would only be cleaned up after all the code in the test has finished running.

## Example

```swift
@TestState var tempDir: URL!
        
beforeEach {
    tempDir = FileManager.default
        .temporaryDirectory
        .appendingPathComponent(randomDirName())
    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)    
}

afterEach {
    try? FileManager.default.removeItem(at: tempDir)
}
```

When this runs, the `afterEach` will crash because `tempDir` has already been reset to nil.

## Solution

~`TestState` has been updated to use an `afterEach` set in a `QuickConfiguration` to ensure that the value is reset after the current example group has finished running. This works because configurations behave like a parent `ExampleGroup` of the root `ExampleGroup` for the spec.~

~On one hand this does feel a little wierd to for Quick itself to be defining a configuration, but it was the simplest approach I could find.~

It's been updated to add a teardown block to the test case to set the value back to nil since that will always be run after the `afterEach` blocks.

### Alternatives considered
Update `ExampleGroup`/`ExampleHooks` to a `alwaysAfterEach` array that would function similar to `justBeforeEach` where it's a second array of closures that are always run last. This would have been a larger change to add support to the Sync/Async versions of `World`, `ExampleGroup`, and `ExampleHooks`

## Checklist

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?