### PR TITLE
Mark tested which are pended-out or not focused as skipped.

### DIFF
--- a/Sources/Quick/DSL/AsyncDSL.swift
+++ b/Sources/Quick/DSL/AsyncDSL.swift
@@ -198,8 +198,8 @@ extension AsyncDSLUser {
      - parameter description: An arbitrary string describing the example or example group.
      - parameter closure: A closure that will not be evaluated.
      */
-    public static func pending(_ description: String, closure: () async throws -> Void) {
-        AsyncWorld.sharedWorld.pending(description, closure: closure)
+    public static func pending(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () async throws -> Void) {
+        AsyncWorld.sharedWorld.pending(description, file: file, line: line, closure: closure)
     }
 
     // MARK: - Defocused

--- a/Sources/Quick/DSL/AsyncWorld+DSL.swift
+++ b/Sources/Quick/DSL/AsyncWorld+DSL.swift
@@ -6,6 +6,7 @@ import Foundation
 */
 extension AsyncWorld {
     // MARK: - Example groups.
+    @nonobjc
     internal func describe(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
         guard currentExampleMetadata == nil else {
             raiseError("'describe' cannot be used inside '\(currentPhase)', 'describe' may only be used inside 'context' or 'describe'.")
@@ -19,6 +20,7 @@ extension AsyncWorld {
         performWithCurrentExampleGroup(group, closure: closure)
     }
 
+    @nonobjc
     internal func context(_ description: String, flags: FilterFlags = [:], closure: () -> Void) {
         guard currentExampleMetadata == nil else {
             raiseError("'context' cannot be used inside '\(currentPhase)', 'context' may only be used inside 'context' or 'describe'.")
@@ -26,10 +28,12 @@ extension AsyncWorld {
         self.describe(description, flags: flags, closure: closure)
     }
 
+    @nonobjc
     internal func fdescribe(_ description: String, closure: () -> Void) {
         self.describe(description, flags: [Filter.focused: true], closure: closure)
     }
 
+    @nonobjc
     internal func xdescribe(_ description: String, closure: () -> Void) {
         self.describe(description, flags: [Filter.pending: true], closure: closure)
     }
@@ -143,8 +147,8 @@ extension AsyncWorld {
 
     // MARK: - Pending
     @nonobjc
-    internal func pending(_ description: String, closure: () async throws -> Void) {
-        print("Pending: \(description)")
+    internal func pending(_ description: String, file: FileString, line: UInt, closure: @escaping () async throws -> Void) {
+        self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 
     private var currentPhase: String {

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -260,8 +260,8 @@ extension SyncDSLUser {
      - parameter description: An arbitrary string describing the example or example group.
      - parameter closure: A closure that will not be evaluated.
      */
-    public static func pending(_ description: String, closure: () throws -> Void) {
-        World.sharedWorld.pending(description, closure: closure)
+    public static func pending(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+        World.sharedWorld.pending(description, file: file, line: line, closure: closure)
     }
 
     // MARK: - Defocused

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -325,12 +325,13 @@ extension World {
 
     // MARK: - Pending
     @nonobjc
-    internal func pending(_ description: String, closure: () async throws -> Void) {
-        print("Pending: \(description)")
+    internal func pending(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+        self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 
-    internal func pending(_ description: String, closure: () -> Void) {
-        print("Pending: \(description)")
+    @objc(pendingWithDescription:file:line:closure:)
+    internal func objc_pending(_ description: String, file: FileString, line: UInt, closure: @escaping () -> Void) {
+        self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 
     private var currentPhase: String {

--- a/Sources/Quick/Examples/AsyncExample.swift
+++ b/Sources/Quick/Examples/AsyncExample.swift
@@ -101,6 +101,27 @@ public class AsyncExample: ExampleBase {
         }
     }
 
+    public func runSkippedTest() async {
+        let asyncWorld = AsyncWorld.sharedWorld
+        let world = World.sharedWorld
+
+        if world.numberOfExamplesRun == 0 {
+            await MainActor.run {
+                world.suiteHooks.executeBefores()
+            }
+        }
+
+        reportSkippedTest(XCTSkip("Test was filtered out."), name: name, callsite: callsite)
+
+        asyncWorld.numberOfAsyncExamplesRun += 1
+
+        if !asyncWorld.isRunningAdditionalSuites && world.numberOfExamplesRun >= world.cachedIncludedExampleCount {
+            await MainActor.run {
+                world.suiteHooks.executeAfters()
+            }
+        }
+    }
+
     /**
         Evaluates the filter flags set on this example and on the example groups
         this example belongs to. Flags set on the example are trumped by flags on

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -151,6 +151,22 @@ public class Example: ExampleBase {
         }
     }
 
+    public func runSkippedTest() {
+        let world = World.sharedWorld
+
+        if world.numberOfExamplesRun == 0 {
+            world.suiteHooks.executeBefores()
+        }
+
+        reportSkippedTest(XCTSkip("Test was filtered out."), name: name, callsite: callsite)
+
+        world.numberOfSyncExamplesRun += 1
+
+        if !world.isRunningAdditionalSuites && world.numberOfExamplesRun >= world.cachedIncludedExampleCount {
+            world.suiteHooks.executeAfters()
+        }
+    }
+
     /**
         Evaluates the filter flags set on this example and on the example groups
         this example belongs to. Flags set on the example are trumped by flags on

--- a/Sources/Quick/Filter.swift
+++ b/Sources/Quick/Filter.swift
@@ -1,14 +1,5 @@
 import Foundation
 
-#if canImport(Darwin)
-// swiftlint:disable type_name
-@objcMembers
-internal class _FilterBase: NSObject {}
-#else
-internal class _FilterBase: NSObject {}
-// swiftlint:enable type_name
-#endif
-
 /**
     A mapping of string keys to booleans that can be used to
     filter examples or example groups. For example, a "focused"
@@ -20,12 +11,13 @@ internal typealias FilterFlags = [String: Bool]
     A namespace for filter flag keys, defined primarily to make the
     keys available in Objective-C.
 */
-final internal class Filter: _FilterBase {
+final internal class Filter: NSObject {
     /**
         Example and example groups with [Focused: true] are included in test runs,
         excluding all other examples without this flag. Use this to only run one or
         two tests that you're currently focusing on.
     */
+    @nonobjc
     internal class var focused: String {
         return "focused"
     }
@@ -34,6 +26,7 @@ final internal class Filter: _FilterBase {
         Example and example groups with [Pending: true] are excluded from test runs.
         Use this to temporarily suspend examples that you know do not pass yet.
     */
+    @nonobjc
     internal class var pending: String {
         return "pending"
     }

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -68,16 +68,20 @@ open class QuickSpec: QuickSpecBase {
         let examples = World.sharedWorld.examples(forSpecClass: self)
 
         var selectorNames = Set<String>()
-        return examples.map { example in
-            let selector = addInstanceMethod(for: example, classSelectorNames: &selectorNames)
+        return examples.map { (test: ExampleWrapper) in
+            let selector = addInstanceMethod(for: test.example, runFullTest: test.runFullTest, classSelectorNames: &selectorNames)
             return NSStringFromSelector(selector)
         }
     }
 
-    private static func addInstanceMethod(for example: Example, classSelectorNames selectorNames: inout Set<String>) -> Selector {
+    private static func addInstanceMethod(for example: Example, runFullTest: Bool, classSelectorNames selectorNames: inout Set<String>) -> Selector {
         let block: @convention(block) (QuickSpec) -> Void = { spec in
             spec.example = example
-            example.run()
+            if runFullTest {
+                example.run()
+            } else {
+                example.runSkippedTest()
+            }
             QuickSpec.current = nil
         }
         let implementation = imp_implementationWithBlock(block as Any)
@@ -105,12 +109,17 @@ open class QuickSpec: QuickSpecBase {
     public class var allTests: [(String, (QuickSpec) -> () throws -> Void)] {
         gatherExamplesIfNeeded()
 
-        let examples = World.sharedWorld.examples(forSpecClass: self)
-        let result = examples.map { example -> (String, (QuickSpec) -> () throws -> Void) in
-            return (example.name, { spec in
+        let exampleWrappers = World.sharedWorld.examples(forSpecClass: self)
+        let result = examples.map { wrapper -> (String, (QuickSpec) -> () throws -> Void) in
+            return (wrapper.example.name, { spec in
+                let example = wrapper.example
                 return {
                     spec.example = example
-                    example.run()
+                    if wrapper.runFullTest {
+                        example.run()
+                    } else {
+                        example.runSkippedTest()
+                    }
                     QuickSpec.current = nil
                 }
             })

--- a/Sources/Quick/World.swift
+++ b/Sources/Quick/World.swift
@@ -169,16 +169,22 @@ final internal class World: _WorldBase {
         not excluded by exclusion filters.
 
         - parameter specClass: The QuickSpec subclass for which examples are to be returned.
-        - returns: A list of examples to be run as test invocations.
+        - returns: A list of examples to be run as test invocations, along with whether to run the full test, or just mark it as skipped.
     */
-    internal func examples(forSpecClass specClass: QuickSpec.Type) -> [Example] {
+    @objc
+    internal func examples(forSpecClass specClass: QuickSpec.Type) -> [ExampleWrapper] {
         // 1. Grab all included examples.
         let included = includedExamples
         // 2. Grab the intersection of (a) examples for this spec, and (b) included examples.
-        let spec = rootExampleGroup(forSpecClass: specClass).examples.filter { included.contains($0) }
+        let spec = rootExampleGroup(forSpecClass: specClass).examples.map { example in
+            return ExampleWrapper(
+                example: example,
+                runFullTest: included.first(where: { $0.example == example})?.runFullTest ?? true
+            )
+        }
         // 3. Remove all excluded examples.
-        return spec.filter { example in
-            !self.configuration.exclusionFilters.contains { $0(example) }
+        return spec.map { test -> ExampleWrapper in
+            ExampleWrapper(example: test.example, runFullTest: test.runFullTest && !self.configuration.exclusionFilters.contains { $0(test.example) })
         }
     }
 
@@ -239,20 +245,28 @@ final internal class World: _WorldBase {
         return all
     }
 
-    private var includedExamples: [Example] {
+    private var includedExamples: [ExampleWrapper] {
         let all = allExamples
-        let included = all.filter { example in
+        let hasFocusedExamples = all.contains { example in
             return self.configuration.inclusionFilters.contains { $0(example) }
         }
 
-        if included.isEmpty && configuration.runAllWhenEverythingFiltered {
-            let exceptExcluded = all.filter { example in
-                return !self.configuration.exclusionFilters.contains { $0(example) }
+        if !hasFocusedExamples && configuration.runAllWhenEverythingFiltered {
+            return all.map { example in
+                ExampleWrapper(
+                    example: example,
+                    runFullTest: !self.configuration.exclusionFilters.contains { $0(example) }
+                )
             }
-
-            return exceptExcluded
         } else {
-            return included
+            return all.map { example in
+                return ExampleWrapper(
+                    example: example,
+                    runFullTest: self.configuration.inclusionFilters.contains {
+                        $0(example)
+                    }
+                )
+            }
         }
     }
 
@@ -266,5 +280,25 @@ final internal class World: _WorldBase {
         if sharedExamples[name] == nil {
             raiseError("No shared example named '\(name)' has been registered. Registered shared examples: '\(Array(sharedExamples.keys))'")
         }
+    }
+}
+
+#if canImport(Darwin)
+// swiftlint:disable type_name
+@objcMembers
+internal class _ExampleWrapperBase: NSObject {}
+#else
+internal class _ExampleWrapperBase: NSObject {}
+// swiftlint:enable type_name
+#endif
+
+final internal class ExampleWrapper: _ExampleWrapperBase {
+    private(set) var example: Example
+    private(set) var runFullTest: Bool
+
+    init(example: Example, runFullTest: Bool) {
+        self.example = example
+        self.runFullTest = runFullTest
+        super.init()
     }
 }

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.h
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.h
@@ -215,18 +215,6 @@ static inline void justBeforeEach(QCKDSLEmptyBlock closure) {
 } NS_SWIFT_UNAVAILABLE("")
 
 /**
- Defines an example or example group that should not be executed. Use
- ``pending(description, closure)`` to temporarily disable
- examples or groups that should not be run yet.
- 
- @param description An arbitrary string describing the example or example group.
- @param closure A closure that will not be evaluated.
- */
-static inline void pending(NSString *description, QCKDSLEmptyBlock closure) {
-    qck_pending(description, closure);
-} NS_SWIFT_UNAVAILABLE("")
-
-/**
  Use this to quickly mark a ``describe(description, closure)`` block as pending.
  This disables all examples within the block.
  */
@@ -265,6 +253,7 @@ static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
 #define itBehavesLike qck_itBehavesLike
 #define xitBehavesLike qck_xitBehavesLike
 #define fitBehavesLike qck_fitBehavesLike
+#define pending qck_pending
 #endif
 
 #define qck_it qck_it_builder(@(__FILE__), __LINE__)
@@ -273,6 +262,7 @@ static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
 #define qck_itBehavesLike qck_itBehavesLike_builder(@(__FILE__), __LINE__)
 #define qck_xitBehavesLike qck_xitBehavesLike_builder(@(__FILE__), __LINE__)
 #define qck_fitBehavesLike qck_fitBehavesLike_builder(@(__FILE__), __LINE__)
+#define qck_pending qck_pending_builder(@(__FILE__), __LINE__)
 
 typedef void (^QCKItBlock)(NSString *description, QCKDSLEmptyBlock closure);
 typedef void (^QCKItBehavesLikeBlock)(NSString *description, QCKDSLSharedExampleContext context);
@@ -283,3 +273,4 @@ QUICK_EXPORT QCKItBlock qck_fit_builder(NSString *file, NSUInteger line) NS_SWIF
 QUICK_EXPORT QCKItBehavesLikeBlock qck_itBehavesLike_builder(NSString *file, NSUInteger line) NS_SWIFT_UNAVAILABLE("");
 QUICK_EXPORT QCKItBehavesLikeBlock qck_xitBehavesLike_builder(NSString *file, NSUInteger line) NS_SWIFT_UNAVAILABLE("");
 QUICK_EXPORT QCKItBehavesLikeBlock qck_fitBehavesLike_builder(NSString *file, NSUInteger line) NS_SWIFT_UNAVAILABLE("");
+QUICK_EXPORT QCKItBlock qck_pending_builder(NSString *file, NSUInteger line) NS_SWIFT_UNAVAILABLE("");

--- a/Sources/QuickObjectiveC/DSL/QCKDSL.m
+++ b/Sources/QuickObjectiveC/DSL/QCKDSL.m
@@ -108,16 +108,10 @@ QCKItBehavesLikeBlock qck_fitBehavesLike_builder(NSString *file, NSUInteger line
     };
 }
 
-void qck_pending(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] pending:description closure:closure];
-}
-
-void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
-    [[World sharedWorld] xdescribe:description closure:closure];
-}
-
-void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure) {
-    qck_xdescribe(description, closure);
+QCKItBlock qck_pending_builder(NSString *file, NSUInteger line) {
+    return ^(NSString *description, QCKDSLEmptyBlock closure) {
+        [[World sharedWorld] pendingWithDescription:description file:file line:line closure:closure];
+    };
 }
 
 void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure) {

--- a/Sources/QuickObjectiveC/QuickSpec.m
+++ b/Sources/QuickObjectiveC/QuickSpec.m
@@ -28,13 +28,13 @@ static QuickSpec *currentSpec = nil;
     // In case of fix in later versions next line can be removed
     [[QuickTestObservation sharedInstance] buildAllExamplesIfNeeded];
 
-    NSArray *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
+    NSArray<ExampleWrapper *> *examples = [[World sharedWorld] examplesForSpecClass:[self class]];
     NSMutableArray *invocations = [NSMutableArray arrayWithCapacity:[examples count]];
     
     NSMutableSet<NSString*> *selectorNames = [NSMutableSet set];
     
-    for (Example *example in examples) {
-        SEL selector = [self addInstanceMethodForExample:example classSelectorNames:selectorNames];
+    for (ExampleWrapper *exampleWrapper in examples) {
+        SEL selector = [self addInstanceMethodForExample:exampleWrapper.example runFullTest:exampleWrapper.runFullTest classSelectorNames:selectorNames];
 
         NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
@@ -124,11 +124,15 @@ static QuickSpec *currentSpec = nil;
 
  @return The selector of the newly defined instance method.
  */
-+ (SEL)addInstanceMethodForExample:(Example *)example classSelectorNames:(NSMutableSet<NSString*> *)selectorNames {
++ (SEL)addInstanceMethodForExample:(Example *)example runFullTest:(BOOL)runFullTest classSelectorNames:(NSMutableSet<NSString*> *)selectorNames {
     IMP implementation = imp_implementationWithBlock(^(QuickSpec *self){
         self.example = example;
         currentSpec = self;
-        [example run];
+        if (runFullTest) {
+            [example run];
+        } else {
+            [example runSkippedTest];
+        }
         currentSpec = nil;
     });
 

--- a/Tests/QuickTests/QuickFocusedTests/FacusedTests+Async.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FacusedTests+Async.swift
@@ -60,6 +60,6 @@ final class FocusedAsyncTests: XCTestCase, XCTestCaseProvider {
             _FunctionalTests_FocusedSpec_Focused.self,
         ])
         #endif
-        XCTAssertEqual(result?.executionCount, 8)
+        XCTAssertEqual((result?.executionCount ?? 0) - (result?.skipCount ?? 0), 8)
     }
 }

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests+ObjC.m
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests+ObjC.m
@@ -50,7 +50,7 @@ QuickSpecEnd
         [FunctionalTests_FocusedSpec_Focused_ObjC class],
         [FunctionalTests_FocusedSpec_Unfocused_ObjC class]
     ]);
-    XCTAssertEqual(result.executionCount, 5);
+    XCTAssertEqual(result.executionCount - result.skipCount, 5);
 }
 
 @end

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -74,6 +74,6 @@ final class FocusedTests: XCTestCase, XCTestCaseProvider {
             _FunctionalTests_FocusedSpec_Focused.self,
         ])
         #endif
-        XCTAssertEqual(result?.executionCount, 8)
+        XCTAssertEqual((result?.executionCount ?? 0) - (result?.skipCount ?? 0), 8)
     }
 }

--- a/Tests/QuickTests/QuickTests/FunctionalTests/Async/PendingAsyncTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/Async/PendingAsyncTests.swift
@@ -17,6 +17,9 @@ class FunctionalTests_PendingAsyncSpec: AsyncSpec {
         xit("an example that will not run") {
             await expect(true).toEventually(beFalsy())
         }
+        pending("it doesn't run code inside a pending at all") {
+            fatalError("this should not be run")
+        }
         xitBehavesLike(FunctionalTests_PendingAsyncSpec_AsyncBehavior.self) { () -> Void in }
         describe("a describe block containing only one enabled example") {
             beforeEach { oneExampleBeforeEachExecutedCount += 1 }
@@ -47,6 +50,7 @@ final class PendingAsyncTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (PendingAsyncTests) -> () throws -> Void)] {
         return [
             ("testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail", testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail),
+            ("testPendingExamplesAllAreMarkedAsSkipped", testPendingExamplesAllAreMarkedAsSkipped),
             ("testBeforeEachOnlyRunForEnabledExamples", testBeforeEachOnlyRunForEnabledExamples),
             ("testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples", testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples),
         ]
@@ -55,6 +59,11 @@ final class PendingAsyncTests: XCTestCase, XCTestCaseProvider {
     func testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail() {
         let result = qck_runSpec(FunctionalTests_PendingAsyncSpec.self)
         XCTAssertTrue(result!.hasSucceeded)
+    }
+
+    func testPendingExamplesAllAreMarkedAsSkipped() {
+        let result = qck_runSpec(FunctionalTests_PendingAsyncSpec.self)
+        XCTAssertEqual(result?.skipCount, 7)
     }
 
     func testBeforeEachOnlyRunForEnabledExamples() {

--- a/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/PendingTests.swift
@@ -23,6 +23,9 @@ class FunctionalTests_PendingSpec: QuickSpec {
         xit("an example that will not run") {
             expect(true).to(beFalsy())
         }
+        pending("it doesn't run code inside a pending at all") {
+            fatalError("this should not be run")
+        }
         xitBehavesLike(FunctionalTests_PendingSpec_Behavior.self) { () -> Void in }
         xitBehavesLike("shared pending behavior")
         xitBehavesLike("shared pending behavior", sharedExampleContext: { [:] })
@@ -55,6 +58,7 @@ final class PendingTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (PendingTests) -> () throws -> Void)] {
         return [
             ("testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail", testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail),
+            ("testPendingExamplesAllAreMarkedAsSkipped", testPendingExamplesAllAreMarkedAsSkipped),
             ("testBeforeEachOnlyRunForEnabledExamples", testBeforeEachOnlyRunForEnabledExamples),
             ("testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples", testBeforeEachDoesNotRunForContextsWithOnlyPendingExamples),
         ]
@@ -63,6 +67,11 @@ final class PendingTests: XCTestCase, XCTestCaseProvider {
     func testAnOtherwiseFailingExampleWhenMarkedPendingDoesNotCauseTheSuiteToFail() {
         let result = qck_runSpec(FunctionalTests_PendingSpec.self)
         XCTAssertTrue(result!.hasSucceeded)
+    }
+
+    func testPendingExamplesAllAreMarkedAsSkipped() {
+        let result = qck_runSpec(FunctionalTests_PendingSpec.self)
+        XCTAssertEqual(result?.skipCount, 9)
     }
 
     func testBeforeEachOnlyRunForEnabledExamples() {


### PR DESCRIPTION
This changes our pending behavior. Now, we will make sure that all tests that Quick skips using `pending`, `xdescribe`, `xit`, `xitBehavesLike` are marked as skipped in the Xcode test navigator.
Similarly, if you have focused a test using `fcontext`, `fdescribe`, `fit`, `fitBehavesLike`, then Quick will mark all the other tests as skipped in the Xcode test navigator.

Sadly, this does come with a performance regression. Perhaps in the future, Xcode will expose an API for us to mark tests as skipped in bulk.

Fixes #332
Fixes #770

 - [x] Is this a new feature (Requires minor version bump)?

