### PR TITLE
Fix AsyncSpec focus filtering across test files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,15 +55,23 @@ let package = Package(
                 dependencies: [ "Quick", "Nimble" ],
                 exclude: [
                     "QuickAfterSuiteTests/AfterSuiteTests+ObjC.m",
-                    "QuickFocusedTests/FocusedTests+ObjC.m",
+                    "QuickFocusedTests",
                     "QuickTests/FunctionalTests/ObjC",
                     "QuickTests/Helpers/QCKSpecRunner.h",
                     "QuickTests/Helpers/QCKSpecRunner.m",
                     "QuickTests/Helpers/QuickTestsBridgingHeader.h",
                     "QuickTests/QuickConfigurationTests.m",
-                    "QuickFocusedTests/Info.plist",
                     "QuickTests/Info.plist",
                     "QuickAfterSuiteTests/Info.plist",
+                ]
+            ),
+            .testTarget(
+                name: "QuickFocusedTests",
+                dependencies: [ "Quick", "Nimble" ],
+                path: "Tests/QuickTests/QuickFocusedTests",
+                exclude: [
+                    "FocusedTests+ObjC.m",
+                    "Info.plist",
                 ]
             ),
             .testTarget(
@@ -83,6 +91,10 @@ let package = Package(
 #if os(macOS)
         targets.append(contentsOf: [
             .target(name: "QuickObjCRuntime", dependencies: []),
+            .testTarget(
+                name: "QuickIssue1324RegressionTests",
+                dependencies: [ "Quick" ]
+            ),
             .target(
                 name: "Quick",
                 dependencies: [ "QuickObjCRuntime" ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -55,15 +55,23 @@ let package = Package(
                 dependencies: [ "Quick", "Nimble" ],
                 exclude: [
                     "QuickAfterSuiteTests/AfterSuiteTests+ObjC.m",
-                    "QuickFocusedTests/FocusedTests+ObjC.m",
+                    "QuickFocusedTests",
                     "QuickTests/FunctionalTests/ObjC",
                     "QuickTests/Helpers/QCKSpecRunner.h",
                     "QuickTests/Helpers/QCKSpecRunner.m",
                     "QuickTests/Helpers/QuickTestsBridgingHeader.h",
                     "QuickTests/QuickConfigurationTests.m",
-                    "QuickFocusedTests/Info.plist",
                     "QuickTests/Info.plist",
                     "QuickAfterSuiteTests/Info.plist",
+                ]
+            ),
+            .testTarget(
+                name: "QuickFocusedTests",
+                dependencies: [ "Quick", "Nimble" ],
+                path: "Tests/QuickTests/QuickFocusedTests",
+                exclude: [
+                    "FocusedTests+ObjC.m",
+                    "Info.plist",
                 ]
             ),
             .testTarget(
@@ -83,6 +91,10 @@ let package = Package(
 #if os(macOS)
         targets.append(contentsOf: [
             .target(name: "QuickObjCRuntime", dependencies: []),
+            .testTarget(
+                name: "QuickIssue1324RegressionTests",
+                dependencies: [ "Quick" ]
+            ),
             .target(
                 name: "Quick",
                 dependencies: [ "QuickObjCRuntime" ],

--- a/Sources/Quick/Async/AsyncSpec.swift
+++ b/Sources/Quick/Async/AsyncSpec.swift
@@ -36,9 +36,15 @@ open class AsyncSpec: AsyncSpecBase {
     override open class var defaultTestSuite: XCTestSuite {
         QuickConfiguration.configureSubclassesIfNeeded(world: World.sharedWorld)
 
-        // Let's gather examples for each spec classes. This has the same effect
-        // as listing spec classes in `LinuxMain.swift` on Linux.
+        #if SWIFT_PACKAGE
+        if AsyncWorld.sharedWorld.isRunningAdditionalSuites {
+            gatherExamplesIfNeeded()
+        } else {
+            gatherAllExamplesIfNeeded()
+        }
+        #else
         gatherExamplesIfNeeded()
+        #endif
 
         return super.defaultTestSuite
     }

--- a/Sources/Quick/QuickSpec.swift
+++ b/Sources/Quick/QuickSpec.swift
@@ -41,9 +41,11 @@ open class QuickSpec: QuickSpecBase {
     override open class var defaultTestSuite: XCTestSuite {
         QuickConfiguration.configureSubclassesIfNeeded(world: World.sharedWorld)
 
-        // Let's gather examples for each spec classes. This has the same effect
-        // as listing spec classes in `LinuxMain.swift` on Linux.
-        gatherExamplesIfNeeded()
+        if World.sharedWorld.isRunningAdditionalSuites {
+            gatherExamplesIfNeeded()
+        } else {
+            gatherAllExamplesIfNeeded()
+        }
 
         return super.defaultTestSuite
     }

--- a/Sources/Quick/SubclassDetection.swift
+++ b/Sources/Quick/SubclassDetection.swift
@@ -39,3 +39,12 @@ func allSubclasses<T: AnyObject>(ofType targetType: T.Type) -> [T.Type] {
     return []
     #endif
 }
+
+#if SWIFT_PACKAGE && canImport(Darwin)
+/// Builds every spec before XCTest creates invocations so suite-wide focus
+/// filters do not depend on the order in which test classes are discovered.
+func gatherAllExamplesIfNeeded() {
+    allSubclasses(ofType: QuickSpec.self).forEach { $0.gatherExamplesIfNeeded() }
+    allSubclasses(ofType: AsyncSpec.self).forEach { $0.gatherExamplesIfNeeded() }
+}
+#endif

--- a/Tests/QuickIssue1324RegressionTests/FocusedAsyncSpec.swift
+++ b/Tests/QuickIssue1324RegressionTests/FocusedAsyncSpec.swift
@@ -1,0 +1,20 @@
+import Quick
+import XCTest
+
+final class ZFocusedAsyncSpec: AsyncSpec {
+    override class func spec() {
+        it("does not run an unfocused example in the focused spec") {
+            XCTFail("Only focused examples should run")
+        }
+
+        fit("runs a focused example") {}
+
+        fdescribe("a focused describe") {
+            it("runs its example") {}
+        }
+
+        fcontext("a focused context") {
+            it("runs its example") {}
+        }
+    }
+}

--- a/Tests/QuickIssue1324RegressionTests/UnfocusedAsyncSpec.swift
+++ b/Tests/QuickIssue1324RegressionTests/UnfocusedAsyncSpec.swift
@@ -1,0 +1,10 @@
+import Quick
+import XCTest
+
+final class AUnfocusedAsyncSpec: AsyncSpec {
+    override class func spec() {
+        it("does not run an unfocused example in another spec") {
+            XCTFail("The focused example should exclude this example")
+        }
+    }
+}

--- a/Tests/QuickTests/QuickFocusedTests/FacusedTests+Async.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FacusedTests+Async.swift
@@ -41,6 +41,7 @@ class _FunctionalTests_FocusedAsyncSpec_Unfocused: AsyncSpec {
     }
 }
 
+#if !SWIFT_PACKAGE
 final class FocusedAsyncTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (FocusedAsyncTests) -> () throws -> Void)] {
         return [
@@ -63,3 +64,4 @@ final class FocusedAsyncTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual((result?.executionCount ?? 0) - (result?.skipCount ?? 0), 8)
     }
 }
+#endif

--- a/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
+++ b/Tests/QuickTests/QuickFocusedTests/FocusedTests.swift
@@ -55,6 +55,7 @@ class _FunctionalTests_FocusedSpec_Unfocused: QuickSpec {
     }
 }
 
+#if !SWIFT_PACKAGE
 final class FocusedTests: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (FocusedTests) -> () throws -> Void)] {
         return [
@@ -77,3 +78,4 @@ final class FocusedTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual((result?.executionCount ?? 0) - (result?.skipCount ?? 0), 8)
     }
 }
+#endif


### PR DESCRIPTION
Fixes #1324.

SwiftPM created test invocations one spec at a time. When an unfocused `AsyncSpec` was discovered before a focused spec, its run decision was captured before the focused examples were registered.

This change gathers all `QuickSpec` and `AsyncSpec` examples before XCTest creates invocations on Darwin SwiftPM. Additional suites created through Quick’s test helpers remain isolated.

The existing focused fixtures now run in their own SwiftPM target, and a regression target discovers an unfocused spec first while covering `fit`, `fdescribe`, and `fcontext`.

Tests:

- Complete SwiftPM test suite
- Issue #1324 regression bundle: 5 tests, 2 intentionally skipped, 0 failures
- macOS Xcode `build-for-testing`
