### PR TITLE
Respect XCTSkip and StopTest errors in beforeEach, afterEach and aroundEach

### DIFF
--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -107,13 +107,7 @@ public class Example: ExampleBase {
             do {
                 try closure()
             } catch {
-                if let stopTestError = error as? StopTest {
-                    self.reportStoppedTest(stopTestError)
-                } else if let testSkippedError = error as? XCTSkip {
-                    self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
-                } else {
-                    self.reportFailedTest(error, name: name, callsite: callsite)
-                }
+                self.handleErrorInTest(error, name: name, callsite: callsite)
             }
 
             self.group!.phase = .aftersExecuting
@@ -127,7 +121,7 @@ public class Example: ExampleBase {
                 do {
                     try closure()
                 } catch {
-                    self.reportFailedTest(error, name: name, callsite: callsite)
+                    self.handleErrorInTest(error, name: name, callsite: callsite)
                     cancelTests = true
                 }
             }
@@ -145,7 +139,7 @@ public class Example: ExampleBase {
         do {
             try wrappedExample()
         } catch {
-            self.reportFailedTest(error, name: name, callsite: callsite)
+            self.handleErrorInTest(error, name: name, callsite: callsite)
         }
 
         group!.phase = .aftersFinished
@@ -174,6 +168,16 @@ public class Example: ExampleBase {
     #if canImport(Darwin)
     static internal let recordSkipSelector = NSSelectorFromString("recordSkipWithDescription:sourceCodeContext:")
     #endif
+
+    internal func handleErrorInTest(_ error: Error, name: String, callsite: Callsite) {
+        if let stopTestError = error as? StopTest {
+            self.reportStoppedTest(stopTestError)
+        } else if let testSkippedError = error as? XCTSkip {
+            self.reportSkippedTest(testSkippedError, name: name, callsite: callsite)
+        } else {
+            self.reportFailedTest(error, name: name, callsite: callsite)
+        }
+    }
 
     internal func reportSkippedTest(_ testSkippedError: XCTSkip, name: String, callsite: Callsite) {
         #if !canImport(Darwin)

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -15,6 +15,7 @@ private var afterEachOrder = [AfterEachType]()
 
 private enum ThrowingAfterEachType: String, CustomStringConvertible {
     case outerOne
+    case outerTwo
     case innerOne
     case innerTwo
     case innerThree
@@ -104,11 +105,75 @@ class FunctionalTests_AfterEachSpec: QuickSpec {
     }
 }
 
+private var skippingAfterEachOrder = [ThrowingAfterEachType]()
+
+class FunctionalTests_AfterEachSkippingSpec: QuickSpec {
+    override class func spec() {
+        describe("skipping tests") {
+            afterEach {
+                if isRunningFunctionalTests {
+                    throw XCTSkip()
+                }
+            }
+
+            afterEach {
+                skippingAfterEachOrder.append(.outerTwo)
+            }
+
+            it("skips this test's afterEach") {
+                skippingAfterEachOrder.append(.outerOne)
+            }
+        }
+    }
+}
+
+private var stoppingAfterEachOrder = [ThrowingAfterEachType]()
+
+class FunctionalTests_AfterEachStoppingSpec: QuickSpec {
+    override class func spec() {
+        describe("stopping tests") {
+            context("silently stopping") {
+                afterEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest.silently
+                    }
+                }
+
+                afterEach {
+                    stoppingAfterEachOrder.append(.outerTwo)
+                }
+
+                it("supports silently stopping tests") {
+                    stoppingAfterEachOrder.append(.outerOne)
+                }
+            }
+
+            context("stopping tests with expected tests") {
+                afterEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest("some error")
+                    }
+                }
+
+                afterEach {
+                    stoppingAfterEachOrder.append(.outerTwo)
+                }
+
+                it("supports stopping tests with an error message") {
+                    stoppingAfterEachOrder.append(.outerOne)
+                }
+            }
+        }
+    }
+}
+
 final class AfterEachTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (AfterEachTests) -> () throws -> Void)] {
         return [
             ("testAfterEachIsExecutedInTheCorrectOrder", testAfterEachIsExecutedInTheCorrectOrder),
             ("testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs", testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs),
+            ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
+            ("testStoppingExamplesAreCorrectlyReported", testStoppingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -151,6 +216,37 @@ final class AfterEachTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(
             throwingAfterEachOrder,
             expectedOrder
+        )
+    }
+
+    func testSkippingExamplesAreCorrectlyReported() {
+        skippingAfterEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_AfterEachSkippingSpec.self)!
+        XCTAssertTrue(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 1)
+        XCTAssertEqual(result.skipCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 0)
+
+        XCTAssertEqual(
+            skippingAfterEachOrder,
+            [.outerOne, .outerTwo] // it runs the test, and continues running the subsequent afterEachs
+        )
+    }
+
+    func testStoppingExamplesAreCorrectlyReported() {
+        stoppingAfterEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_AfterEachStoppingSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.unexpectedExceptionCount, 0)
+        XCTAssertEqual(result.totalFailureCount, 1)
+
+        XCTAssertEqual(
+            stoppingAfterEachOrder,
+            [.outerOne, .outerTwo, .outerOne, .outerTwo] // it continues running subsequent afterEachs
         )
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/AfterEachTests.swift
@@ -112,7 +112,7 @@ class FunctionalTests_AfterEachSkippingSpec: QuickSpec {
         describe("skipping tests") {
             afterEach {
                 if isRunningFunctionalTests {
-                    throw XCTSkip()
+                    throw XCTSkip("this test is intentionally skipped")
                 }
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
@@ -15,6 +15,7 @@ private var afterEachOrder = [AfterEachType]()
 
 private enum ThrowingAfterEachType: String, CustomStringConvertible {
     case outerOne
+    case outerTwo
     case innerOne
     case innerTwo
     case innerThree
@@ -104,11 +105,75 @@ class FunctionalTests_AfterEachAsyncSpec: AsyncSpec {
     }
 }
 
+private var skippingAfterEachOrder = [ThrowingAfterEachType]()
+
+class FunctionalTests_AfterEachSkippingAsyncSpec: QuickSpec {
+    override class func spec() {
+        describe("skipping tests") {
+            afterEach {
+                if isRunningFunctionalTests {
+                    throw XCTSkip()
+                }
+            }
+
+            afterEach {
+                skippingAfterEachOrder.append(.outerTwo)
+            }
+
+            it("skips this test's afterEach") {
+                skippingAfterEachOrder.append(.outerOne)
+            }
+        }
+    }
+}
+
+private var stoppingAfterEachOrder = [ThrowingAfterEachType]()
+
+class FunctionalTests_AfterEachStoppingAsyncSpec: QuickSpec {
+    override class func spec() {
+        describe("stopping tests") {
+            context("silently stopping") {
+                afterEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest.silently
+                    }
+                }
+
+                afterEach {
+                    stoppingAfterEachOrder.append(.outerTwo)
+                }
+
+                it("supports silently stopping tests") {
+                    stoppingAfterEachOrder.append(.outerOne)
+                }
+            }
+
+            context("stopping tests with expected tests") {
+                afterEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest("some error")
+                    }
+                }
+
+                afterEach {
+                    stoppingAfterEachOrder.append(.outerTwo)
+                }
+
+                it("supports stopping tests with an error message") {
+                    stoppingAfterEachOrder.append(.outerOne)
+                }
+            }
+        }
+    }
+}
+
 final class AfterEachAsyncTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (AfterEachAsyncTests) -> () throws -> Void)] {
         return [
             ("testAfterEachIsExecutedInTheCorrectOrder", testAfterEachIsExecutedInTheCorrectOrder),
             ("testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs", testAfterEachWhenThrowingStopsRunningAdditionalAfterEachs),
+            ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
+            ("testStoppingExamplesAreCorrectlyReported", testStoppingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -151,6 +216,37 @@ final class AfterEachAsyncTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(
             throwingAfterEachOrder,
             expectedOrder
+        )
+    }
+
+    func testSkippingExamplesAreCorrectlyReported() {
+        skippingAfterEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_AfterEachSkippingAsyncSpec.self)!
+        XCTAssertTrue(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 1)
+        XCTAssertEqual(result.skipCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 0)
+
+        XCTAssertEqual(
+            skippingAfterEachOrder,
+            [.outerOne, .outerTwo] // it runs the test, and continues running the subsequent afterEachs
+        )
+    }
+
+    func testStoppingExamplesAreCorrectlyReported() {
+        stoppingAfterEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_AfterEachStoppingAsyncSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.unexpectedExceptionCount, 0)
+        XCTAssertEqual(result.totalFailureCount, 1)
+
+        XCTAssertEqual(
+            stoppingAfterEachOrder,
+            [.outerOne, .outerTwo, .outerOne, .outerTwo] // it continues running subsequent afterEachs
         )
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/AfterEachAsyncTests.swift
@@ -112,7 +112,7 @@ class FunctionalTests_AfterEachSkippingAsyncSpec: QuickSpec {
         describe("skipping tests") {
             afterEach {
                 if isRunningFunctionalTests {
-                    throw XCTSkip()
+                    throw XCTSkip("this test is intentionally skipped")
                 }
             }
 

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
@@ -115,7 +115,7 @@ class FunctionalTests_BeforeEachSkippingAsyncSpec: AsyncSpec {
     override class func spec() {
         describe("skipping tests") {
             beforeEach {
-                throw XCTSkip()
+                throw XCTSkip("this test is intentionally skipped")
             }
 
             afterEach {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/BeforeEachAsyncTests.swift
@@ -109,11 +109,73 @@ class FunctionalTests_BeforeEachAsyncSpec: AsyncSpec {
     }
 }
 
+private var skippingBeforeEachOrder = [ThrowingBeforeEachType]()
+
+class FunctionalTests_BeforeEachSkippingAsyncSpec: AsyncSpec {
+    override class func spec() {
+        describe("skipping tests") {
+            beforeEach {
+                throw XCTSkip()
+            }
+
+            afterEach {
+                skippingBeforeEachOrder.append(.afterEach)
+            }
+
+            it("skips this test") {
+                skippingBeforeEachOrder.append(.inner)
+            }
+        }
+    }
+}
+
+private var stoppingBeforeEachOrder = [ThrowingBeforeEachType]()
+
+class FunctionalTests_BeforeEachStoppingAsyncSpec: AsyncSpec {
+    override class func spec() {
+        describe("stopping tests") {
+            context("silently stopping") {
+                beforeEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest.silently
+                    }
+                }
+
+                afterEach {
+                    stoppingBeforeEachOrder.append(.outerOne)
+                }
+
+                it("supports silently stopping tests") {
+                    stoppingBeforeEachOrder.append(.inner)
+                }
+            }
+
+            context("stopping tests with expected tests") {
+                beforeEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest("some error")
+                    }
+                }
+
+                afterEach {
+                    stoppingBeforeEachOrder.append(.outerTwo)
+                }
+
+                it("supports stopping tests with an error message") {
+                    stoppingBeforeEachOrder.append(.inner)
+                }
+            }
+        }
+    }
+}
+
 final class BeforeEachAsyncTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeforeEachAsyncTests) -> () throws -> Void)] {
         return [
             ("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
             ("testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs", testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs),
+            ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
+            ("testStoppingExamplesAreCorrectlyReported", testStoppingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -164,6 +226,37 @@ final class BeforeEachAsyncTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(
             throwingBeforeEachOrder,
             expectedOrder
+        )
+    }
+
+    func testSkippingExamplesAreCorrectlyReported() {
+        skippingBeforeEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_BeforeEachSkippingAsyncSpec.self)!
+        XCTAssertTrue(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 1)
+        XCTAssertEqual(result.skipCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 0)
+
+        XCTAssertEqual(
+            skippingBeforeEachOrder,
+            [.afterEach] // it still runs the afterEachs
+        )
+    }
+
+    func testStoppingExamplesAreCorrectlyReported() {
+        stoppingBeforeEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_BeforeEachStoppingAsyncSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.unexpectedExceptionCount, 0)
+        XCTAssertEqual(result.totalFailureCount, 1)
+
+        XCTAssertEqual(
+            stoppingBeforeEachOrder,
+            [.outerOne, .outerTwo]
         )
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -112,7 +112,7 @@ class FunctionalTests_BeforeEachSkippingSpec: QuickSpec {
     override class func spec() {
         describe("skipping tests") {
             beforeEach {
-                throw XCTSkip()
+                throw XCTSkip("this test is intentionally skipped")
             }
 
             afterEach {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BeforeEachTests.swift
@@ -106,11 +106,73 @@ class FunctionalTests_BeforeEachSpec: QuickSpec {
     }
 }
 
+private var skippingBeforeEachOrder = [ThrowingBeforeEachType]()
+
+class FunctionalTests_BeforeEachSkippingSpec: QuickSpec {
+    override class func spec() {
+        describe("skipping tests") {
+            beforeEach {
+                throw XCTSkip()
+            }
+
+            afterEach {
+                skippingBeforeEachOrder.append(.afterEach)
+            }
+
+            it("skips this test") {
+                skippingBeforeEachOrder.append(.inner)
+            }
+        }
+    }
+}
+
+private var stoppingBeforeEachOrder = [ThrowingBeforeEachType]()
+
+class FunctionalTests_BeforeEachStoppingSpec: QuickSpec {
+    override class func spec() {
+        describe("stopping tests") {
+            context("silently stopping") {
+                beforeEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest.silently
+                    }
+                }
+
+                afterEach {
+                    stoppingBeforeEachOrder.append(.outerOne)
+                }
+
+                it("supports silently stopping tests") {
+                    stoppingBeforeEachOrder.append(.inner)
+                }
+            }
+
+            context("stopping tests with expected tests") {
+                beforeEach {
+                    if isRunningFunctionalTests {
+                        throw StopTest("some error")
+                    }
+                }
+
+                afterEach {
+                    stoppingBeforeEachOrder.append(.outerTwo)
+                }
+
+                it("supports stopping tests with an error message") {
+                    stoppingBeforeEachOrder.append(.inner)
+                }
+            }
+        }
+    }
+}
+
 final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeforeEachTests) -> () throws -> Void)] {
         return [
             ("testBeforeEachIsExecutedInTheCorrectOrder", testBeforeEachIsExecutedInTheCorrectOrder),
             ("testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs", testBeforeEachWhenThrowingStopsRunningTestsButDoesCallAfterEachs),
+            ("testSkippingExamplesAreCorrectlyReported", testSkippingExamplesAreCorrectlyReported),
+            ("testStoppingExamplesAreCorrectlyReported", testStoppingExamplesAreCorrectlyReported),
         ]
     }
 
@@ -161,6 +223,37 @@ final class BeforeEachTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(
             throwingBeforeEachOrder,
             expectedOrder
+        )
+    }
+
+    func testSkippingExamplesAreCorrectlyReported() {
+        skippingBeforeEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_BeforeEachSkippingSpec.self)!
+        XCTAssertTrue(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 1)
+        XCTAssertEqual(result.skipCount, 1)
+        XCTAssertEqual(result.totalFailureCount, 0)
+
+        XCTAssertEqual(
+            skippingBeforeEachOrder,
+            [.afterEach] // it still runs the afterEachs
+        )
+    }
+
+    func testStoppingExamplesAreCorrectlyReported() {
+        stoppingBeforeEachOrder = []
+
+        let result = qck_runSpec(FunctionalTests_BeforeEachStoppingSpec.self)!
+        XCTAssertFalse(result.hasSucceeded)
+        XCTAssertEqual(result.executionCount, 2)
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.unexpectedExceptionCount, 0)
+        XCTAssertEqual(result.totalFailureCount, 1)
+
+        XCTAssertEqual(
+            stoppingBeforeEachOrder,
+            [.outerOne, .outerTwo]
         )
     }
 }


### PR DESCRIPTION
Bugfix. When you throw an XCTSkip or StopTest error in `beforeEach`, `afterEach`, or `aroundEach`, then we should respect that and properly handle them (instead of as standard errors).