### PR TITLE
Add QuickLint, a CLI tool to detect focused specs, and optionally remove the focus.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
-        "version" : "2.1.2"
+        "revision" : "3ef6999c73b6938cc0da422f2c912d0158abb0a0",
+        "version" : "2.2.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
-        "version" : "2.2.0"
+        "revision" : "2ef56b2caf25f55fa7eef8784c30d5a767550f54",
+        "version" : "2.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
-        "version" : "13.2.0"
+        "revision" : "efe11bbca024b57115260709b5c05e01131470d0",
+        "version" : "13.2.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "46989693916f56d1186bd59ac15124caef896560",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-fakes",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/swift-fakes.git",
+      "state" : {
+        "revision" : "d38a57c30ec2cbc7fb1c69e20fe3d7b7aebd60b3",
+        "version" : "0.0.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,20 @@ let package = Package(
         .library(name: "Quick", targets: ["Quick"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.1"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
+        .package(url: "https://github.com/Quick/swift-fakes.git", from: "0.0.1"),
     ],
     targets: {
         var targets: [Target] = [
+            .executableTarget(
+                name: "QuickLint",
+                dependencies: [
+                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                    .product(name: "Algorithms", package: "swift-algorithms"),
+                ]
+            ),
             .testTarget(
                 name: "QuickTests",
                 dependencies: [ "Quick", "Nimble" ],
@@ -35,6 +45,15 @@ let package = Package(
                 name: "QuickIssue853RegressionTests",
                 dependencies: [ "Quick" ]
             ),
+            .testTarget(
+                name: "QuickLintTests",
+                dependencies: [
+                    "QuickLint",
+                    "Quick",
+                    "Nimble",
+                    .product(name: "Fakes", package: "swift-fakes"),
+                ]
+            )
         ]
 #if os(macOS)
         targets.append(contentsOf: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,10 @@ let package = Package(
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
+        .executable(name: "QuickLint", targets: ["QuickLint"]),
+        .plugin(name: "QuickDefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
+        .plugin(name: "QuickLintBuildToolPlugin", targets: ["LintBuildToolPlugin"]),
+        .plugin(name: "QuickLintCommandPlugin", targets: ["LintCommandPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
@@ -18,6 +22,21 @@ let package = Package(
     ],
     targets: {
         var targets: [Target] = [
+            .plugin(
+                name: "DefocusCommandPlugin",
+                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintBuildToolPlugin",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintCommandPlugin",
+                capability: .command(intent: .custom(verb: "quicklint", description: "Verify no focused tests in Quick tests"), permissions: []),
+                dependencies: ["QuickLint"]
+            ),
             .executableTarget(
                 name: "QuickLint",
                 dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,10 @@ let package = Package(
     products: [
         .library(name: "Quick", targets: ["Quick"]),
         .executable(name: "QuickLint", targets: ["QuickLint"]),
-        .plugin(name: "QuickDefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
-        .plugin(name: "QuickLintBuildToolPlugin", targets: ["LintBuildToolPlugin"]),
-        .plugin(name: "QuickLintCommandPlugin", targets: ["LintCommandPlugin"]),
+        .plugin(name: "DefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
+        .plugin(name: "LintError", targets: ["LintError"]),
+        .plugin(name: "LintWarning", targets: ["LintWarning"]),
+        .plugin(name: "LintCommandPlugin", targets: ["LintCommandPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
@@ -24,11 +25,16 @@ let package = Package(
         var targets: [Target] = [
             .plugin(
                 name: "DefocusCommandPlugin",
-                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
+                capability: .command(intent: .sourceCodeFormatting(), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick tests")]),
                 dependencies: ["QuickLint"]
             ),
             .plugin(
-                name: "LintBuildToolPlugin",
+                name: "LintError",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintWarning",
                 capability: .buildTool(),
                 dependencies: ["QuickLint"]
             ),

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
-        .executable(name: "QuickLint", targets: ["QuickLint"]),
+        .executable(name: "quicklint", targets: ["QuickLint"]),
         .plugin(name: "DefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
         .plugin(name: "LintError", targets: ["LintError"]),
         .plugin(name: "LintWarning", targets: ["LintWarning"]),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -9,12 +9,35 @@ let package = Package(
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
+        .executable(name: "QuickLint", targets: ["QuickLint"]),
+//        .plugin(name: "QuickBuildToolPlugin", targets: ["QuickBuildToolPlugin"]),
+//        .plugin(name: "QuickCommandPlugin", targets: ["QuickCommandPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.1"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
+        .package(url: "https://github.com/Quick/swift-fakes.git", from: "0.0.1"),
     ],
     targets: {
         var targets: [Target] = [
+//            .plugin(
+//                name: "QuickBuildToolPlugin",
+//                capability: .buildTool(),
+//                dependencies: []
+//            ),
+//            .plugin(
+//                name: "QuickCommandPlugin",
+//                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
+//                dependencies: []
+//            ),
+            .executableTarget(
+                name: "QuickLint",
+                dependencies: [
+                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                    .product(name: "Algorithms", package: "swift-algorithms"),
+                ]
+            ),
             .testTarget(
                 name: "QuickTests",
                 dependencies: [ "Quick", "Nimble" ],
@@ -35,6 +58,15 @@ let package = Package(
                 name: "QuickIssue853RegressionTests",
                 dependencies: [ "Quick" ]
             ),
+            .testTarget(
+                name: "QuickLintTests",
+                dependencies: [
+                    "QuickLint",
+                    "Quick",
+                    "Nimble",
+                    .product(name: "Fakes", package: "swift-fakes"),
+                ]
+            )
         ]
 #if os(macOS)
         targets.append(contentsOf: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -10,9 +10,10 @@ let package = Package(
     products: [
         .library(name: "Quick", targets: ["Quick"]),
         .executable(name: "QuickLint", targets: ["QuickLint"]),
-        .plugin(name: "QuickDefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
-        .plugin(name: "QuickLintBuildToolPlugin", targets: ["LintBuildToolPlugin"]),
-        .plugin(name: "QuickLintCommandPlugin", targets: ["LintCommandPlugin"]),
+        .plugin(name: "DefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
+        .plugin(name: "LintError", targets: ["LintError"]),
+        .plugin(name: "LintWarning", targets: ["LintWarning"]),
+        .plugin(name: "LintCommandPlugin", targets: ["LintCommandPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
@@ -24,11 +25,16 @@ let package = Package(
         var targets: [Target] = [
             .plugin(
                 name: "DefocusCommandPlugin",
-                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
+                capability: .command(intent: .sourceCodeFormatting(), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick tests")]),
                 dependencies: ["QuickLint"]
             ),
             .plugin(
-                name: "LintBuildToolPlugin",
+                name: "LintError",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintWarning",
                 capability: .buildTool(),
                 dependencies: ["QuickLint"]
             ),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -10,8 +10,9 @@ let package = Package(
     products: [
         .library(name: "Quick", targets: ["Quick"]),
         .executable(name: "QuickLint", targets: ["QuickLint"]),
-//        .plugin(name: "QuickBuildToolPlugin", targets: ["QuickBuildToolPlugin"]),
-//        .plugin(name: "QuickCommandPlugin", targets: ["QuickCommandPlugin"]),
+        .plugin(name: "QuickDefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
+        .plugin(name: "QuickLintBuildToolPlugin", targets: ["LintBuildToolPlugin"]),
+        .plugin(name: "QuickLintCommandPlugin", targets: ["LintCommandPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
@@ -21,16 +22,21 @@ let package = Package(
     ],
     targets: {
         var targets: [Target] = [
-//            .plugin(
-//                name: "QuickBuildToolPlugin",
-//                capability: .buildTool(),
-//                dependencies: []
-//            ),
-//            .plugin(
-//                name: "QuickCommandPlugin",
-//                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
-//                dependencies: []
-//            ),
+            .plugin(
+                name: "DefocusCommandPlugin",
+                capability: .command(intent: .custom(verb: "defocus", description: "Remove focus from Quick examples"), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick examples")]),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintBuildToolPlugin",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintCommandPlugin",
+                capability: .command(intent: .custom(verb: "quicklint", description: "Verify no focused tests in Quick tests"), permissions: []),
+                dependencies: ["QuickLint"]
+            ),
             .executableTarget(
                 name: "QuickLint",
                 dependencies: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),
-        .executable(name: "QuickLint", targets: ["QuickLint"]),
+        .executable(name: "quicklint", targets: ["QuickLint"]),
         .plugin(name: "DefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
         .plugin(name: "LintError", targets: ["LintError"]),
         .plugin(name: "LintWarning", targets: ["LintWarning"]),

--- a/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
+++ b/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
@@ -1,0 +1,56 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct DefocusCommandPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) throws {
+        try run(
+            tool: try context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.package.directory.string),
+            arguments: arguments
+        )
+    }
+
+    private func run(
+        tool: PluginContext.Tool,
+        workingDirectory: URL,
+        arguments: [String]
+    ) throws {
+        let process: Process = .init()
+        process.currentDirectoryURL = workingDirectory
+        process.executableURL = URL(fileURLWithPath: tool.path.string)
+        process.arguments = ["defocus"] + arguments
+        try process.run()
+        process.waitUntilExit()
+        switch process.terminationReason {
+        case .exit:
+            break
+        case .uncaughtSignal:
+            Diagnostics.error("Uncaught Signal")
+        @unknown default:
+            Diagnostics.error("Unexpected Termination Reason")
+        }
+        guard process.terminationStatus == EXIT_SUCCESS else {
+            Diagnostics.error("Command Failed")
+            return
+        }
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension DefocusCommandPlugin: XcodeCommandPlugin {
+    /// This entry point is called when operating on an Xcode project.
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        try run(
+            tool: context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
+            arguments: []
+        )
+    }
+}
+#endif

--- a/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
+++ b/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
@@ -39,18 +39,3 @@ struct DefocusCommandPlugin: CommandPlugin {
         }
     }
 }
-
-#if canImport(XcodeProjectPlugin)
-import XcodeProjectPlugin
-
-extension DefocusCommandPlugin: XcodeCommandPlugin {
-    /// This entry point is called when operating on an Xcode project.
-    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
-        try run(
-            tool: context.tool(named: "QuickLint"),
-            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
-            arguments: []
-        )
-    }
-}
-#endif

--- a/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
+++ b/Plugins/DefocusCommandPlugin/DefocusCommandPlugin.swift
@@ -39,3 +39,19 @@ struct DefocusCommandPlugin: CommandPlugin {
         }
     }
 }
+
+#if canImport(XcodeProjectPlugin)
+
+import XcodeProjectPlugin
+
+extension DefocusCommandPlugin: XcodeCommandPlugin {
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        try run(
+            tool: try context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
+            arguments: arguments
+        )
+    }
+}
+
+#endif

--- a/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
+++ b/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
@@ -1,0 +1,64 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct LintBuildToolPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: any Target) async throws -> [Command] {
+        try makeCommand(
+            executable: context.tool(named: "QuickLint"),
+            files: (target as? SourceModuleTarget).flatMap(lintableFiles(target:)) ?? [],
+            pluginWorkDirectory: context.pluginWorkDirectory
+        )
+    }
+
+    private func lintableFiles(target: SourceModuleTarget) -> [Path] {
+        target
+            .sourceFiles
+            .filter(isLintable(file:))
+            .map { $0.path }
+    }
+
+    private func isLintable(file: PackagePlugin.File) -> Bool {
+        return ["swift", "m", "mm"].contains(file.path.extension ?? "")
+    }
+
+    private func makeCommand(
+        executable: PluginContext.Tool,
+        files: [Path],
+        pluginWorkDirectory path: Path) throws -> [Command] {
+            guard files.isEmpty == false else { return [] }
+
+            return [Command.prebuildCommand(
+                displayName: "QuickLint",
+                executable: executable.path,
+                arguments: ["lint"] + files.map { $0.string },
+                outputFilesDirectory: path.appending("Output")
+            )]
+        }
+}
+
+#if canImport(XcodeProjectPlugin)
+
+import XcodeProjectPlugin
+
+extension LintBuildToolPlugin: XcodeBuildToolPlugin {
+    func createBuildCommands(
+            context: XcodePluginContext,
+            target: XcodeTarget
+        ) throws -> [Command] {
+            try makeCommand(
+                executable: context.tool(named: "Quicklint"),
+                files: lintableFiles(target: target),
+                pluginWorkDirectory: context.pluginWorkDirectory
+            )
+        }
+
+    private func lintableFiles(target: XcodeTarget) -> [Path] {
+        target.inputFiles
+            .filter(isLintable(file:))
+            .map { $0.path }
+    }
+
+}
+
+#endif

--- a/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
+++ b/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
@@ -28,11 +28,11 @@ struct LintBuildToolPlugin: BuildToolPlugin {
         pluginWorkDirectory path: Path) throws -> [Command] {
             guard files.isEmpty == false else { return [] }
 
-            return [Command.prebuildCommand(
+            return [Command.buildCommand(
                 displayName: "QuickLint",
                 executable: executable.path,
                 arguments: ["lint"] + files.map { $0.string },
-                outputFilesDirectory: path.appending("Output")
+                inputFiles: files
             )]
         }
 }

--- a/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
+++ b/Plugins/LintBuildToolPlugin/LintBuildToolPlugin.swift
@@ -47,7 +47,7 @@ extension LintBuildToolPlugin: XcodeBuildToolPlugin {
             target: XcodeTarget
         ) throws -> [Command] {
             try makeCommand(
-                executable: context.tool(named: "Quicklint"),
+                executable: context.tool(named: "QuickLint"),
                 files: lintableFiles(target: target),
                 pluginWorkDirectory: context.pluginWorkDirectory
             )

--- a/Plugins/LintCommandPlugin/LintCommandPlugin.swift
+++ b/Plugins/LintCommandPlugin/LintCommandPlugin.swift
@@ -1,0 +1,57 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct LintCommandPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) throws {
+        try run(
+            tool: try context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.package.directory.string),
+            arguments: arguments
+        )
+    }
+
+    private func run(
+        tool: PluginContext.Tool,
+        workingDirectory: URL,
+        arguments: [String]
+    ) throws {
+        let process: Process = .init()
+        process.currentDirectoryURL = workingDirectory
+        process.executableURL = URL(fileURLWithPath: tool.path.string)
+        process.arguments = ["lint"] + arguments
+        try process.run()
+        process.waitUntilExit()
+        switch process.terminationReason {
+        case .exit:
+            break
+        case .uncaughtSignal:
+            Diagnostics.error("Uncaught Signal")
+        @unknown default:
+            Diagnostics.error("Unexpected Termination Reason")
+        }
+        guard process.terminationStatus == EXIT_SUCCESS else {
+            Diagnostics.error("Command Failed")
+            return
+        }
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension LintCommandPlugin: XcodeCommandPlugin {
+    /// This entry point is called when operating on an Xcode project.
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        try run(
+            tool: context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
+            arguments: []
+        )
+    }
+}
+#endif
+

--- a/Plugins/LintCommandPlugin/LintCommandPlugin.swift
+++ b/Plugins/LintCommandPlugin/LintCommandPlugin.swift
@@ -39,19 +39,3 @@ struct LintCommandPlugin: CommandPlugin {
         }
     }
 }
-
-#if canImport(XcodeProjectPlugin)
-import XcodeProjectPlugin
-
-extension LintCommandPlugin: XcodeCommandPlugin {
-    /// This entry point is called when operating on an Xcode project.
-    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
-        try run(
-            tool: context.tool(named: "QuickLint"),
-            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
-            arguments: []
-        )
-    }
-}
-#endif
-

--- a/Plugins/LintCommandPlugin/LintCommandPlugin.swift
+++ b/Plugins/LintCommandPlugin/LintCommandPlugin.swift
@@ -39,3 +39,19 @@ struct LintCommandPlugin: CommandPlugin {
         }
     }
 }
+
+#if canImport(XcodeProjectPlugin)
+
+import XcodeProjectPlugin
+
+extension LintCommandPlugin: XcodeCommandPlugin {
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        try run(
+            tool: try context.tool(named: "QuickLint"),
+            workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string),
+            arguments: arguments
+        )
+    }
+}
+
+#endif

--- a/Plugins/LintError/LintError.swift
+++ b/Plugins/LintError/LintError.swift
@@ -2,7 +2,7 @@ import Foundation
 import PackagePlugin
 
 @main
-struct LintBuildToolPlugin: BuildToolPlugin {
+struct LintError: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: any Target) async throws -> [Command] {
         try makeCommand(
             executable: context.tool(named: "QuickLint"),
@@ -31,7 +31,7 @@ struct LintBuildToolPlugin: BuildToolPlugin {
             return [Command.buildCommand(
                 displayName: "QuickLint",
                 executable: executable.path,
-                arguments: ["lint"] + files.map { $0.string },
+                arguments: ["lint", "--error"] + files.map { $0.string },
                 inputFiles: files
             )]
         }
@@ -41,7 +41,7 @@ struct LintBuildToolPlugin: BuildToolPlugin {
 
 import XcodeProjectPlugin
 
-extension LintBuildToolPlugin: XcodeBuildToolPlugin {
+extension LintError: XcodeBuildToolPlugin {
     func createBuildCommands(
             context: XcodePluginContext,
             target: XcodeTarget

--- a/Plugins/LintError/LintError.swift
+++ b/Plugins/LintError/LintError.swift
@@ -29,10 +29,11 @@ struct LintError: BuildToolPlugin {
             guard files.isEmpty == false else { return [] }
 
             return [Command.buildCommand(
-                displayName: "QuickLint",
+                displayName: "quicklint",
                 executable: executable.path,
                 arguments: ["lint", "--error"] + files.map { $0.string },
-                inputFiles: files
+                inputFiles: files,
+                outputFiles: files
             )]
         }
 }

--- a/Plugins/LintWarning/LintWarning.swift
+++ b/Plugins/LintWarning/LintWarning.swift
@@ -1,0 +1,64 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct LintWarning: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: any Target) async throws -> [Command] {
+        try makeCommand(
+            executable: context.tool(named: "QuickLint"),
+            files: (target as? SourceModuleTarget).flatMap(lintableFiles(target:)) ?? [],
+            pluginWorkDirectory: context.pluginWorkDirectory
+        )
+    }
+
+    private func lintableFiles(target: SourceModuleTarget) -> [Path] {
+        target
+            .sourceFiles
+            .filter(isLintable(file:))
+            .map { $0.path }
+    }
+
+    private func isLintable(file: PackagePlugin.File) -> Bool {
+        return ["swift", "m", "mm"].contains(file.path.extension ?? "")
+    }
+
+    private func makeCommand(
+        executable: PluginContext.Tool,
+        files: [Path],
+        pluginWorkDirectory path: Path) throws -> [Command] {
+            guard files.isEmpty == false else { return [] }
+
+            return [Command.buildCommand(
+                displayName: "QuickLint",
+                executable: executable.path,
+                arguments: ["lint"] + files.map { $0.string },
+                inputFiles: files
+            )]
+        }
+}
+
+#if canImport(XcodeProjectPlugin)
+
+import XcodeProjectPlugin
+
+extension LintWarning: XcodeBuildToolPlugin {
+    func createBuildCommands(
+            context: XcodePluginContext,
+            target: XcodeTarget
+        ) throws -> [Command] {
+            try makeCommand(
+                executable: context.tool(named: "QuickLint"),
+                files: lintableFiles(target: target),
+                pluginWorkDirectory: context.pluginWorkDirectory
+            )
+        }
+
+    private func lintableFiles(target: XcodeTarget) -> [Path] {
+        target.inputFiles
+            .filter(isLintable(file:))
+            .map { $0.path }
+    }
+
+}
+
+#endif

--- a/Plugins/LintWarning/LintWarning.swift
+++ b/Plugins/LintWarning/LintWarning.swift
@@ -29,10 +29,11 @@ struct LintWarning: BuildToolPlugin {
             guard files.isEmpty == false else { return [] }
 
             return [Command.buildCommand(
-                displayName: "QuickLint",
+                displayName: "quicklint",
                 executable: executable.path,
                 arguments: ["lint"] + files.map { $0.string },
-                inputFiles: files
+                inputFiles: files,
+                outputFiles: files
             )]
         }
 }

--- a/Quick.podspec
+++ b/Quick.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
   s.exclude_files = [
     'Sources/Quick/QuickSpec.swift',
     'Sources/Quick/QuickMain.swift',
+    'Sources/QuickLint/**',
   ]
 
   s.framework = "XCTest"

--- a/Sources/QuickLint/DefocusFormatter.swift
+++ b/Sources/QuickLint/DefocusFormatter.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+protocol DefocusFormatter: Sendable {
+    func format(rootUrls: [URL]) async throws
+}
+
+struct FoundationDefocusFormatter: DefocusFormatter {
+    let detector: FileDetector
+    let fileInterface: FileInterface
+
+    func format(rootUrls: [URL]) async throws {
+        let detectedFiles = try await detector.files(
+            matching: focusRegexString,
+            at: rootUrls,
+            fileExtension: focusFileExtension
+        )
+
+        try await withThrowingTaskGroup(of: Void.self, body: { taskGroup in
+            for match in detectedFiles {
+                taskGroup.addTask {
+                    try self.format(url: match.url)
+                }
+            }
+
+            try await taskGroup.waitForAll()
+        })
+    }
+
+    private func format(url: URL) throws {
+        let contents = try fileInterface.read(url: url)
+        let regex = try NSRegularExpression(pattern: focusRegexString)
+
+        let output = regex.stringByReplacingMatches(
+            in: contents,
+            range: contents.nsRange,
+            withTemplate: "$1\\("
+        )
+        try fileInterface.write(contents: output, to: url)
+    }
+}

--- a/Sources/QuickLint/DirectoryManager.swift
+++ b/Sources/QuickLint/DirectoryManager.swift
@@ -5,8 +5,8 @@ protocol DirectoryManager: Sendable {
     /// Return a list of the contents of the directory at the given URL.
     ///
     /// - parameter directory: The directory as a URL to enumerate.
-    /// - returns: The contents of the directory. This is not a deep-enumeration.
-    /// No subfolders are searched, nor are any symlinks followed.
+    /// - returns: The contents of the directory. This is a deep enumeration,
+    /// however, no symlinks will be followed.
     func contentsOf(directory: URL) async throws -> [URL]
 }
 
@@ -15,10 +15,28 @@ actor FoundationDirectoryManager: DirectoryManager {
     let fileManager: FileManager = .default
 
     func contentsOf(directory: URL) throws -> [URL] {
-        try fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: []
-        )
+        if isDirectory(url: directory) {
+            do {
+                return try fileManager.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: []
+                ).flatMap { file in
+                    try self.contentsOf(directory: file)
+                }
+            } catch {
+                return []
+            }
+        } else {
+            return [directory]
+        }
+    }
+
+    private func isDirectory(url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+            return isDirectory.boolValue
+        }
+        return false
     }
 }

--- a/Sources/QuickLint/DirectoryManager.swift
+++ b/Sources/QuickLint/DirectoryManager.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A simple wrapper protocol for enumerating the contents of a directory.
+protocol DirectoryManager: Sendable {
+    /// Return a list of the contents of the directory at the given URL.
+    ///
+    /// - parameter directory: The directory as a URL to enumerate.
+    /// - returns: The contents of the directory. This is not a deep-enumeration.
+    /// No subfolders are searched, nor are any symlinks followed.
+    func contentsOf(directory: URL) async throws -> [URL]
+}
+
+/// A type which wraps ``FileManager`` in an actor.
+actor FoundationDirectoryManager: DirectoryManager {
+    let fileManager: FileManager = .default
+
+    func contentsOf(directory: URL) throws -> [URL] {
+        try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []
+        )
+    }
+}

--- a/Sources/QuickLint/FileDetector.swift
+++ b/Sources/QuickLint/FileDetector.swift
@@ -1,0 +1,140 @@
+import Algorithms
+import Foundation
+
+struct RegexMatch: Sendable, Comparable {
+    let url: URL
+    let line: UInt
+    let character: UInt
+
+    static func < (lhs: RegexMatch, rhs: RegexMatch) -> Bool {
+        if lhs.url == rhs.url {
+            if lhs.line == rhs.line {
+                return lhs.character < rhs.character
+            }
+            return lhs.line < rhs.line
+        }
+        return lhs.url.absoluteString < rhs.url.absoluteString
+    }
+}
+
+/**
+ FileDetector specifies the behavior for performing a regex
+ on multiple files (as detected in the directories passed in)
+ whose file extension matches the given regex.
+ */
+protocol FileDetector: Sendable {
+    /**
+     Return files, lines and characters that match the given regex,
+     are under the hierarchy of the file urls passed in,
+     and whose extension matches the given fileExtension regex.
+
+     - parameter matching: The regex to search the contents of a candidate
+     file for.
+     - parameter at: The directories to enumerate over to find files to search
+     for.
+     - parameter fileExtension: The regex specifying the extension that all
+     candidate files must have before we search there contents.
+     - returns: A list of ``RegexMatch`` results, containing the file (as a
+     URL), the line, and characters that match.
+     If the content of a file matches the `matching` regex multiple times,
+     then there will be an equal number of `RegexMatch` for that same file.
+     */
+    func files(matching regex: String, at urls: [URL], fileExtension: String) async throws -> [RegexMatch]
+}
+
+struct FoundationFileDetector: FileDetector {
+    let directoryManager: DirectoryManager
+    let fileInterface: FileInterface
+
+    func files(matching regex: String, at urls: [URL], fileExtension: String) async throws -> [RegexMatch] {
+        let regularExpression = try NSRegularExpression(pattern: regex)
+        let fileExtensionRegex = try NSRegularExpression(pattern: fileExtension)
+        return try await withThrowingTaskGroup(of: [RegexMatch].self, returning: [RegexMatch].self) { taskGroup in
+            let urls = try await deepEnumerateDirectories(at: urls)
+            for url in urls where fileExtensionRegex.hasMatch(url.pathExtension) {
+                taskGroup.addTask {
+                    return try self.urlContentsMatch(
+                        regex: regularExpression,
+                        url: url
+                    ).map { lineNumber, character in
+                        return RegexMatch(url: url, line: lineNumber, character: character)
+                    }
+                }
+            }
+
+            var results: [RegexMatch] = []
+            for try await result in taskGroup {
+                results.append(contentsOf: result)
+            }
+            return results
+        }
+    }
+
+    private func deepEnumerateDirectories(at urls: [URL]) async throws -> [URL] {
+        return try await withThrowingTaskGroup(of: [URL].self) { taskGroup in
+            for url in urls {
+                taskGroup.addTask {
+                    try await deepEnumerateDirectory(at: url)
+                }
+            }
+
+            var foundUrls: [URL] = []
+            for try await result in taskGroup {
+                foundUrls.append(contentsOf: result)
+            }
+            return foundUrls.uniqued { $0.absoluteString }
+        }
+    }
+
+    private func deepEnumerateDirectory(at url: URL) async throws -> [URL] {
+        var urls = try await directoryManager.contentsOf(directory: url)
+        for subUrl in urls {
+            if subUrl.hasDirectoryPath {
+                urls.append(
+                    contentsOf: try await directoryManager.contentsOf(
+                        directory: subUrl
+                    )
+                )
+            }
+        }
+        return urls
+    }
+
+    // returns the line number if the contents of the url match the regex.
+    // returns nil otherwise.
+    private func urlContentsMatch(regex: NSRegularExpression, url: URL) throws -> [(line: UInt, character: UInt)] {
+        let contents = try fileInterface.read(url: url)
+        let nsContents = NSString(string: contents)
+
+        return regex.matches(in: contents, range: contents.nsRange)
+            .compactMap { (textCheckingResult: NSTextCheckingResult) -> NSRange? in
+                if textCheckingResult.numberOfRanges == 0 { return nil }
+
+                let range = textCheckingResult.range(at: 0)
+                if range.location == NSNotFound { return nil }
+                return range
+            }
+            .uniqued()
+            .map { (range: NSRange) -> (line: UInt, character: UInt) in
+                let lines = nsContents
+                    .substring(to: range.location)
+                    .components(separatedBy: CharacterSet.newlines)
+                return (
+                    UInt(lines.count),
+                    UInt((lines.last?.count ?? 0) + 1)
+                )
+            }
+    }
+}
+
+extension NSRegularExpression {
+    func hasMatch(_ string: String) -> Bool {
+        self.firstMatch(in: string, range: string.nsRange) != nil
+    }
+}
+
+extension String {
+    var nsRange: NSRange {
+        NSRange(location: 0, length: utf16.count)
+    }
+}

--- a/Sources/QuickLint/FileDetector.swift
+++ b/Sources/QuickLint/FileDetector.swift
@@ -74,7 +74,7 @@ struct FoundationFileDetector: FileDetector {
         return try await withThrowingTaskGroup(of: [URL].self) { taskGroup in
             for url in urls {
                 taskGroup.addTask {
-                    try await deepEnumerateDirectory(at: url)
+                    try await directoryManager.contentsOf(directory: url)
                 }
             }
 
@@ -84,20 +84,6 @@ struct FoundationFileDetector: FileDetector {
             }
             return foundUrls.uniqued { $0.absoluteString }
         }
-    }
-
-    private func deepEnumerateDirectory(at url: URL) async throws -> [URL] {
-        var urls = try await directoryManager.contentsOf(directory: url)
-        for subUrl in urls {
-            if subUrl.hasDirectoryPath {
-                urls.append(
-                    contentsOf: try await directoryManager.contentsOf(
-                        directory: subUrl
-                    )
-                )
-            }
-        }
-        return urls
     }
 
     // returns the line number if the contents of the url match the regex.

--- a/Sources/QuickLint/FileInterface.swift
+++ b/Sources/QuickLint/FileInterface.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A simple wrapper protocol for reading and writing a file.
+///
+/// This allows you to inject a FileReader instance in test, instead of
+/// having to actually touch the file system.
+protocol FileInterface: Sendable {
+    func read(url: URL) throws -> String
+    func write(contents: String, to url: URL) throws
+}
+
+struct SimpleFileInterface: FileInterface {
+    func read(url: URL) throws -> String {
+        try String(contentsOf: url)
+    }
+
+    func write(contents: String, to url: URL) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/QuickLint/FocusLint.swift
+++ b/Sources/QuickLint/FocusLint.swift
@@ -4,14 +4,15 @@ let focusRegexString = "f(describe|context|itBehavesLike|it)\\("
 let focusFileExtension = "^(swift|m|mm)$" // swift, objective-c, objective-c++
 
 protocol FocusLint: Sendable {
-    func lint(urls: [URL], errorOnIssues: Bool) async throws
+    /// Lint the files in the urls, returns the amount of issues found.
+    func lint(urls: [URL], errorOnIssues: Bool) async throws -> Int
 }
 
 struct XcodeFocusLint: FocusLint {
     let detector: FileDetector
     let output: Writer
 
-    func lint(urls: [URL], errorOnIssues: Bool) async throws {
+    func lint(urls: [URL], errorOnIssues: Bool) async throws -> Int {
         let results = try await detector.files(
             matching: focusRegexString,
             at: urls,
@@ -21,6 +22,7 @@ struct XcodeFocusLint: FocusLint {
         if results.isEmpty == false {
             output.stderr(lines: results.map { generateXcodeOutput(for: $0, errorOnIssues: errorOnIssues) })
         }
+        return results.count
     }
 
     private func generateXcodeOutput(for result: RegexMatch, errorOnIssues: Bool) -> String {

--- a/Sources/QuickLint/FocusLint.swift
+++ b/Sources/QuickLint/FocusLint.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+let focusRegexString = "f(describe|context|itBehavesLike|it)\\("
+let focusFileExtension = "^(swift|m|mm)$" // swift, objective-c, objective-c++
+
+protocol FocusLint: Sendable {
+    func lint(urls: [URL], errorOnIssues: Bool) async throws
+}
+
+struct XcodeFocusLint: FocusLint {
+    let detector: FileDetector
+    let output: Writer
+
+    func lint(urls: [URL], errorOnIssues: Bool) async throws {
+        let results = try await detector.files(
+            matching: focusRegexString,
+            at: urls,
+            fileExtension: focusFileExtension
+        ).sorted()
+
+        if results.isEmpty == false {
+            output.stderr(lines: results.map { generateXcodeOutput(for: $0, errorOnIssues: errorOnIssues) })
+        }
+    }
+
+    private func generateXcodeOutput(for result: RegexMatch, errorOnIssues: Bool) -> String {
+        return [
+            "\(result.url.path)",
+            ":\(result.line)",
+            ":\(result.character): ",
+            "\(errorOnIssues ? "error" : "warning"): ",
+            "Focused Spec Detected."
+        ].joined()
+    }
+}

--- a/Sources/QuickLint/QuickLint.swift
+++ b/Sources/QuickLint/QuickLint.swift
@@ -1,0 +1,78 @@
+import ArgumentParser
+import Foundation
+
+/**
+ Search for any Quick examples with focus and flag it if there is any focus found.
+
+ By default, just warn on any focused examples.
+ However, with the "--error" flag, the focused examples will be marked as errors.
+ */
+struct LintCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "lint"
+    )
+
+    @Flag(name: .long, help: "Mark focused examples as errors")
+    var error: Bool = false
+
+    @Argument
+    var paths = [String]()
+
+    var dependencies = ServiceLocator()
+
+    mutating func run() async throws {
+        let paths = self.paths.isEmpty ? [""] : self.paths
+        let workingDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let urls = paths.map {
+            if $0.hasPrefix("/") {
+                return URL(fileURLWithPath: $0)
+            } else {
+                return workingDirectory.appendingPathComponent($0)
+            }
+        }
+
+        try await dependencies.linter.lint(
+            urls: urls,
+            errorOnIssues: error
+        )
+    }
+}
+
+/**
+ Search for any Quick examples with focus, and remove focus from it.
+ */
+struct DefocusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "defocus"
+    )
+
+    @Argument
+    var paths = [String]()
+
+    var dependencies = ServiceLocator()
+
+    mutating func run() async throws {
+        let paths = self.paths.isEmpty ? [""] : self.paths
+        let workingDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let urls = paths.map {
+            if $0.hasPrefix("/") {
+                return URL(fileURLWithPath: $0)
+            } else {
+                return workingDirectory.appendingPathComponent($0)
+            }
+        }
+
+        try await dependencies.defocusFormatter.format(
+            rootUrls: urls
+        )
+    }
+}
+
+@main
+struct QuickMain: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "A utility for linting and formatting Quick Specs for focus issues.",
+        subcommands: [LintCommand.self, DefocusCommand.self],
+        defaultSubcommand: LintCommand.self
+    )
+}

--- a/Sources/QuickLint/QuickLint.swift
+++ b/Sources/QuickLint/QuickLint.swift
@@ -31,10 +31,12 @@ struct LintCommand: AsyncParsableCommand {
             }
         }
 
-        try await dependencies.linter.lint(
+        if try await dependencies.linter.lint(
             urls: urls,
             errorOnIssues: error
-        )
+        ) != 0 && error {
+            throw ExitCode(1)
+        }
     }
 }
 

--- a/Sources/QuickLint/ServiceLocator.swift
+++ b/Sources/QuickLint/ServiceLocator.swift
@@ -1,0 +1,35 @@
+// Not my favorite way of managing dependencies, but it works for
+// small projects like QuickLint. This is still significantly better
+// than using global singletons, anyway.
+//
+// This is only used at the top-level `LintCommand` and `DefocusCommand`.
+struct ServiceLocator {
+    lazy var defocusFormatter: DefocusFormatter = {
+        FoundationDefocusFormatter(
+            detector: detector,
+            fileInterface: fileInterface
+        )
+    }()
+
+    lazy var detector: FileDetector = {
+        return FoundationFileDetector(
+            directoryManager: directoryManager,
+            fileInterface: fileInterface
+        )
+    }()
+
+    lazy var directoryManager: DirectoryManager = FoundationDirectoryManager()
+
+    lazy var fileInterface: FileInterface = SimpleFileInterface()
+
+    lazy var linter: FocusLint = {
+        return XcodeFocusLint(detector: detector, output: writer)
+    }()
+
+    lazy var writer: Writer = TerminalWriter()
+}
+
+extension ServiceLocator: Codable {
+    init(from decoder: any Decoder) throws {}
+    func encode(to encoder: any Encoder) throws {}
+}

--- a/Sources/QuickLint/Writer.swift
+++ b/Sources/QuickLint/Writer.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol Writer: Sendable {
+    func stderr(lines: [String])
+}
+
+struct TerminalWriter: Writer {
+    func stderr(lines: [String]) {
+        guard lines.isEmpty == false else { return }
+        let data = Data(lines.joined(separator: newline).appending(newline).utf8)
+        FileHandle.standardError.write(data)
+    }
+
+    private var newline: String {
+        #if os(Windows)
+        return "\r\n"
+        #else
+        return "\n"
+        #endif
+    }
+}

--- a/Tests/LintFixtures/Nesting/Nesting.swift
+++ b/Tests/LintFixtures/Nesting/Nesting.swift
@@ -1,0 +1,12 @@
+import Quick
+
+// This also checks nesting, and the directory structure is set up to make sure it also checks nested files as well.
+final class Nesting: QuickSpec {
+    override class func spec() {
+        fdescribe("a focused example group") {
+            fit("still identifies focused examples later on") {}
+        }
+
+        fcontext("with multiple focuses on the same line") { fit("still identifies the focusing!") {} } // swiftlint:disable:this line_length
+    }
+}

--- a/Tests/LintFixtures/SampleSpec.swift
+++ b/Tests/LintFixtures/SampleSpec.swift
@@ -1,0 +1,28 @@
+import Quick
+
+final class SampleSpec: QuickSpec {
+    override class func spec() {
+        // context
+        fcontext("focused context") {}
+        context("unfocused context") {}
+        xcontext("pending context") {}
+
+        // describe
+        fdescribe("focused describe") {}
+        describe("unfocused describe") {}
+        xdescribe("pending describe") {}
+
+        // itBehavesLike
+        fitBehavesLike("") {}
+        itBehavesLike("") {}
+        xitBehavesLike("") {}
+
+        // it
+        fit("focused it") {}
+        it("unfocused it") {}
+        xit("pending it") {}
+
+        // pending
+        pending("just pending. Which is treated internally like pending it.") {}
+    }
+}

--- a/Tests/QuickLintTests/DefocusCommandSpec.swift
+++ b/Tests/QuickLintTests/DefocusCommandSpec.swift
@@ -1,0 +1,94 @@
+import Quick
+import Nimble
+import Foundation
+@testable import QuickLint
+
+final class DefocusCommandSpec: AsyncSpec {
+    override class func spec() {
+        let testRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let lintFixtures = testRoot
+            .appendingPathComponent("LintFixtures")
+        let backupFixtures = testRoot
+            .appendingPathComponent("lintFixtureBackup")
+
+        beforeEach {
+            try FileManager.default.copyItem(at: lintFixtures, to: backupFixtures)
+        }
+
+        afterEach {
+            try FileManager.default.removeItem(at: backupFixtures)
+        }
+
+        it("finds and defocuses focused specs") {
+            var subject = DefocusCommand()
+            subject.paths = [backupFixtures.path]
+
+            try await subject.run()
+
+            expect {
+                try String(
+                    contentsOf: backupFixtures
+                        .appendingPathComponent("SampleSpec.swift")
+                )
+            }.to(equal(expectedSampleSpec))
+
+            expect {
+                try String(
+                    contentsOf: backupFixtures
+                        .appendingPathComponent("Nesting")
+                        .appendingPathComponent("Nesting.swift")
+                )
+            }.to(equal(expectedNestingSpec))
+        }
+    }
+}
+
+let expectedSampleSpec = """
+import Quick
+
+final class SampleSpec: QuickSpec {
+    override class func spec() {
+        // context
+        context("focused context") {}
+        context("unfocused context") {}
+        xcontext("pending context") {}
+
+        // describe
+        describe("focused describe") {}
+        describe("unfocused describe") {}
+        xdescribe("pending describe") {}
+
+        // itBehavesLike
+        itBehavesLike("") {}
+        itBehavesLike("") {}
+        xitBehavesLike("") {}
+
+        // it
+        it("focused it") {}
+        it("unfocused it") {}
+        xit("pending it") {}
+
+        // pending
+        pending("just pending. Which is treated internally like pending it.") {}
+    }
+}
+
+"""
+
+let expectedNestingSpec = """
+import Quick
+
+// This also checks nesting, and the directory structure is set up to make sure it also checks nested files as well.
+final class Nesting: QuickSpec {
+    override class func spec() {
+        describe("a focused example group") {
+            it("still identifies focused examples later on") {}
+        }
+
+        context("with multiple focuses on the same line") { it("still identifies the focusing!") {} } // swiftlint:disable:this line_length
+    }
+}
+
+"""

--- a/Tests/QuickLintTests/DefocusCommandSpec.swift
+++ b/Tests/QuickLintTests/DefocusCommandSpec.swift
@@ -21,26 +21,55 @@ final class DefocusCommandSpec: AsyncSpec {
             try FileManager.default.removeItem(at: backupFixtures)
         }
 
-        it("finds and defocuses focused specs") {
-            var subject = DefocusCommand()
-            subject.paths = [backupFixtures.path]
+        context("when given a directory to look at") {
+            it("finds and defocuses focused specs") {
+                var subject = DefocusCommand()
+                subject.paths = [backupFixtures.path]
 
-            try await subject.run()
+                try await subject.run()
 
-            expect {
-                try String(
-                    contentsOf: backupFixtures
-                        .appendingPathComponent("SampleSpec.swift")
-                )
-            }.to(equal(expectedSampleSpec))
+                expect {
+                    try String(
+                        contentsOf: backupFixtures
+                            .appendingPathComponent("SampleSpec.swift")
+                    )
+                }.to(equal(expectedSampleSpec))
 
-            expect {
-                try String(
-                    contentsOf: backupFixtures
-                        .appendingPathComponent("Nesting")
-                        .appendingPathComponent("Nesting.swift")
-                )
-            }.to(equal(expectedNestingSpec))
+                expect {
+                    try String(
+                        contentsOf: backupFixtures
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift")
+                    )
+                }.to(equal(expectedNestingSpec))
+            }
+        }
+
+        context("when given the precise paths to the files") {
+            it("finds and defocuses focused specs") {
+                let sampleSpec = backupFixtures
+                    .appendingPathComponent("SampleSpec.swift")
+                let nesting = backupFixtures
+                    .appendingPathComponent("Nesting")
+                    .appendingPathComponent("Nesting.swift")
+
+                var subject = DefocusCommand()
+                subject.paths = [sampleSpec.path, nesting.path]
+
+                try await subject.run()
+
+                expect {
+                    try String(
+                        contentsOf: sampleSpec
+                    )
+                }.to(equal(expectedSampleSpec))
+
+                expect {
+                    try String(
+                        contentsOf: nesting
+                    )
+                }.to(equal(expectedNestingSpec))
+            }
         }
     }
 }

--- a/Tests/QuickLintTests/DefocusFormatterSpec.swift
+++ b/Tests/QuickLintTests/DefocusFormatterSpec.swift
@@ -1,0 +1,113 @@
+import Fakes
+import Quick
+import Nimble
+import Foundation
+@testable import QuickLint
+
+final class DefocusFormatterSpec: AsyncSpec {
+    override class func spec() {
+        @TestState var detector: FakeFileDetector! = FakeFileDetector()
+        @TestState var fileInterface: FakeFileInterface! = FakeFileInterface()
+
+        @TestState var subject: FoundationDefocusFormatter!
+
+        beforeEach {
+            subject = .init(detector: detector, fileInterface: fileInterface)
+        }
+
+        describe("format(rootUrls:)") {
+            let rootUrls = [
+                URL(fileURLWithPath: "/a"),
+                URL(fileURLWithPath: "/b")
+            ]
+
+            @TestState var result: Result<Void, Error>?
+
+            beforeEach {
+                detector.filesSpy.stub(success: [])
+            }
+
+            justBeforeEach {
+                result = await Result {
+                    try await subject.format(rootUrls: rootUrls)
+                }
+            }
+
+            it("asks the detector to search for any swift or objective-c(++) files that have focused specs") {
+                expect(detector.filesSpy).to(beCalled(satisfyAllOf(
+                    map(\.matching, equal(focusRegexString)),
+                    map(\.urls, equal(rootUrls)),
+                    map(\.fileExtension, equal(focusFileExtension))
+                ), times: 1))
+            }
+
+            context("when the detector throws an error") {
+                enum TestError: Error {
+                    case ohNo
+                }
+
+                beforeEach {
+                    detector.filesSpy.stub(failure: TestError.ohNo)
+                }
+
+                it("throws the error") {
+                    expect { try result?.get() }.to(throwError(TestError.ohNo))
+                }
+            }
+
+            context("when there are matches found") {
+                let matches = [
+                    RegexMatch(
+                        url: URL(fileURLWithPath: "/a"),
+                        line: 10,
+                        character: 15
+                    )
+                ]
+                beforeEach {
+                    detector.filesSpy.stub(success: matches)
+
+                    fileInterface.readSpy.stub(
+                        success: """
+                        "this line isn't fit for replacing."
+                        fit("hello!") {}
+                        fitBehavesLike("hello")
+                        fitBehavesLike(SomeBehavior.self)
+                        fdescribe("something") { fit("nesting!") {}}
+                        fcontext("whatever")
+
+                        it("hi") {}
+                        xit("hello") {}
+                        """
+                    )
+                }
+
+                it("reads the files found") {
+                    expect(fileInterface.readSpy).to(beCalled(URL(fileURLWithPath: "/a")))
+                }
+
+                it("replaces all instances of focused specs with unfocused specs and writes that to the file.") {
+                    let expectedContents = """
+                    "this line isn't fit for replacing."
+                    it("hello!") {}
+                    itBehavesLike("hello")
+                    itBehavesLike(SomeBehavior.self)
+                    describe("something") { it("nesting!") {}}
+                    context("whatever")
+
+                    it("hi") {}
+                    xit("hello") {}
+                    """
+
+                    expect(fileInterface.writeSpy).to(beCalled(satisfyAllOf(
+                        map(\.contents, equal(expectedContents)),
+                        map(\.url, equal(URL(fileURLWithPath: "/a")))
+                    )))
+                }
+
+                it("doesn't throw an error") {
+                    expect { try result?.get() }.to(beVoid())
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuickLintTests/Fakes/FakeFileDetector.swift
+++ b/Tests/QuickLintTests/Fakes/FakeFileDetector.swift
@@ -1,0 +1,10 @@
+import Fakes
+import Foundation
+@testable import QuickLint
+
+final class FakeFileDetector: FileDetector {
+    let filesSpy = ThrowingPendableSpy<(matching: String, urls: [URL], fileExtension: String), [RegexMatch], Error>()
+    func files(matching regex: String, at urls: [URL], fileExtension: String) async throws -> [RegexMatch] {
+        return try await filesSpy((regex, urls, fileExtension))
+    }
+}

--- a/Tests/QuickLintTests/Fakes/FakeFileInterface.swift
+++ b/Tests/QuickLintTests/Fakes/FakeFileInterface.swift
@@ -1,0 +1,15 @@
+import Fakes
+import Foundation
+@testable import QuickLint
+
+final class FakeFileInterface: FileInterface {
+    let readSpy = ThrowingSpy<URL, String, Error>(success: "")
+    func read(url: URL) throws -> String {
+        return try readSpy(url)
+    }
+
+    let writeSpy = ThrowingSpy<(contents: String, url: URL), Void, Error>()
+    func write(contents: String, to url: URL) throws {
+        return try writeSpy((contents, url))
+    }
+}

--- a/Tests/QuickLintTests/Fakes/FakeWriter.swift
+++ b/Tests/QuickLintTests/Fakes/FakeWriter.swift
@@ -1,0 +1,9 @@
+import Fakes
+@testable import QuickLint
+
+final class FakeWriter: Writer {
+    let stderrSpy = Spy<[String], Void>()
+    func stderr(lines: [String]) {
+        return stderrSpy(lines)
+    }
+}

--- a/Tests/QuickLintTests/FileDetectorSpec.swift
+++ b/Tests/QuickLintTests/FileDetectorSpec.swift
@@ -13,8 +13,11 @@ final class FileDetectorSpec: AsyncSpec {
         describe("files(matching:at:fileExtension:)") {
             it("identifies files matching the regex & file extension in the given directory structure") {
                 let currentDirectory = URL(fileURLWithPath: #filePath)
-                let specDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
-                let lintFixturesDirectory = specDirectory.appending(path: "LintFixtures")
+                let specDirectory = currentDirectory
+                    .deletingLastPathComponent()
+                    .deletingLastPathComponent()
+                let lintFixturesDirectory = specDirectory
+                    .appendingPathComponent("LintFixtures")
 
                 await expect {
                     try await subject.files(
@@ -24,32 +27,41 @@ final class FileDetectorSpec: AsyncSpec {
                     ).sorted()
                 }.to(equal([
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 6,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 16,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 21,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 7,
                         character: 13
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 10,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 10,
                         character: 62
                     ),
@@ -59,10 +71,13 @@ final class FileDetectorSpec: AsyncSpec {
             it("identifies files matching the regex & file extension when given the exact files to search") {
                 let currentDirectory = URL(fileURLWithPath: #filePath)
                 let specDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
-                let lintFixturesDirectory = specDirectory.appending(path: "LintFixtures")
+                let lintFixturesDirectory = specDirectory.appendingPathComponent("LintFixtures")
                 let files: [URL] = [
-                    lintFixturesDirectory.appending(path: "SampleSpec.swift"),
-                    lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift")
+                    lintFixturesDirectory
+                        .appendingPathComponent("SampleSpec.swift"),
+                    lintFixturesDirectory
+                        .appendingPathComponent("Nesting")
+                        .appendingPathComponent("Nesting.swift")
                 ]
 
                 await expect {
@@ -73,32 +88,41 @@ final class FileDetectorSpec: AsyncSpec {
                     ).sorted()
                 }.to(equal([
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 6,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 16,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("SampleSpec.swift"),
                         line: 21,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 7,
                         character: 13
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 10,
                         character: 9
                     ),
                     RegexMatch(
-                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        url: lintFixturesDirectory
+                            .appendingPathComponent("Nesting")
+                            .appendingPathComponent("Nesting.swift"),
                         line: 10,
                         character: 62
                     ),

--- a/Tests/QuickLintTests/FileDetectorSpec.swift
+++ b/Tests/QuickLintTests/FileDetectorSpec.swift
@@ -55,6 +55,55 @@ final class FileDetectorSpec: AsyncSpec {
                     ),
                 ].sorted()))
             }
+
+            it("identifies files matching the regex & file extension when given the exact files to search") {
+                let currentDirectory = URL(fileURLWithPath: #filePath)
+                let specDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
+                let lintFixturesDirectory = specDirectory.appending(path: "LintFixtures")
+                let files: [URL] = [
+                    lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                    lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift")
+                ]
+
+                await expect {
+                    try await subject.files(
+                        matching: "f(it|context)",
+                        at: files,
+                        fileExtension: "swift"
+                    ).sorted()
+                }.to(equal([
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 6,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 16,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 21,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 7,
+                        character: 13
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 10,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 10,
+                        character: 62
+                    ),
+                ].sorted()))
+            }
         }
     }
 }

--- a/Tests/QuickLintTests/FileDetectorSpec.swift
+++ b/Tests/QuickLintTests/FileDetectorSpec.swift
@@ -1,0 +1,60 @@
+import Quick
+import Nimble
+import Foundation
+@testable import QuickLint
+
+final class FileDetectorSpec: AsyncSpec {
+    override class func spec() {
+        @TestState var subject: FileDetector! = FoundationFileDetector(
+            directoryManager: FoundationDirectoryManager(),
+            fileInterface: SimpleFileInterface()
+        )
+
+        describe("files(matching:at:fileExtension:)") {
+            it("identifies files matching the regex & file extension in the given directory structure") {
+                let currentDirectory = URL(fileURLWithPath: #filePath)
+                let specDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
+                let lintFixturesDirectory = specDirectory.appending(path: "LintFixtures")
+
+                await expect {
+                    try await subject.files(
+                        matching: "f(it|context)",
+                        at: [lintFixturesDirectory],
+                        fileExtension: "swift"
+                    ).sorted()
+                }.to(equal([
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 6,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 16,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "SampleSpec.swift"),
+                        line: 21,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 7,
+                        character: 13
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 10,
+                        character: 9
+                    ),
+                    RegexMatch(
+                        url: lintFixturesDirectory.appending(path: "Nesting").appending(path: "Nesting.swift"),
+                        line: 10,
+                        character: 62
+                    ),
+                ].sorted()))
+            }
+        }
+    }
+}

--- a/Tests/QuickLintTests/FocusLintSpec.swift
+++ b/Tests/QuickLintTests/FocusLintSpec.swift
@@ -1,0 +1,134 @@
+import Fakes
+import Quick
+import Nimble
+import Foundation
+@testable import QuickLint
+
+final class FocusLintSpec: AsyncSpec {
+    override class func spec() {
+        @TestState var subject: XcodeFocusLint!
+        @TestState var detector: FakeFileDetector! = FakeFileDetector()
+        @TestState var writer: FakeWriter! = FakeWriter()
+
+        beforeEach {
+            subject = XcodeFocusLint(detector: detector, output: writer)
+        }
+
+        describe("lines(urls:errorOnIssues:)") {
+            let urls = [
+                URL(fileURLWithPath: "/invalid"),
+                URL(fileURLWithPath: "/nonexistent"),
+            ]
+            var errorOnIssues = false
+            @TestState var result: Result<Void, Error>?
+
+            beforeEach {
+                errorOnIssues = false
+                detector.filesSpy.stub(success: [])
+            }
+
+            justBeforeEach {
+                result = await Result {
+                    try await subject.lint(
+                        urls: urls,
+                        errorOnIssues: errorOnIssues
+                    )
+                }
+            }
+
+            it("asks the detector to search for any swift or objective-c(++) files that have focused specs") {
+                expect(detector.filesSpy).to(beCalled(satisfyAllOf(
+                    map(\.matching, equal(focusRegexString)),
+                    map(\.urls, equal(urls)),
+                    map(\.fileExtension, equal(focusFileExtension))
+                ), times: 1))
+            }
+
+            context("when no matches are found") {
+                beforeEach {
+                    detector.filesSpy.stub(success: [])
+                }
+
+                it("doesn't output anything") {
+                    expect(writer.stderrSpy).toNot(beCalled())
+                }
+            }
+
+            context("when the detector throws an error") {
+                enum TestError: Error {
+                    case ohNo
+                }
+
+                beforeEach {
+                    detector.filesSpy.stub(failure: TestError.ohNo)
+                }
+
+                it("throws the error") {
+                    expect { try result?.get() }.to(throwError(TestError.ohNo))
+                }
+
+                it("doesn't output anything") {
+                    expect(writer.stderrSpy).toNot(beCalled())
+                }
+            }
+
+            context("when there are matches found") {
+                let matches = [
+                    RegexMatch(
+                        url: URL(fileURLWithPath: "/a"),
+                        line: 10,
+                        character: 15
+                    ),
+                    RegexMatch(
+                        url: URL(fileURLWithPath: "/b"),
+                        line: 5,
+                        character: 2
+                    ),
+                ]
+                beforeEach {
+                    detector.filesSpy.stub(success: matches)
+                }
+
+                context("and errorOnIssues is true") {
+                    beforeEach {
+                        errorOnIssues = true
+                    }
+
+                    it("converts the results to xcode-compatible strings, noting that these are errors") {
+                        expect(writer.stderrSpy).to(beCalled(
+                            [
+                                "/a:10:15: error: Focused Spec Detected.",
+                                "/b:5:2: error: Focused Spec Detected.",
+                            ],
+                            times: 1
+                        ))
+                    }
+
+                    it("doesn't throw an error") {
+                        expect { try result?.get() }.to(beVoid())
+                    }
+                }
+
+                context("and errorOnIssues is false") {
+                    beforeEach {
+                        errorOnIssues = false
+                    }
+
+                    it("converts the results to xcode-compatible strings, noting that these are just warnings") {
+                        expect(writer.stderrSpy).to(beCalled(
+                            [
+                                "/a:10:15: warning: Focused Spec Detected.",
+                                "/b:5:2: warning: Focused Spec Detected.",
+                            ],
+                            times: 1
+                        ))
+                    }
+
+                    it("doesn't throw an error") {
+                        expect { try result?.get() }.to(beVoid())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuickLintTests/FocusLintSpec.swift
+++ b/Tests/QuickLintTests/FocusLintSpec.swift
@@ -20,7 +20,7 @@ final class FocusLintSpec: AsyncSpec {
                 URL(fileURLWithPath: "/nonexistent"),
             ]
             var errorOnIssues = false
-            @TestState var result: Result<Void, Error>?
+            @TestState var result: Result<Int, Error>?
 
             beforeEach {
                 errorOnIssues = false
@@ -29,7 +29,7 @@ final class FocusLintSpec: AsyncSpec {
 
             justBeforeEach {
                 result = await Result {
-                    try await subject.lint(
+                    return try await subject.lint(
                         urls: urls,
                         errorOnIssues: errorOnIssues
                     )
@@ -51,6 +51,10 @@ final class FocusLintSpec: AsyncSpec {
 
                 it("doesn't output anything") {
                     expect(writer.stderrSpy).toNot(beCalled())
+                }
+
+                it("returns 0") {
+                    expect { try result?.get() }.to(equal(0))
                 }
             }
 
@@ -104,8 +108,8 @@ final class FocusLintSpec: AsyncSpec {
                         ))
                     }
 
-                    it("doesn't throw an error") {
-                        expect { try result?.get() }.to(beVoid())
+                    it("returns the amount of issues found") {
+                        expect { try result?.get() }.to(equal(2))
                     }
                 }
 
@@ -124,8 +128,8 @@ final class FocusLintSpec: AsyncSpec {
                         ))
                     }
 
-                    it("doesn't throw an error") {
-                        expect { try result?.get() }.to(beVoid())
+                    it("returns 0") {
+                        expect { try result?.get() }.to(equal(2))
                     }
                 }
             }

--- a/Tests/QuickLintTests/LintCommandSpec.swift
+++ b/Tests/QuickLintTests/LintCommandSpec.swift
@@ -11,27 +11,60 @@ final class LintCommandSpec: AsyncSpec {
             .deletingLastPathComponent()
             .appendingPathComponent("LintFixtures")
 
-        it("finds and lints focused specs") {
-            var subject = LintCommand()
-            subject.paths = [rootURL.path]
-            subject.error = false
+        context("when given a directory to search") {
+            it("identifies any focused specs") {
+                var subject = LintCommand()
+                subject.paths = [rootURL.path]
+                subject.error = false
 
-            let writer = FakeWriter()
+                let writer = FakeWriter()
 
-            subject.dependencies.writer = writer
+                subject.dependencies.writer = writer
 
-            try await subject.run()
+                try await subject.run()
 
-            expect(writer.stderrSpy).to(beCalled([
-                "\(rootURL.path)/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
-                "\(rootURL.path)/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
-                "\(rootURL.path)/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
-                "\(rootURL.path)/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
-                "\(rootURL.path)/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
-                "\(rootURL.path)/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
-                "\(rootURL.path)/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
-                "\(rootURL.path)/SampleSpec.swift:21:9: warning: Focused Spec Detected."
-            ]))
+                expect(writer.stderrSpy).to(beCalled([
+                    "\(rootURL.path)/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:21:9: warning: Focused Spec Detected."
+                ]))
+            }
+        }
+
+        context("when given the precise paths to the specs") {
+            it("identifies any focused specs") {
+                let sampleSpec = rootURL
+                    .appendingPathComponent("SampleSpec.swift")
+                let nesting = rootURL
+                    .appendingPathComponent("Nesting")
+                    .appendingPathComponent("Nesting.swift")
+
+                var subject = LintCommand()
+                subject.paths = [sampleSpec.path, nesting.path]
+                subject.error = false
+
+                let writer = FakeWriter()
+
+                subject.dependencies.writer = writer
+
+                try await subject.run()
+
+                expect(writer.stderrSpy).to(beCalled([
+                    "\(rootURL.path)/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
+                    "\(rootURL.path)/SampleSpec.swift:21:9: warning: Focused Spec Detected."
+                ]))
+            }
         }
     }
 }

--- a/Tests/QuickLintTests/LintCommandSpec.swift
+++ b/Tests/QuickLintTests/LintCommandSpec.swift
@@ -1,0 +1,37 @@
+import Fakes
+import Quick
+import Nimble
+import Foundation
+@testable import QuickLint
+
+final class LintCommandSpec: AsyncSpec {
+    override class func spec() {
+        let rootURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("LintFixtures")
+
+        it("finds and lints focused specs") {
+            var subject = LintCommand()
+            subject.paths = [rootURL.path]
+            subject.error = false
+
+            let writer = FakeWriter()
+
+            subject.dependencies.writer = writer
+
+            try await subject.run()
+
+            expect(writer.stderrSpy).to(beCalled([
+                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
+                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:21:9: warning: Focused Spec Detected."
+            ]))
+        }
+    }
+}

--- a/Tests/QuickLintTests/LintCommandSpec.swift
+++ b/Tests/QuickLintTests/LintCommandSpec.swift
@@ -23,14 +23,14 @@ final class LintCommandSpec: AsyncSpec {
             try await subject.run()
 
             expect(writer.stderrSpy).to(beCalled([
-                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
-                "/Users/you/workspace/Quick/Tests/LintFixtures/SampleSpec.swift:21:9: warning: Focused Spec Detected."
+                "\(rootURL.path)/Nesting/Nesting.swift:6:9: warning: Focused Spec Detected.",
+                "\(rootURL.path)/Nesting/Nesting.swift:7:13: warning: Focused Spec Detected.",
+                "\(rootURL.path)/Nesting/Nesting.swift:10:9: warning: Focused Spec Detected.",
+                "\(rootURL.path)/Nesting/Nesting.swift:10:62: warning: Focused Spec Detected.",
+                "\(rootURL.path)/SampleSpec.swift:6:9: warning: Focused Spec Detected.",
+                "\(rootURL.path)/SampleSpec.swift:11:9: warning: Focused Spec Detected.",
+                "\(rootURL.path)/SampleSpec.swift:16:9: warning: Focused Spec Detected.",
+                "\(rootURL.path)/SampleSpec.swift:21:9: warning: Focused Spec Detected."
             ]))
         }
     }

--- a/Tests/QuickLintTests/Result+CapturingAsync.swift
+++ b/Tests/QuickLintTests/Result+CapturingAsync.swift
@@ -1,0 +1,46 @@
+// This is not shipped publicly with Quick because this extension
+// should be included with Result.
+// But, feel free to use this snippet until it's included with Swift.
+
+extension Result where Failure == Swift.Error {
+    init(capturing: () async throws -> Success) async {
+        do {
+            self = .success(try await capturing())
+        } catch {
+            self = .failure(error)
+        }
+    }
+}
+
+import XCTest
+import Nimble
+
+final class ResultCapturingAsyncTests: XCTestCase {
+    func testCapturingSuccess() async {
+        func returnsValue<T>(_ value: T) async throws -> T {
+            return value
+        }
+
+        await expect {
+            await Result {
+                try await returnsValue(2)
+            }
+        }.to(beSuccess(test: { expect($0).to(equal(2)) }))
+    }
+
+    func testCapturingError() async {
+        func throwsError<T>(_ error: Error) async throws -> T {
+            throw error
+        }
+
+        enum TestError: Error {
+            case uhOh
+        }
+
+        await expect {
+            await Result<Int, Error> {
+                try await throwsError(TestError.uhOh)
+            }
+        }.to(beFailure(test: { expect($0).to(matchError(TestError.uhOh))}))
+    }
+}


### PR DESCRIPTION
Oftentimes, teams who use Quick's spec focusing either have to be really diligent about removing focus, or write a script to check for focus (and either block the push, or fail CI). Usually the latter is chosen. In an effort to alleviate writing those scripts, I wrote QuickLint. Which detects focused specs in the current directory, and also allows you to defocus the specs.

QuickLint also serves as an example of how to write testable code, and how to use Quick, [Nimble](https://github.com/Quick/Nimble), and the new [Swift Fakes](https://github.com/Quick/swift-fakes) packages.

Upcoming in this PR are also build tool and command plugins (for SwiftPM and Xcode) to lint and defocus your specs.

New feature, doesn't break the public API. So... minor version bump!