### PR TITLE
Updated closures in QuickSpec to be annotated with MainActor

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -205,7 +205,7 @@ extension SyncDSLUser {
      - parameter file: The absolute path to the file containing the example. A sensible default is provided.
      - parameter line: The line containing the example. A sensible default is provided.
      */
-    public static func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+    public static func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
         World.sharedWorld.it(description, file: file, line: line, closure: closure)
     }
 
@@ -289,7 +289,7 @@ extension SyncDSLUser {
      Use this to quickly mark an `it` closure as pending.
      This disables the example and ensures the code within the closure is never run.
      */
-    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
         World.sharedWorld.xit(description, file: file, line: line, closure: closure)
     }
 
@@ -338,7 +338,7 @@ extension SyncDSLUser {
      Use this to quickly focus an `it` closure, focusing the example.
      If any examples in the test suite are focused, only those examples are executed.
      */
-    public static func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
+    public static func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
         World.sharedWorld.fit(description, file: file, line: line, closure: closure)
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -192,7 +192,7 @@ extension World {
 
     // MARK: - Examples (Swift)
     @nonobjc
-    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping ExampleClosure) {
         if beforesCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'.")
         }
@@ -208,12 +208,12 @@ extension World {
     }
 
     @nonobjc
-    internal func fit(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+    internal func fit(_ description: String, file: FileString, line: UInt, closure: @escaping ExampleClosure) {
         self.it(description, flags: [Filter.focused: true], file: file, line: line, closure: closure)
     }
 
     @nonobjc
-    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
+    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping ExampleClosure) {
         self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -61,9 +61,9 @@ public class Example: ExampleBase {
     weak internal var group: ExampleGroup?
 
     private let internalDescription: String
-    private let closure: () throws -> Void
+    private let closure: @MainActor () throws -> Void
 
-    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () throws -> Void) {
+    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping @MainActor () throws -> Void) {
         self.internalDescription = description
         self.closure = closure
         super.init(callsite: callsite, flags: flags)
@@ -86,6 +86,7 @@ public class Example: ExampleBase {
         return "\(groupName), \(description)"
     }
 
+    @MainActor
     public func run() {
         let world = World.sharedWorld
 
@@ -151,6 +152,7 @@ public class Example: ExampleBase {
         }
     }
 
+    @MainActor
     public func runSkippedTest() {
         let world = World.sharedWorld
 

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -61,9 +61,9 @@ public class Example: ExampleBase {
     weak internal var group: ExampleGroup?
 
     private let internalDescription: String
-    private let closure: @MainActor () throws -> Void
+    private let closure: ExampleClosure
 
-    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping @MainActor () throws -> Void) {
+    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping ExampleClosure) {
         self.internalDescription = description
         self.closure = closure
         super.init(callsite: callsite, flags: flags)

--- a/Sources/Quick/Hooks/Closures.swift
+++ b/Sources/Quick/Hooks/Closures.swift
@@ -8,13 +8,13 @@ public typealias BeforeExampleAsyncClosure = () async throws -> Void
 /**
     A throwing closure executed before an example is run.
  */
-public typealias BeforeExampleClosure = () throws -> Void
+public typealias BeforeExampleClosure = @MainActor () throws -> Void
 
 /**
     A closure executed before an example is run.
     This is only used by ObjC.
  */
-public typealias BeforeExampleNonThrowingClosure = () -> Void
+public typealias BeforeExampleNonThrowingClosure = @MainActor () -> Void
 
 /**
     An async throwing closure executed before an example is run. The closure is given example metadata,
@@ -26,14 +26,19 @@ public typealias BeforeExampleWithMetadataAsyncClosure = (_ exampleMetadata: Exa
     A throwing closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
  */
-public typealias BeforeExampleWithMetadataClosure = (_ exampleMetadata: ExampleMetadata) throws -> Void
+public typealias BeforeExampleWithMetadataClosure = @MainActor (_ exampleMetadata: ExampleMetadata) throws -> Void
 
 /**
     A closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
     This is only used by ObjC
  */
-public typealias BeforeExampleWithMetadataNonThrowingClosure = (_ exampleMetadata: ExampleMetadata) -> Void
+public typealias BeforeExampleWithMetadataNonThrowingClosure = @MainActor (_ exampleMetadata: ExampleMetadata) -> Void
+
+/**
+    A closure for running an example.
+ */
+public typealias ExampleClosure = @MainActor () throws -> Void
 
 /**
     An async throwing closure executed after an example is run.
@@ -72,12 +77,12 @@ public typealias AfterExampleWithMetadataNonThrowingClosure = BeforeExampleWithM
 /**
     A throwing closure which wraps an example. The closure must call runExample() exactly once.
 */
-public typealias AroundExampleClosure = (_ runExample: @escaping () -> Void) throws -> Void
+public typealias AroundExampleClosure = @MainActor (_ runExample: @escaping () -> Void) throws -> Void
 
 /**
     A closure which wraps an example. The closure must call runExample() exactly once.
 */
-public typealias AroundExampleNonThrowingClosure = (_ runExample: @escaping () -> Void) -> Void
+public typealias AroundExampleNonThrowingClosure = @MainActor (_ runExample: @escaping () -> Void) -> Void
 
 /**
     A throwing closure which wraps an example. The closure is given example metadata,
@@ -85,7 +90,7 @@ public typealias AroundExampleNonThrowingClosure = (_ runExample: @escaping () -
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataClosure =
-    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) throws -> Void
+@MainActor (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) throws -> Void
 
 /**
     A throwing closure which wraps an example. The closure is given example metadata,
@@ -93,7 +98,7 @@ public typealias AroundExampleWithMetadataClosure =
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataNonThrowingClosure =
-    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) -> Void
+@MainActor (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) -> Void
 
 /**
     An async throwing closure which wraps an example. The closure must call runExample() exactly once.
@@ -118,12 +123,12 @@ public typealias BeforeSuiteAsyncClosure = () async throws -> Void
 /**
     A throwing closure executed before any examples are run.
 */
-public typealias BeforeSuiteClosure = () throws -> Void
+public typealias BeforeSuiteClosure = @MainActor () throws -> Void
 
 /**
     A closure executed before any examples are run.
 */
-public typealias BeforeSuiteNonThrowingClosure = () -> Void
+public typealias BeforeSuiteNonThrowingClosure = @MainActor () -> Void
 
 /**
     An async throwing closure executed after all examples have finished running.

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -14,6 +14,7 @@ final internal class SuiteHooks {
         afters.append(closure)
     }
 
+    @MainActor
     internal func executeBefores() {
         phase = .beforesExecuting
         for before in befores {
@@ -26,6 +27,7 @@ final internal class SuiteHooks {
         phase = .beforesFinished
     }
 
+    @MainActor
     internal func executeAfters() {
         phase = .aftersExecuting
         for after in afters {

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -75,7 +75,7 @@ open class QuickSpec: QuickSpecBase {
     }
 
     private static func addInstanceMethod(for example: Example, runFullTest: Bool, classSelectorNames selectorNames: inout Set<String>) -> Selector {
-        let block: @convention(block) (QuickSpec) -> Void = { spec in
+        let block: @convention(block) @MainActor (QuickSpec) -> Void = { spec in
             spec.example = example
             if runFullTest {
                 example.run()
@@ -113,7 +113,7 @@ open class QuickSpec: QuickSpecBase {
         let result = exampleWrappers.map { wrapper -> (String, (QuickSpec) -> () throws -> Void) in
             return (wrapper.example.name, { spec in
                 let example = wrapper.example
-                return {
+                return { @MainActor in
                     spec.example = example
                     if wrapper.runFullTest {
                         example.run()


### PR DESCRIPTION
This is following the discussion I started here.
- https://github.com/Quick/Quick/discussions/1288

## Background

`XCTestCase` always calls synchronous tests on the main thread. This is to support testing UIKit types which can't be used on background threads. 

However when testing custom types annotated with `@MainActor` the compiler produces errors on uses in the tests like the following.

```
Main actor-isolated property 'stateSubject' can not be referenced from a non-isolated context
```
```
Call to main actor-isolated initializer 'init()' in a synchronous nonisolated context
```

For some unknown reason, the concurrency checking doesn't give the same errors for `@MainActor` UIKit types.

## Changes

This PR adds `@MainActor` annotations to the `QuickSpec` before/after/it closures so the compiler knows that they will be executed on the `MainActor`, matching the existing runtime behavour.

This allows tests to use types annotated with `@MainActor` without needing to switch to `AsyncSpec` and annotate every closure with `@MainActor`.

 - Does this have tests?
    - No. I'm not sure how to write a test for how the project compiles. I build quick with complete concurrency checking enabled and no new warnings were added. I ran the Quick tests and tried it with our project's tests and both successfully ran.
      <img width=300px src='https://github.com/Quick/Quick/assets/680442/6139b6f3-de4e-4b58-b6db-4cb370815a6c'/>
 - Does this have documentation?
   - No since the behaviour didn't change, it's just adding details so the compiler knows about it.
 - Does this break the public API (Requires major version bump)? / Is this a new feature (Requires minor version bump)?
   - The only changes we had to make in out project were to a couple funcs (< 10) defined in `context` and `describe` that now required a `@MainActor` annotation so they can be called in `it`. The scope of the impact will entirely depend on the code base, but it could warrant a major version bump.

