### PR TITLE
Fix breaking QuickSpec usage when building under Strict Concurrency

### DIFF
--- a/Sources/Quick/DSL/DSL.swift
+++ b/Sources/Quick/DSL/DSL.swift
@@ -205,7 +205,7 @@ extension SyncDSLUser {
      - parameter file: The absolute path to the file containing the example. A sensible default is provided.
      - parameter line: The line containing the example. A sensible default is provided.
      */
-    public static func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
+    public static func it(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
         World.sharedWorld.it(description, file: file, line: line, closure: closure)
     }
 
@@ -289,7 +289,7 @@ extension SyncDSLUser {
      Use this to quickly mark an `it` closure as pending.
      This disables the example and ensures the code within the closure is never run.
      */
-    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
+    public static func xit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
         World.sharedWorld.xit(description, file: file, line: line, closure: closure)
     }
 
@@ -338,7 +338,7 @@ extension SyncDSLUser {
      Use this to quickly focus an `it` closure, focusing the example.
      If any examples in the test suite are focused, only those examples are executed.
      */
-    public static func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping ExampleClosure) {
+    public static func fit(_ description: String, file: FileString = #file, line: UInt = #line, closure: @escaping () throws -> Void) {
         World.sharedWorld.fit(description, file: file, line: line, closure: closure)
     }
 

--- a/Sources/Quick/DSL/World+DSL.swift
+++ b/Sources/Quick/DSL/World+DSL.swift
@@ -192,7 +192,7 @@ extension World {
 
     // MARK: - Examples (Swift)
     @nonobjc
-    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping ExampleClosure) {
+    internal func it(_ description: String, flags: FilterFlags = [:], file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         if beforesCurrentlyExecuting {
             raiseError("'it' cannot be used inside 'beforeEach', 'it' may only be used inside 'context' or 'describe'.")
         }
@@ -208,12 +208,12 @@ extension World {
     }
 
     @nonobjc
-    internal func fit(_ description: String, file: FileString, line: UInt, closure: @escaping ExampleClosure) {
+    internal func fit(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         self.it(description, flags: [Filter.focused: true], file: file, line: line, closure: closure)
     }
 
     @nonobjc
-    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping ExampleClosure) {
+    internal func xit(_ description: String, file: FileString, line: UInt, closure: @escaping () throws -> Void) {
         self.it(description, flags: [Filter.pending: true], file: file, line: line, closure: closure)
     }
 

--- a/Sources/Quick/Examples/Example.swift
+++ b/Sources/Quick/Examples/Example.swift
@@ -61,9 +61,9 @@ public class Example: ExampleBase {
     weak internal var group: ExampleGroup?
 
     private let internalDescription: String
-    private let closure: ExampleClosure
+    private let closure: () throws -> Void
 
-    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping ExampleClosure) {
+    internal init(description: String, callsite: Callsite, flags: FilterFlags, closure: @escaping () throws -> Void) {
         self.internalDescription = description
         self.closure = closure
         super.init(callsite: callsite, flags: flags)
@@ -86,7 +86,6 @@ public class Example: ExampleBase {
         return "\(groupName), \(description)"
     }
 
-    @MainActor
     public func run() {
         let world = World.sharedWorld
 
@@ -152,7 +151,6 @@ public class Example: ExampleBase {
         }
     }
 
-    @MainActor
     public func runSkippedTest() {
         let world = World.sharedWorld
 

--- a/Sources/Quick/Hooks/Closures.swift
+++ b/Sources/Quick/Hooks/Closures.swift
@@ -8,13 +8,13 @@ public typealias BeforeExampleAsyncClosure = () async throws -> Void
 /**
     A throwing closure executed before an example is run.
  */
-public typealias BeforeExampleClosure = @MainActor () throws -> Void
+public typealias BeforeExampleClosure = () throws -> Void
 
 /**
     A closure executed before an example is run.
     This is only used by ObjC.
  */
-public typealias BeforeExampleNonThrowingClosure = @MainActor () -> Void
+public typealias BeforeExampleNonThrowingClosure = () -> Void
 
 /**
     An async throwing closure executed before an example is run. The closure is given example metadata,
@@ -26,19 +26,14 @@ public typealias BeforeExampleWithMetadataAsyncClosure = (_ exampleMetadata: Exa
     A throwing closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
  */
-public typealias BeforeExampleWithMetadataClosure = @MainActor (_ exampleMetadata: ExampleMetadata) throws -> Void
+public typealias BeforeExampleWithMetadataClosure = (_ exampleMetadata: ExampleMetadata) throws -> Void
 
 /**
     A closure executed before an example is run. The closure is given example metadata,
     which contains information about the example that is about to be run.
     This is only used by ObjC
  */
-public typealias BeforeExampleWithMetadataNonThrowingClosure = @MainActor (_ exampleMetadata: ExampleMetadata) -> Void
-
-/**
-    A closure for running an example.
- */
-public typealias ExampleClosure = @MainActor () throws -> Void
+public typealias BeforeExampleWithMetadataNonThrowingClosure = (_ exampleMetadata: ExampleMetadata) -> Void
 
 /**
     An async throwing closure executed after an example is run.
@@ -77,12 +72,12 @@ public typealias AfterExampleWithMetadataNonThrowingClosure = BeforeExampleWithM
 /**
     A throwing closure which wraps an example. The closure must call runExample() exactly once.
 */
-public typealias AroundExampleClosure = @MainActor (_ runExample: @escaping () -> Void) throws -> Void
+public typealias AroundExampleClosure = (_ runExample: @escaping () -> Void) throws -> Void
 
 /**
     A closure which wraps an example. The closure must call runExample() exactly once.
 */
-public typealias AroundExampleNonThrowingClosure = @MainActor (_ runExample: @escaping () -> Void) -> Void
+public typealias AroundExampleNonThrowingClosure = (_ runExample: @escaping () -> Void) -> Void
 
 /**
     A throwing closure which wraps an example. The closure is given example metadata,
@@ -90,7 +85,7 @@ public typealias AroundExampleNonThrowingClosure = @MainActor (_ runExample: @es
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataClosure =
-@MainActor (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) throws -> Void
+    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) throws -> Void
 
 /**
     A throwing closure which wraps an example. The closure is given example metadata,
@@ -98,7 +93,7 @@ public typealias AroundExampleWithMetadataClosure =
     The closure must call runExample() exactly once.
 */
 public typealias AroundExampleWithMetadataNonThrowingClosure =
-@MainActor (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) -> Void
+    (_ exampleMetadata: ExampleMetadata, _ runExample: @escaping () -> Void) -> Void
 
 /**
     An async throwing closure which wraps an example. The closure must call runExample() exactly once.
@@ -123,12 +118,12 @@ public typealias BeforeSuiteAsyncClosure = () async throws -> Void
 /**
     A throwing closure executed before any examples are run.
 */
-public typealias BeforeSuiteClosure = @MainActor () throws -> Void
+public typealias BeforeSuiteClosure = () throws -> Void
 
 /**
     A closure executed before any examples are run.
 */
-public typealias BeforeSuiteNonThrowingClosure = @MainActor () -> Void
+public typealias BeforeSuiteNonThrowingClosure = () -> Void
 
 /**
     An async throwing closure executed after all examples have finished running.

--- a/Sources/Quick/Hooks/SuiteHooks.swift
+++ b/Sources/Quick/Hooks/SuiteHooks.swift
@@ -14,7 +14,6 @@ final internal class SuiteHooks {
         afters.append(closure)
     }
 
-    @MainActor
     internal func executeBefores() {
         phase = .beforesExecuting
         for before in befores {
@@ -27,7 +26,6 @@ final internal class SuiteHooks {
         phase = .beforesFinished
     }
 
-    @MainActor
     internal func executeAfters() {
         phase = .aftersExecuting
         for after in afters {

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -75,7 +75,7 @@ open class QuickSpec: QuickSpecBase {
     }
 
     private static func addInstanceMethod(for example: Example, runFullTest: Bool, classSelectorNames selectorNames: inout Set<String>) -> Selector {
-        let block: @convention(block) @MainActor (QuickSpec) -> Void = { spec in
+        let block: @convention(block) (QuickSpec) -> Void = { spec in
             spec.example = example
             if runFullTest {
                 example.run()
@@ -113,7 +113,7 @@ open class QuickSpec: QuickSpecBase {
         let result = exampleWrappers.map { wrapper -> (String, (QuickSpec) -> () throws -> Void) in
             return (wrapper.example.name, { spec in
                 let example = wrapper.example
-                return { @MainActor in
+                return {
                     spec.example = example
                     if wrapper.runFullTest {
                         example.run()


### PR DESCRIPTION
Fixes https://github.com/Quick/Quick/issues/1298

https://github.com/Quick/Quick/pull/1289, which seemed like good idea at the time, ended up breaking standard specs when building under strict concurrency.

This will reintroduce build errors of type "Main actor-isolated property 'stateSubject' can not be referenced from a non-isolated context" and "Call to main actor-isolated initializer 'init()' in a synchronous nonisolated context" when calling main actor-actor isolated code from a QuickSpec. The workaround for these errors is to wrap the code in `MainActor.assumeIsolated`.

Admin note: Before I release the next version of Quick with this change, I'm going to look at other ways to mitigate this issue.