### PR TITLE
Mark the async versions of sharedExamples as unavailable.

### DIFF
--- a/Sources/Quick/DSL/AsyncDSL.swift
+++ b/Sources/Quick/DSL/AsyncDSL.swift
@@ -190,6 +190,24 @@ extension AsyncDSLUser {
         AsyncWorld.sharedWorld.itBehavesLike(behavior, context: context, file: file, line: line)
     }
 
+    /**
+     In the Synchronous DSL, `sharedExamples` offers an untyped way to define
+     a group of shared examples that can be re-used in several locations using `itBehavesLike`.
+
+     In Quick 7, we decided to remove support for `sharedExamples` in the Asynchronous DSL. Please use the typed `Behavior` DSL in place of `sharedExamples`
+     */
+    @available(*, unavailable, message: "sharedExamples is unavailable in Quick's Async DSL. Please migrate to the Behvavior DSL, which offers type-safety for the injected configuration.")
+    public static func sharedExamples(_ name: String, closure: @escaping () -> Void) {}
+
+    /**
+     In the Synchronous DSL, `sharedExamples` offers an untyped way to define
+     a group of shared examples that can be re-used in several locations using `itBehavesLike`.
+
+     In Quick 7, we decided to remove support for `sharedExamples` in the Asynchronous DSL. Please use the typed `Behavior` DSL in place of `sharedExamples`
+     */
+    @available(*, unavailable, message: "sharedExamples is unavailable in Quick's Async DSL. Please migrate to the Behvavior DSL, which offers type-safety for the injected configuration.")
+    public static func sharedExamples(_ name: String, closure: @escaping SharedExampleClosure) {}
+
     // MARK: - Pending
     /**
      Defines an example or example group that should not be executed. Use `pending` to temporarily disable

--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -49,6 +49,8 @@ extension SyncDSLUser {
      - parameter closure: A closure containing the examples. This behaves just like an example group defined
      using `describe` or `context`--the closure may contain any number of `beforeEach`
      and `afterEach` closures, as well as any number of examples (defined using `it`).
+
+     - Remark: `sharedExamples` is untyped. Please use ``Behavior`` instead, as it offers type-safety.
      */
     public static func sharedExamples(_ name: String, closure: @escaping () -> Void) {
         World.sharedWorld.sharedExamples(name) { _ in closure() }
@@ -64,7 +66,9 @@ extension SyncDSLUser {
      using `describe` or `context`--the closure may contain any number of `beforeEach`
      and `afterEach` closures, as well as any number of examples (defined using `it`).
 
-     The closure takes a SharedExampleContext as an argument. This context is a function
+     - Remark: `sharedExamples` and the context passed in to it are untyped. Please use ``Behavior`` instead, as it offers type-safety.
+
+     The closure takes a ``SharedExampleContext`` as an argument. This context is a function
      that can be executed to retrieve parameters passed in via an `itBehavesLike` function.
      */
     public static func sharedExamples(_ name: String, closure: @escaping SharedExampleClosure) {


### PR DESCRIPTION
Add a remark to the synchronous version to prompt users to upgrade to Behavior.

Resolves #1278

Note: as of this PR, I have no plans to remove `sharedExamples` from the synchronous DSL.