### PR TITLE
named the context param aContext to match the actual protocol

### DIFF
--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -35,7 +35,7 @@ like `SomethingEdible`:
 
 ```swift
 class SomethingEdible: Behavior<Edible> {
-  override class func spec(_ context: @escaping () -> Edible) {
+  override class func spec(_ aContext: @escaping () -> Edible) {
     var edible: Edible!
     beforeEach {
       edible = context()

--- a/Documentation/en-us/SharedExamples.md
+++ b/Documentation/en-us/SharedExamples.md
@@ -38,7 +38,7 @@ class SomethingEdible: Behavior<Edible> {
   override class func spec(_ aContext: @escaping () -> Edible) {
     var edible: Edible!
     beforeEach {
-      edible = context()
+      edible = aContext()
     }
 
     it("makes dolphins happy") {


### PR DESCRIPTION
Hi there, in the SharedExamples docs, the use of the Behavior class is slightly incorrect in that it names the context param `context` instead of `aContext` like the class itself. This has the nasty consequence of shadowing any use of `context` blocks within the `spec` func.

