### PR TITLE
Build carthage artifacts as a github action.

### DIFF
--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -1,0 +1,36 @@
+name: Carthage
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5.3.1
+        with:
+          paths: '[".github/workflows/carthage.yml", "Sources/**", "Rakefile"]'
+          do_not_skip: '["push", "workflow_dispatch", "schedule"]'
+
+  carthage:
+    name: Carthage Build
+    needs: filter
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}
+      - run: rake carthage:build
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: "Release Artifacts"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  carthage_archive:
+    name: Darwin, Xcode 14.0
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: ["14.0.1"]
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Archive Quick
+        run: |
+          rake carthage:build
+          zip -r Quick.xcframework.zip Carthage/Build/Quick.xcframework
+      - name: Upload Quick.xcframework.zip
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Quick.xcframework.zip

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,13 @@ namespace "podspec" do
   end
 end
 
+namespace "carthage" do
+  desc "Build Carthage artifacts"
+  task :build do
+    run "carthage build --no-skip-current --use-xcframeworks --verbose"
+  end
+end
+
 namespace "test" do
   desc "Run unit tests for all iOS targets"
   task :ios do |t|

--- a/script/release
+++ b/script/release
@@ -4,7 +4,6 @@ POD_NAME=Quick
 PODSPEC=Quick.podspec
 
 POD=${COCOAPODS:-"bundle exec pod"}
-CARTHAGE=${CARTHAGE:-"carthage"}
 GH=${GH:-"gh"}
 
 function help {
@@ -41,11 +40,6 @@ if [ -z "`which $POD`" ]; then
     die "Cocoapods is required to produce a release. Install with rubygems using 'gem install cocoapods'. Aborting."
 fi
 echo " > Cocoapods is installed"
-
-if [ -z "`which $CARTHAGE`" ]; then
-    die "Carthage is required to produce a release. Install with brew using 'brew install carthage'. Aborting."
-fi
-echo " > Carthage is installed"
 
 if [ -z "`which $GH`" ]; then
     die "gh (github CLI) is required to produce a release. Install with brew using 'brew install gh'. Aborting."
@@ -164,11 +158,6 @@ echo "-> Pushing to pod trunk..."
 
 $POD trunk push "$PODSPEC"
 
-echo "Creating a carthage archive to include in the release"
-$CARTHAGE build --archive --use-xcframeworks
-zip -r Quick.xcframework.zip Carthage/Build/Quick.xcframework
-
-
 # Check version tag to determine whether to mark the release as a prerelease version or not.
 echo $VERSION_TAG | grep -q -E "^v\d+\.\d+\.\d+\$"
 if [ $? -eq 0 ]; then
@@ -179,7 +168,7 @@ fi
 
 echo "-> Creating a github release using auto-generated notes."
 
-$GH release create -R Quick/Quick $VERSION_TAG Quick.framework.zip Quick.xcframework.zip --generate-notes $PRERELEASE_FLAGS
+$GH release create -R Quick/Quick $VERSION_TAG --generate-notes $PRERELEASE_FLAGS
 
 echo
 echo "================ Finalizing the Release ================"
@@ -187,6 +176,7 @@ echo
 echo " - Opening GitHub to allow for any edits to the release notes."
 echo "   - You should add a Highlights section at the top to call out any notable changes or fixes."
 echo "   - In particular, any breaking changes should be listed under Highlights."
+echo "   - Carthage archive frameworks will be automatically uploaded after the release is published."
 echo " - Announce!"
 
 open "https://github.com/Quick/Quick/releases/tag/$VERSION_TAG"


### PR DESCRIPTION
Build the Quick Carthage artifact on Xcode 14, which corresponds to swift 5.7 - the oldest version we currently support.

Remove building the Carthage artifact from the release script, because GitHub actions should be doing this for us.

Add a GitHub PR action to verify that Carthage artifacts can actually be built.