### PR TITLE
fix: deprecated XCTest warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Quick",
     platforms: [
-        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9)
+        .macOS(.v10_13), .iOS(.v12), .tvOS(.v12)
     ],
     products: [
         .library(name: "Quick", targets: ["Quick"]),

--- a/Sources/Quick/Example.swift
+++ b/Sources/Quick/Example.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 #if canImport(Darwin)
 // swiftlint:disable type_name
@@ -90,7 +91,6 @@ final public class Example: _ExampleBase {
             #else
             let file = callsite.file
             #endif
-            #if swift(>=5.3) && !SWIFT_PACKAGE
             let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(callsite.line))
             let sourceCodeContext = XCTSourceCodeContext(location: location)
             let issue = XCTIssue(
@@ -99,14 +99,6 @@ final public class Example: _ExampleBase {
                 sourceCodeContext: sourceCodeContext
             )
             QuickSpec.current.record(issue)
-            #else
-            QuickSpec.current.recordFailure(
-                withDescription: description,
-                inFile: file,
-                atLine: Int(callsite.line),
-                expected: false
-            )
-            #endif
         }
 
         group!.phase = .aftersExecuting

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -123,28 +123,12 @@ open class QuickSpec: QuickSpecBase {
 
     // MARK: Delegation to `QuickSpec.current`.
 
-    override public func recordFailure(
-        withDescription description: String,
-        inFile filePath: String,
-        atLine lineNumber: Int,
-        expected: Bool
-    ) {
+    override public func record(_ issue: XCTIssue) {
         guard self === Self.current else {
-            Self.current.recordFailure(
-                withDescription: description,
-                inFile: filePath,
-                atLine: lineNumber,
-                expected: expected
-            )
+            Self.current.record(issue)
             return
         }
-
-        super.recordFailure(
-            withDescription: description,
-            inFile: filePath,
-            atLine: lineNumber,
-            expected: expected
-        )
+        super.record(issue)
     }
 }
 


### PR DESCRIPTION
set minimal versions iOS 12, macOS 13

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed? No warning in Xcode
 - What code was refactored / updated to support this change? Package and Example.swift
 - What issues are related to this PR? Or why was this change introduced? https://github.com/Quick/Nimble/issues/829

Checklist - While not every PR needs it, new features should consider this list:

 - [X] Does this have tests? No
 - [X] Does this have documentation? No
 - [X] Does this break the public API (Requires major version bump)? No
 - [X] Is this a new feature (Requires minor version bump)? No

