### PR TITLE
Spike: BDD DSL on top of Swift Testing

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,115 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Quick",
+    platforms: [
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)
+    ],
+    products: [
+        .library(name: "Quick", targets: ["Quick"]),
+        .library(name: "QuickTesting", targets: ["QuickTesting"]),
+        .executable(name: "quicklint", targets: ["QuickLint"]),
+        .plugin(name: "DefocusCommandPlugin", targets: ["DefocusCommandPlugin"]),
+        .plugin(name: "LintError", targets: ["LintError"]),
+        .plugin(name: "LintWarning", targets: ["LintWarning"]),
+        .plugin(name: "LintCommandPlugin", targets: ["LintCommandPlugin"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.1"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
+        .package(url: "https://github.com/Quick/swift-fakes.git", from: "0.0.1"),
+    ],
+    targets: {
+        var targets: [Target] = [
+            .plugin(
+                name: "DefocusCommandPlugin",
+                capability: .command(intent: .sourceCodeFormatting(), permissions: [.writeToPackageDirectory(reason: "Remove focus from Quick tests")]),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintError",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintWarning",
+                capability: .buildTool(),
+                dependencies: ["QuickLint"]
+            ),
+            .plugin(
+                name: "LintCommandPlugin",
+                capability: .command(intent: .custom(verb: "quicklint", description: "Verify no focused tests in Quick tests"), permissions: []),
+                dependencies: ["QuickLint"]
+            ),
+            .executableTarget(
+                name: "QuickLint",
+                dependencies: [
+                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                    .product(name: "Algorithms", package: "swift-algorithms"),
+                ]
+            ),
+            .testTarget(
+                name: "QuickTests",
+                dependencies: [ "Quick", "Nimble" ],
+                exclude: [
+                    "QuickAfterSuiteTests/AfterSuiteTests+ObjC.m",
+                    "QuickFocusedTests/FocusedTests+ObjC.m",
+                    "QuickTests/FunctionalTests/ObjC",
+                    "QuickTests/Helpers/QCKSpecRunner.h",
+                    "QuickTests/Helpers/QCKSpecRunner.m",
+                    "QuickTests/Helpers/QuickTestsBridgingHeader.h",
+                    "QuickTests/QuickConfigurationTests.m",
+                    "QuickFocusedTests/Info.plist",
+                    "QuickTests/Info.plist",
+                    "QuickAfterSuiteTests/Info.plist",
+                ]
+            ),
+            .testTarget(
+                name: "QuickIssue853RegressionTests",
+                dependencies: [ "Quick" ]
+            ),
+            .testTarget(
+                name: "QuickLintTests",
+                dependencies: [
+                    "QuickLint",
+                    "Quick",
+                    "Nimble",
+                    .product(name: "Fakes", package: "swift-fakes"),
+                ]
+            ),
+            .target(name: "QuickTesting", dependencies: []),
+            .testTarget(
+                name: "QuickTestingTests",
+                dependencies: [ "QuickTesting", "Nimble" ]
+            ),
+        ]
+#if os(macOS)
+        targets.append(contentsOf: [
+            .target(name: "QuickObjCRuntime", dependencies: []),
+            .target(
+                name: "Quick",
+                dependencies: [ "QuickObjCRuntime" ],
+                exclude: [
+                    "Info.plist",
+                ]
+            ),
+        ])
+#else
+        targets.append(contentsOf: [
+            .target(
+                name: "Quick",
+                dependencies: [],
+                exclude: [
+                    "Info.plist"
+                ]
+            ),
+        ])
+#endif
+        return targets
+    }(),
+    swiftLanguageVersions: [.v5]
+)
+

--- a/Sources/QuickTesting/DSL.swift
+++ b/Sources/QuickTesting/DSL.swift
@@ -1,0 +1,125 @@
+import Testing
+
+public protocol Spec: Sendable {
+    @SpecBuilder var body: Behavior { get }
+}
+
+@resultBuilder
+public struct SpecBuilder {
+    typealias FinalResult = Behavior
+
+    public static func buildBlock(_ components: Behavior...) -> [Behavior] {
+        components
+    }
+
+    public static func buildFinalResult(_ component: [any Behavior]) -> Behavior {
+        AnonymousExampleGroup(behaviors: component)
+    }
+}
+
+public struct Example: Sendable {
+    public let name: String
+    public let sourceLocation: SourceLocation
+    public let closure: @Sendable () async throws -> Void
+
+    func addToExampleGroup(named: String) -> Example {
+        Example(
+            name: [named, name].joined(separator: ", "),
+            sourceLocation: sourceLocation,
+            closure: closure
+        )
+    }
+}
+
+public protocol Behavior: Sendable {
+    var examples: [Example] { get }
+}
+
+struct ExampleGroup: Behavior {
+    let behavior: @Sendable () -> Behavior
+    let name: String
+
+    init(_ name: String, @SpecBuilder behavior: @escaping @Sendable () -> Behavior) {
+        self.name = name
+        self.behavior = behavior
+    }
+
+    var examples: [Example] {
+        behavior().examples.map {
+            $0.addToExampleGroup(named: name)
+        }
+    }
+}
+
+struct AnonymousExampleGroup: Behavior {
+    let behaviors: [Behavior]
+
+    init(behaviors: [Behavior]) {
+        self.behaviors = behaviors
+    }
+
+    var examples: [Example] {
+        behaviors.flatMap { $0.examples }
+    }
+}
+
+struct SynchronousExample: Behavior {
+    let name: String
+    let sourceLocation: SourceLocation
+    let example: @MainActor @Sendable () throws -> Void
+
+    var examples: [Example] {
+        [
+            Example(name: name, sourceLocation: sourceLocation) {
+                try await MainActor.run {
+                    try self.example()
+                }
+            }
+        ]
+    }
+}
+
+struct AsynchronousExample: Behavior {
+    let name: String
+    let sourceLocation: SourceLocation
+    let example: @Sendable () async throws -> Void
+
+    var examples: [Example] {
+        [
+            Example(name: name, sourceLocation: sourceLocation) {
+                try await self.example()
+            }
+        ]
+    }
+}
+
+@discardableResult
+public func describe(_ name: String, @SpecBuilder behavior: @escaping @Sendable () -> Behavior) -> Behavior {
+    ExampleGroup(name, behavior: behavior)
+}
+
+@discardableResult
+public func it(
+    _ name: String,
+    sourceLocation: SourceLocation = Testing.SourceLocation(),
+    example: @escaping @MainActor @Sendable () throws -> Void
+) -> Behavior {
+    SynchronousExample(
+        name: name,
+        sourceLocation: sourceLocation,
+        example: example
+    )
+}
+
+@discardableResult
+public func asyncIt(
+    _ name: String,
+    sourceLocation: SourceLocation = Testing.SourceLocation(),
+    example: @escaping @Sendable () async throws -> Void
+) -> Behavior {
+    AsynchronousExample(
+        name: name,
+        sourceLocation: sourceLocation,
+        example: example
+    )
+}

--- a/Sources/QuickTesting/Spec+Tests.swift
+++ b/Sources/QuickTesting/Spec+Tests.swift
@@ -1,0 +1,7 @@
+import Testing
+
+extension Spec {
+    var tests: [Test] {
+        [] // On hold, `Test` needs to have a public initializer.
+    }
+}

--- a/Tests/QuickTestingTests/DSLTests.swift
+++ b/Tests/QuickTestingTests/DSLTests.swift
@@ -1,0 +1,19 @@
+import Testing
+import QuickTesting
+
+struct MySpec: Spec {
+    var body: Behavior {
+        let ocean = ["whales", "dolphins"]
+        describe("some example group") {
+            it("does the thing") {
+                #expect(ocean.contains("dolphins"))
+            }
+        }
+
+        describe("some other example group") {
+            it("does the other thing") {
+                #expect(ocean.contains("whales"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Swift Testing is the new, mostly open source testing framework for Swift. It provides a pytest-style approach to testing, with native support for nested tests, like what Quick and other BDD-style frameworks provide.

This PR is an attempt to create a Quick-Style DSL on top of Swift Testing. This work explicitly does not support Objective-C, using resultbuilders to build its DSL.

This PR, for now, adds a new library target, QuickTesting, just to provide a separate space for these new type names. I intend to later merge this new target back in to the main Quick target.



---
Previous Work

I previously tried to implement Quick's Async support using resultbuilders, which was quite the learning experience: https://github.com/Quick/Quick/pull/1194