### PR TITLE
Fix crash in AsyncSpec when using TestState

### DIFF
--- a/Sources/Quick/Async/AsyncSpec.swift
+++ b/Sources/Quick/Async/AsyncSpec.swift
@@ -83,11 +83,11 @@ open class AsyncSpec: AsyncSpecBase {
 
     private static func addInstanceMethod(for example: AsyncExample, classSelectorNames selectorNames: inout Set<String>) -> Selector {
         let block: @convention(block) (AsyncSpec, @escaping () -> Void) -> Void = { spec, completionHandler in
-            spec.example = example
             Task {
+                spec.example = example
                 await example.run()
-                completionHandler()
                 AsyncSpec.current = nil
+                completionHandler()
             }
         }
         let implementation = imp_implementationWithBlock(block as Any)


### PR DESCRIPTION
Fixes #1258 

Sometimes, Using TestState in AsyncSpec would crash. I traced this down to a race condition where a new test could be started/running, and then we would unset `AsyncSpec.current`.

The diff here is fairly small, so let's step through it:

This is the actual test method that we create for XCTest, example.run is when we actually run the test code.

Was:

```swift
spec.example = example
Task {
    await example.run()
    completionHandler()
    AsyncSpec.current = nil
}
```

Now:

```swift
Task {
    spec.example = example
    await example.run()
    AsyncSpec.current = nil
    completionHandler()
}
```

While I'm fairly certain that moving `spec.example = example` into the Task isn't necessary, I also know that it doesn't hurt. For reference, as a side effect of setting `spec.example`, we also set `AsyncSpec.current`. See [AsyncSpec.example](https://github.com/Quick/Quick/blob/main/Sources/Quick/Async/AsyncSpec.swift#L18-L22).

The actual bug here is setting `AsyncSpec.current = nil` after we call `completionHandler`. `completionHandler` is where we tell XCTest that we've finished running the test and it can move on (because we're integrating with an Objective-C API, and lose some safety there). I can definitely see the not-uncommon case where XCTest would start running the next test after we call completionHandler but before we had executed the `AsyncSpec.current = nil` line. For example, the following control flow:

```
Thread 1 (running test 1): completionHandler()
Thread 2 (running test 2): spec.example = example
Thread 1: AsyncSpec.current = nil
Thread 2: await example.run()
...
```

It's useful to remember that, despite XCTest supporting async specs, XCTest does not support running tests concurrently in the same process (and for good reasons - way too easy to trip over any of the many singletons in an app). When you run tests concurrently, XCTest spins up multiple processes to run them.

Anyway, by moving the `AsyncSpec.current = nil` to before we call `completionHandler()`, we can be sure that unsetting AsyncSpec.current will happen before we run the next test.